### PR TITLE
Link zu v10-Artikel im Changelog

### DIFF
--- a/htdocs/templates2/ocstyle/articles/DE/changelog.tpl
+++ b/htdocs/templates2/ocstyle/articles/DE/changelog.tpl
@@ -14,6 +14,7 @@
 
 	<p>Eine redaktionell aufbereitete Erläuterung neuer OC-Versionen gibt es auch im <em>Altmetall-Blog</em>:</p>
 	<ul>
+		<li><a href="http://blog.dafb-o.de/opencaching-de-version-10-freigegeben/">Version 10</a>: Nachladen von Logeinträgen, ausführliche Statistik im Benutzerprofil, Detailänderungen ...</li>
 		<li><a href="http://blog.dafb-o.de/alle-neune-oder-ein-update-fuer-opencachingde/">Version 9</a>: Suchfunktion, OConly-Features, Liste der eigenen Caches + Loghistorie, Schutzgebiete ...</li>
 		<li><a href="http://blog.dafb-o.de/opencaching-3-0-version-8-veroeffentlicht/">Version 8</a>: Statuslogs, Listinglayout, Koordinaten für zusätzliche Wegpunkte, Safari-Caches, Kartenfilteroptionen speichern, automatische Archivierung</li>
 		<li><a href="http://blog.dafb-o.de/okapi-jetzt-auch-fuer-opencaching-de/">Version 7</a>: OKAPI</li>


### PR DESCRIPTION
Nur eine Kleinigkeit: In der Übersicht der Redaktionell aufbereiteten "Versionsartikeln" fehlte noch Version 10.
