### PR TITLE
embed webchat into page

### DIFF
--- a/htdocs/templates2/ocstyle/webchat.tpl
+++ b/htdocs/templates2/ocstyle/webchat.tpl
@@ -1,0 +1,17 @@
+{***************************************************************************
+*  You can find the license in the docs directory
+*
+*  Unicode Reminder メモ
+***************************************************************************}
+
+{* webchat for freenode irc using qwebirc embedded via iframe *}
+
+<div class="content2-container bg-blue02">
+	<p class="content-title-noshade-size3">
+		<img src="resource2/{$opt.template.style}/images/misc/32x32-news.png" style="align: left; margin-right: 10px;" width="24" height="24" alt="" />
+		{t}Webchat/IRC{/t}
+	</p>
+</div>
+<div style="padding:2px 0 6px 0">
+	<iframe style="margin: 0 auto; display: block;" src="http://webchat.freenode.net/?nick={$chatusername}&amp;channels=opencaching.de&amp;prompt=1" width="647" height="400"></iframe>
+</div>

--- a/htdocs/webchat.php
+++ b/htdocs/webchat.php
@@ -1,0 +1,30 @@
+<?php
+/***************************************************************************
+ *  For license information see doc/license.txt
+ *
+ *  Unicode Reminder メモ
+ *
+ *  Display some status information about the server and Opencaching
+ ***************************************************************************/
+
+	require('./lib2/web.inc.php');
+	require('./lib2/logic/logpics.inc.php');
+	$sUserCountry = $login->getUserCountry();
+	
+	$tpl->name = 'webchat';
+	$tpl->menuitem = MNU_CHAT;
+
+	$tpl->caching = true;
+	$tpl->cache_lifetime = 300;
+	$tpl->cache_id = $sUserCountry;
+
+	// check loggedin and set username for chat
+	$chatusername = $translate->t('Guest', '', basename(__FILE__), __LINE__);
+	if ($login->userid != 0)
+		$chatusername = urlencode($login->username);
+	
+	// assign to template
+	$tpl->assign('chatusername',$chatusername);
+
+	$tpl->display();
+?>


### PR DESCRIPTION
to use chat.opencaching.de as shown on the new flyer, we need to embed the chat into oc-code and redirect to it. Information what needs to be changed in settings.inc.php you find in ref #196, is now assigned to you.
