### PR TITLE
Fix for bug #3906 "default country".

### DIFF
--- a/htdocs/lib/common.inc.php
+++ b/htdocs/lib/common.inc.php
@@ -1198,7 +1198,7 @@ function __autoload($class_name)
 
 	function getUserCountry()
 	{
-		global $opt, $cookie;
+		global $opt, $cookie, $usr;
 
 		// language specified in cookie?
 		if ($cookie->is_set('usercountry'))
@@ -1223,7 +1223,8 @@ function __autoload($class_name)
 		// default country of installation (or domain)
 		if (isset($opt['template']['default']['country']))
 			return $opt['template']['default']['country'];
-
-		return 'EN';
+		
+		// country could not be determined by the above checks -> return "GB"
+		return 'GB';
 	}
 ?>

--- a/htdocs/newcache.php
+++ b/htdocs/newcache.php
@@ -88,7 +88,7 @@
 				$sel_size = isset($_POST['size']) ? $_POST['size'] : -1;
 			}
 			$sel_lang = isset($_POST['desc_lang']) ? $_POST['desc_lang'] : $default_lang;
-			$sel_country = isset($_POST['country']) ? $_POST['country'] : $default_country;
+			$sel_country = isset($_POST['country']) ? $_POST['country'] : getUserCountry();
 			$show_all_countries = isset($_POST['show_all_countries']) ? $_POST['show_all_countries'] : 0;
 			$show_all_langs = isset($_POST['show_all_langs']) ? $_POST['show_all_langs'] : 0;
 
@@ -427,10 +427,10 @@
 			}
 
 			// $opt['locale'][$locale]['country'] would give country of chosen langugage
-			$sUserCountry = getUserCountry(); // gives country selected at top right corner
+			// build the "country" dropdown list, preselect $sel_country
 			while ($record = sql_fetch_array($rs))
 			{
-				$sSelected = ($record['short'] == $sUserCountry) ? ' selected="selected"' : '';
+				$sSelected = ($record['short'] == $sel_country) ? ' selected="selected"' : '';
 				$countriesoptions .= '<option value="' . htmlspecialchars($record['short'], ENT_COMPAT, 'UTF-8') . '"' . $sSelected . '>' . htmlspecialchars($record['name'], ENT_COMPAT, 'UTF-8') . '</option>' . "\n";
 			}
 			sql_free_result($rs);


### PR DESCRIPTION
In htdocs/lib/common.inc.php, getUserCountry():
- added "global" declaration of "$usr", which was missing
- using "GB" as the fallback country code instead of "EN", which is not a valid country code

In htdocs/newcache.php:
- using "getUserCountry()" to initialize "$sel_country" if no "_POST['country']" was given, instead of "$default_country"
- using "$sel_country" to preselect the country in the countries combobox, instead of "getUserCountrs()"
