### PR TITLE
208: new events

### DIFF
--- a/htdocs/newevents.php
+++ b/htdocs/newevents.php
@@ -1,0 +1,64 @@
+<?php
+/***************************************************************************
+ *  For license information see doc/license.txt
+ *
+ *  Unicode Reminder メモ
+ ***************************************************************************/
+
+	require('./lib2/web.inc.php');
+	$tpl->name = 'newevents';
+	$tpl->menuitem = MNU_START_NEWCACHES;
+
+	$startat = isset($_REQUEST['startat']) ? $_REQUEST['startat']+0 : 0;
+	$perpage = 100;
+	$startat -= $startat % $perpage;
+	if ($startat < 0) $startat = 0;
+
+	$tpl->caching = true;
+	$tpl->cache_id = $startat;
+	if ($startat > 10 * $perpage)
+		$tpl->cache_lifetime = 3600;
+	else
+		$tpl->cache_lifetime = 300;
+
+	if (!$tpl->is_cached())
+	{
+		require($opt['rootpath'] . 'lib2/logic/cacheIcon.inc.php');
+
+		$newCaches = array();
+
+		$rsNewCaches = sql_slave('SELECT `caches`.`cache_id` `cacheid`, `caches`.`wp_oc` `wpoc`, `user`.`user_id` `userid`, `caches`.`country` `country`, `caches`.`name` `cachename`, `user`.`username` `username`, `caches`.`date_created` `date_created`, `cache_type`.`icon_large` FROM `caches` INNER JOIN `user` ON `caches`.`user_id`=`user`.`user_id` INNER JOIN `cache_type` ON `caches`.`type`=`cache_type`.`id` WHERE `caches`.`status` = 1 AND `caches`.`type` = 6 ORDER BY `caches`.`date_created` DESC LIMIT ' . ($startat+0) . ', ' . ($perpage+0));
+		while ($rNewCache = sql_fetch_assoc($rsNewCaches))
+		{
+			$rNewCache['icon_large'] = getSmallCacheIcon($rNewCache['icon_large']);
+			$newCaches[] = $rNewCache;
+		}
+		sql_free_result($rsNewCaches);
+		$tpl->assign('newCaches', $newCaches);
+
+		$count = sql_value_slave('SELECT COUNT(*) `count` FROM `caches`INNER JOIN `cache_status` ON `caches`.`status`=`cache_status`.`id` WHERE `cache_status`.`allow_user_view`=1', 0);
+		$maxstart = (ceil($count / $perpage)-1) * $perpage;
+
+		if ($startat < 4 * $perpage)
+		{
+			$firstpage = 0;
+			$lastpage = 8 * $perpage;
+		}
+		else
+		{
+			$firstpage = $startat - 4 * $perpage;
+			$lastpage = $firstpage + 8 * $perpage;
+		}
+		if ($lastpage > $maxstart)
+			$lastpage = $maxstart;
+
+		$tpl->assign('firstpage', $firstpage);
+		$tpl->assign('lastpage', $lastpage);
+		$tpl->assign('perpage', $perpage);
+
+		$tpl->assign('startat', $startat);
+		$tpl->assign('maxstart', $maxstart);
+	}
+
+	$tpl->display();
+?>

