### PR TITLE
created gui for managing adminrights for users

### DIFF
--- a/htdocs/adminrights.php
+++ b/htdocs/adminrights.php
@@ -1,0 +1,161 @@
+<?php
+
+/* * *************************************************************************
+ *  For license information see doc/license.txt
+ *
+ *  Unicode Reminder メモ
+ * ************************************************************************* */
+
+require('./lib2/web.inc.php');
+require_once('./lib2/logic/user.class.php');
+
+$tpl->name = 'adminrights';
+$tpl->menuitem = MNU_ADMIN_RIGHTS;
+
+$error = 0;
+
+$login->verify();
+if ($login->userid == 0)
+    $tpl->redirect_login();
+
+if (!($login->admin & 128))
+    $tpl->error(ERROR_NO_ACCESS);
+
+$action = isset($_REQUEST['action']) ? $_REQUEST['action'] : 'display';
+$userid = isset($_REQUEST['userid']) ? $_REQUEST['userid'] + 0 : 0;
+$permid = isset($_REQUEST['permid']) ? $_REQUEST['permid'] + 0 : 0;
+
+
+if ($action == 'searchuser') {
+    searchUser();
+} else if ($action == 'removeperms') {
+    removePerms();
+    searchUser();
+
+    $tpl->display();
+} else if ($action == 'addperm') {
+    addPerms();
+    searchUser();
+
+    $tpl->display();
+} else {
+    $tpl->display();
+}
+
+function searchUser() {
+    global $tpl, $opt, $userid;
+
+    $username = isset($_REQUEST['username']) ? $_REQUEST['username'] : '';
+
+
+
+
+
+    $rs = sql("SELECT `user_id`, `username`, `admin` FROM `user` WHERE `username`='&1' OR `email`='&1' OR `user_id`='&2'", $username, $userid);
+    $r = sql_fetch_assoc($rs);
+    sql_free_result($rs);
+    if ($r == false) {
+        $tpl->assign('error', 'userunknown');
+        $tpl->display();
+    }
+    $tpl->assign('haveallperms', false);
+    $tpl->assign('haveno', false);
+    //Rights the User have
+    $rights = array();
+    $norights = array();
+    if ($r['admin'] & ADMIN_TRANSLATE) {
+        $rights[ADMIN_TRANSLATE] = "translate";
+    } else {
+        $norights[ADMIN_TRANSLATE] = "translate";
+    }
+    if ($r['admin'] & ADMIN_MAINTAINANCE) {
+        $rights[ADMIN_MAINTAINANCE] = "dbmaint";
+    } else {
+        $norights[ADMIN_MAINTAINANCE] = "dbmaint";
+    }
+    if ($r['admin'] & ADMIN_USER) {
+        $rights[ADMIN_USER] = "user/caches";
+    } else {
+        $norights[ADMIN_USER] = "user/caches";
+    }
+    if ($r['admin'] & ADMIN_NEWS) {
+        $rights[ADMIN_NEWS] = "newsapprove";
+    } else {
+        $norights[ADMIN_NEWS] = "newsapprove";
+    }
+    if ($r['admin'] & ADMIN_RESTORE) {
+        $rights[ADMIN_RESTORE] = "vand.restore";
+    } else {
+        $norights[ADMIN_RESTORE] = "vand.restore";
+    }
+    if ($r['admin'] & 128) {
+        $rights[128] = "root";
+    } else {
+        $norights[128] = "root";
+    }
+    if ($r['admin'] & ADMIN_LISTING) {
+        $rights[ADMIN_LISTING] = "listing";
+    } else {
+        $norights[ADMIN_LISTING] = "listing";
+    }
+
+
+    $r['rights'] = $rights;
+    if (!empty($norights)) {
+        $r['norights'] = $norights;
+    } else {
+        $tpl->assign('haveallperms', true);
+    }
+
+    $tpl->assign('showdetails', true);
+    $tpl->assign('username', $r['username']);
+
+
+    $tpl->assign('user', $r);
+
+    $user = new user($r['user_id']);
+    if (!$user->exist())
+        $tpl->error(ERROR_UNKNOWN);
+
+    $tpl->display();
+}
+
+function removePerms() {
+    global $userid, $permid, $tpl;
+
+    if ($permid != ADMIN_TRANSLATE && $permid != ADMIN_MAINTAINANCE && $permid != ADMIN_USER && $permid != ADMIN_NEWS && $permid != ADMIN_RESTORE && $permid != ADMIN_LISTING && $permid != 128 && $permid != ADMIN_TRANSLATE) {
+        $tpl->error(ERROR_NO_ACCESS);
+    }
+    $rs = sql("SELECT `admin` FROM `user` WHERE `user_id`='&1'", $userid);
+    $r = sql_fetch_assoc($rs);
+    sql_free_result($rs);
+    if ($r == false) {
+        $tpl->assign('error', 'userunknown');
+        $tpl->display();
+    }
+    if ($r['admin'] & $permid) {
+        $perm = $r['admin'] - $permid;
+        sql("UPDATE `user` SET `admin`='&1' WHERE `user_id`='&2'", $perm, $userid);
+    }
+}
+
+function addPerms() {
+    global $userid, $permid, $tpl;
+
+    if ($permid != ADMIN_TRANSLATE && $permid != ADMIN_MAINTAINANCE && $permid != ADMIN_USER && $permid != ADMIN_NEWS && $permid != ADMIN_RESTORE && $permid != ADMIN_LISTING && $permid != 128 && $permid != ADMIN_TRANSLATE) {
+        $tpl->error(ERROR_NO_ACCESS);
+    }
+    $rs = sql("SELECT `admin` FROM `user` WHERE `user_id`='&1'", $userid);
+    $r = sql_fetch_assoc($rs);
+    sql_free_result($rs);
+    if ($r == false) {
+        $tpl->assign('error', 'userunknown');
+        $tpl->display();
+    }
+    if (!($r['admin'] & $permid)) {
+        $perm = $r['admin'] + $permid;
+        sql("UPDATE `user` SET `admin`='&1' WHERE `user_id`='&2'", $perm, $userid);
+    }
+}
+
+?>

