### PR TITLE
changed location string to the same layout as on the start page

### DIFF
--- a/htdocs/templates2/ocstyle/viewcache.tpl
+++ b/htdocs/templates2/ocstyle/viewcache.tpl
@@ -125,11 +125,9 @@
 						<img src="images/flags/{$cache.countryCode|lower}.gif" style="vertical-align:middle" />&nbsp; {$cache.country|escape}
 					{else}
 						<img src="images/flags/{$cache.code1|lower}.gif" style="vertical-align:middle" />&nbsp;
-						{$cache.adm1}{if $cache.adm2!=""},
-							{$cache.adm2}{if $cache.adm4!=""}
-								&nbsp;=>&nbsp;{$cache.adm4}
-							{/if}
-						{/if}
+						{$cache.adm1|escape} {if $cache.adm1!=null & $cache.adm2!=null} &gt; {/if}
+						{$cache.adm2|escape} {if ($cache.adm2!=null & $cache.adm4!=null) | ($cache.adm1!=null & $cache.adm4!=null)} &gt; {/if}
+						{$cache.adm4|escape}
 					{/if}
 				</span>
 			</p>

--- a/htdocs/templates2/ocstyle/viewcache_print.tpl
+++ b/htdocs/templates2/ocstyle/viewcache_print.tpl
@@ -114,12 +114,9 @@
 						{else}
 							<img src="images/flags/{$cache.code1|lower}.gif" style="vertical-align:middle" />&nbsp;
 							<b>{$cache.adm1}</b><br />
-							{if $cache.adm2!=""}
+							{if ($cache.adm2!=null | $cache.adm4!=null)}
 								<font size="1">
-								{$cache.adm2}
-								{if $cache.adm4!=""}
-									&nbsp;=>&nbsp;{$cache.adm4}
-								{/if}
+								{$cache.adm2|escape} {if ($cache.adm2!=null & $cache.adm4!=null)} &gt; {/if} {$cache.adm4|escape}
 								</font>
 								<br />
 							{/if}


### PR DESCRIPTION
Auf der Startseite werden die einzelnen Elemente der Cache-Locations mit einem Größer-Zeichen getrennt:

Deutschland > Nordrhein-Westfalen > Ennepe-Ruhr-Kreis

in viewcache.php mit Komma und Pfeil:

Deutschland, Nordrhein-Westfalen => Ennepe-Ruhr-Kreis

Dieser Commit ändert viewcache.php (und _print) so, dass die erste version verwendet wird.
