### PR TITLE
Tool cs2cs ersetzen ; update #200

### DIFF
--- a/htdocs/coordinates.php
+++ b/htdocs/coordinates.php
@@ -27,7 +27,7 @@
 	$tpl->assign('coordUTM', $coord->getUTM());
 	$tpl->assign('coordGK', $coord->getGK());
 	$tpl->assign('coordRD', $coord->getRD());
-	$tpl->assign('showRD', ($coord->nLat >= 0 && $coord->nLon >= 0));
+	$tpl->assign('showRD', ($coord->nLat >= 45 && $coord->nLat <= 57 && $coord->nLon >= 0 && $coord->nLon <= 15));
 	$tpl->assign('coordQTH', $coord->getQTH());
 	$tpl->assign('coordSwissGrid', $coord->getSwissGrid());
 


### PR DESCRIPTION
Ich musste den Bereich leider noch weiter einschränken.
Die Berechnungen für Dutch Grid sind nur innerhalb enger Grenzen noch halbwegs korrekt.
Daher werden die Berechnungen nur noch dann eingeblendet, wenn sie innerhalb der Längengrade 0-15 und der Breitengrade 45-57 liegen. Das entspricht in etwa den Benelux-Staaten, halb Frankreich, Österreich, Schweiz, Deutschland und Dänemark.