--- a/htdocs/templates2/ocstyle/adminrights.tpl
+++ b/htdocs/templates2/ocstyle/adminrights.tpl
@@ -1,0 +1,90 @@
+{***************************************************************************
+*  You can find the license in the docs directory
+*
+*  Unicode Reminder メモ
+***************************************************************************}
+{* OCSTYLE *}
+
+<div class="content2-pagetitle">
+    <img src="resource2/{$opt.template.style}/images/misc/32x32-tools.png" style="align: left; margin-right: 10px;" width="32" height="32" alt="World" />
+    {t}OC-Admins{/t}
+</div>
+
+<div class="content2-container">
+
+    <p>&nbsp;</p>
+
+    <form method="post" action="adminrights.php">
+        <input type="hidden" name="action" value="searchuser" />
+        <p style="line-height: 1.6em;"><strong>{t}Username or email address{/t}:</strong> &nbsp;<input type="text" name="username" size="30" value="{$username|escape}" /></p>
+
+        {if $error=='userunknown'}
+            <p style="line-height: 1.6em; color: red; font-weight: bold;">{t}Username unknown{/t}</p>
+        {/if}
+
+
+        <p style="line-height: 1.6em;"><input type="submit" name="find" value="{t}Submit{/t}" class="formbutton" onclick="submitbutton('find')" /></p>
+
+
+    </form>
+    {if $showdetails==true}
+        <form method="post" action="adminrights.php">
+            <div class="content2-pagetitle">
+                <img src="resource2/{$opt.template.style}/images/misc/32x32-tools.png" style="align: left; margin-right: 10px;" width="32" height="32" alt="World" />
+                {t}Useraccount details{/t}
+            </div>
+
+            <table class="narrowtable">
+                <tr>
+                    <td>{t}Username:{/t}</td>
+                    <td><a href="viewprofile.php?userid={$user.user_id|escape}" target="_blank">{$user.username|escape}</a></td>
+                </tr>
+                <tr>
+                    <td>{t}User-ID:{/t}</td>
+                    <td><a href="viewprofile.php?userid={$user.user_id|escape}" target="_blank">{$user.user_id|escape}</a></td>
+                </tr>
+
+                <tr>
+                    <td>{t}User rights{/t}</td>
+                    {if !$havenoperms}
+                    {foreach from=$user.rights item=right key=permid}
+                        <td>{$right}  <a href="adminrights.php?action=removeperms&userid={$user.user_id|escape}&permid={$permid}" > {t}remove{/t}</a> </td>
+                    </tr>
+                    <tr>
+                        <td></td>
+                    {/foreach}
+                    {else}
+                        <td>{t}The selected user does not have any administrative rights !{/t}</td>
+                    {/if}
+                </tr>
+
+            </table>
+
+        </form> 
+        <br> </br>
+        <form method="post" action="adminrights.php?userid={$user.user_id|escape}">
+            <input type="hidden" name="action" value="addperm" />
+            {if !$haveallperms}
+            <table class="narrowtable">
+                <tr>
+                    <td>
+                        {t}Add Permission: {/t} 
+                    </td>
+                    <td>
+                        <select name = "permid" >
+                            {foreach from=$user.norights item=right key=permid}
+                                <option value={$permid}>{$right}</option> 
+                            {/foreach}
+                    </td>
+                    <td>
+                    <p style="line-height: 1.6em;"><input type="submit" name="add" value="{t}Add{/t}" class="formbutton" onclick="submitbutton('add')" /></p>
+                    
+                    </td>
+                        
+                    </select>
+                </tr>
+            </table>
+                    {/if}
+        </form>
+    {/if}
+</div>


### PR DESCRIPTION
Bitte testen :)
Ermöglicht die vergabe und den entzug von Benutzerrechten über eine Graphische oberfläche.
Funktioniert in lokaler testumgebung.

Hier die sql abfrage zum einfügen des menüpunktes.

INSERT INTO `opencaching`.`sys_menu` (`id`, `id_string`, `title`, `title_trans_id`, `menustring`, `menustring_trans_id`, `access`, `href`, `visible`, `parent`, `position`, `color`, `sitemap`, `only_if_parent`) VALUES (NULL, 'MNU_ADMIN_RIGHTS', 'Adminrights', '', 'Permissions', '', '1', 'adminrights.php', '1', '12', '9', '', '', NULL);