--- a/htdocs/templates2/ocstyle/newevents.tpl
+++ b/htdocs/templates2/ocstyle/newevents.tpl
@@ -1,0 +1,76 @@
+{***************************************************************************
+ *  You can find the license in the docs directory
+ *
+ *  Unicode Reminder メモ
+ ***************************************************************************}
+{* OCSTYLE *}
+<div class="content2-pagetitle">
+	<img src="resource2/{$opt.template.style}/images/cacheicon/event.gif" style="align: left; margin-right: 10px;" width="32" height="32" alt="{t}Latest caches{/t}" />
+	{t}Upcoming/Latest Events{/t}
+</div>
+
+<table width="100%" class="table">
+	<tr>
+		<td class="header-small">
+
+			{if $startat>0}
+				<a href="newcaches.php?startat=0">&lt;&lt;</a>
+				<a href="newcaches.php?startat={$startat-$perpage}">&lt;</a>
+			{else}
+				&lt;&lt;
+				&lt;
+			{/if}
+
+			{section name=page start=$firstpage loop=$lastpage+1 step=100}
+				{if $smarty.section.page.index!=$startat}
+					<a href="newcaches.php?startat={$smarty.section.page.index}">{$smarty.section.page.index/$perpage+1}</a>
+				{else}
+					{$smarty.section.page.index/$perpage+1}
+				{/if}
+			{/section}
+
+			{if $startat<$maxstart}
+				<a href="newcaches.php?startat={$startat+$perpage}">&gt;</a>
+				<a href="newcaches.php?startat={$maxstart}">&gt;&gt;</a>
+			{else}
+				&gt;
+				&gt;&gt;
+			{/if}
+
+		</td>
+	</tr>
+
+	{foreach name=newCaches from=$newCaches item=newCache}
+		<tr><td>{$newCache.date_created|date_format:$opt.format.date} ({$newCache.country}): <img src="resource2/{$opt.template.style}/images/cacheicon/{$newCache.icon_large}" width="16" height="16" border="0" alt="Cache" title="Cache" style="margin-top:4px;" /> <a href="viewcache.php?wp={$newCache.wpoc}">{$newCache.cachename|escape}</a> {t}by{/t} <a href="viewprofile.php?userid={$newCache.userid}">{$newCache.username|escape}</a></td></tr>
+	{/foreach}
+
+	<tr>
+		<td class="header-small">
+
+			{if $startat>0}
+				<a href="newcaches.php?startat=0">&lt;&lt;</a>
+				<a href="newcaches.php?startat={$startat-$perpage}">&lt;</a>
+			{else}
+				&lt;&lt;
+				&lt;
+			{/if}
+
+			{section name=page start=$firstpage loop=$lastpage+1 step=100}
+				{if $smarty.section.page.index!=$startat}
+					<a href="newcaches.php?startat={$smarty.section.page.index}">{$smarty.section.page.index/$perpage+1}</a>
+				{else}
+					{$smarty.section.page.index/$perpage+1}
+				{/if}
+			{/section}
+
+			{if $startat<$maxstart}
+				<a href="newcaches.php?startat={$startat+$perpage}">&gt;</a>
+				<a href="newcaches.php?startat={$maxstart}">&gt;&gt;</a>
+			{else}
+				&gt;
+				&gt;&gt;
+			{/if}
+
+		</td>
+	</tr>
+</table>

--- a/htdocs/templates2/ocstyle/start.tpl
+++ b/htdocs/templates2/ocstyle/start.tpl
@@ -68,6 +68,7 @@
 	<p class="content-title-noshade-size3">
 		<img src="resource2/{$opt.template.style}/images/cacheicon/event.gif" style="align: left; margin-right: 10px;" width="24" height="24" alt="" />
 		{t 1=$usercountry|escape}The next events in %1{/t}
+	&nbsp; <span class="content-title-link">[<a href="newevents.php?country={$usercountryCode}">{t}more{/t}...</a>]</span>
 	</p>
 </div>
 <div class="content2-section-no-p">


### PR DESCRIPTION
Erzeugt einen "Mehr..."-Link hinter den Events auf der Startseite. Auf

| Zur Optimierung den Index caches.type um das date_created-Feld erweitern?

habe ich verzichtet, das kann ggf. später nachgeholt werden, wenn es sich als nötig erweist.

WICHTIG: Eine Übersetzung wird fällig! --> "Upcoming/Latest Events" - "Anstehende/Neueste Events"

Auf eine Anpassung von Menü/Breadcrumbmenü habe ich verzichtet, da sich ja die neuesten Events im Grunde nahtlos in die Reiher der neuen Caches einreihen. Sollte hier noch Bedarf bestehen, muss ein entsprechender Datensatz in der Tabelle "sys_menu" eingefügt und die Datei "newevents.php" entsprechend editiert werden.
