### PR TITLE
#4481: Meldungsübersicht verbessern

### DIFF
--- a/htdocs/adminreports.php
+++ b/htdocs/adminreports.php
@@ -113,11 +113,13 @@
 		$rs = sql("SELECT `cr`.`id`,
 				               IF(`cr`.`status`=1,'(*) ', '') AS `new`,
 				               `c`.`name`,
+				               `u2`.`username` AS `ownernick`,
 				               `u`.`username`,
-                               `cr`.`lastmodified`
+				               `cr`.`lastmodified`
 				          FROM `cache_reports` `cr`
 				    INNER JOIN `caches` `c` ON `c`.`cache_id` = `cr`.`cacheid`
 				    INNER JOIN `user` `u` ON `u`.`user_id`  = `cr`.`userid`
+				    INNER JOIN `user` AS `u2` ON `u2`.`user_id`=`c`.`user_id`
 				         WHERE `cr`.`status` < 3
 				           AND (`cr`.`adminid` IS NULL OR `cr`.`adminid`=&1)
 			        ORDER BY `cr`.`status` DESC, `cr`.`lastmodified` ASC", 

--- a/htdocs/templates2/ocstyle/adminreports.tpl
+++ b/htdocs/templates2/ocstyle/adminreports.tpl
@@ -26,13 +26,16 @@
 	{/if}
 
 	{if $list == true}
-		<ul>
-			{foreach from=$reportedcaches item=rc}
-				<li><a href="adminreports.php?id={$rc.id}">{$rc.new|escape}{$rc.name|escape} reported by {$rc.username|escape} ({$rc.lastmodified|date_format:$opt.format.datelong})</a></li>
-			{foreachelse}
-				<li>{t}No reported caches{/t}</li>
-			{/foreach}
-		</ul>
+	
+		<table>
+		<tr><th>{t}ID{/t}</th><th>{t}Name{/t}</th><th>{t}Owner{/t}</th><th>{t}Reporter{/t}</th><th>{t}Date{/t}</th></tr>
+		{foreach from=$reportedcaches item=rc}
+			<td><a href="adminreports.php?id={$rc.id}">{$rc.id}</td><td><a href="adminreports.php?id={$rc.id}">{$rc.new|escape}{$rc.name|escape}</a></td><td>{$rc.ownernick|escape}</td><td>{$rc.username|escape}</td><td>{$rc.lastmodified|date_format:$opt.format.datelong}</td></tr>
+		{foreachelse}
+			<tr><td colspan=5>{t}No reported caches{/t}</td></tr>
+		{/foreach}
+		</table>
+		
 		{if $reportedcaches != NULL}
 			<p style="line-height: 1.6em;">{t}(*) New reports{/t}</p>
 		{/if}


### PR DESCRIPTION
- Liste von Cachmeldungen als Tabelle statt "unordered list"
- Zusätzliche Tabellenfelder: Cache-Owner, Meldedatum
- Sortierung: älteste Meldungen zuerst

Anmerkung: Was die Übersetzung angeht, bin ich mir nicht sicher, ob es so korrekt ist (zu übersetzende Strings sinf mit "{t}...{/t}" markiert.
