### PR TITLE
Editorial version for changelog v11

### DIFF
--- a/htdocs/templates2/ocstyle/articles/DE/changelog.tpl
+++ b/htdocs/templates2/ocstyle/articles/DE/changelog.tpl
@@ -14,6 +14,7 @@
 
 	<p>Eine redaktionell aufbereitete Erläuterung neuer OC-Versionen gibt es auch im <em>Altmetall-Blog</em>:</p>
 	<ul>
+		<li><a href="http://blog.dafb-o.de/opencaching-3-0-version-11-veroeffentlicht/">Version 11</a>: Automatische Verkleinerung von Bildern, Links zu Logseinträgen, Kleinigkeiten ...</li>
 		<li><a href="http://blog.dafb-o.de/opencaching-de-version-10-freigegeben/">Version 10</a>: Nachladen von Logeinträgen, ausführliche Statistik im Benutzerprofil, Detailänderungen ...</li>
 		<li><a href="http://blog.dafb-o.de/alle-neune-oder-ein-update-fuer-opencachingde/">Version 9</a>: Suchfunktion, OConly-Features, Liste der eigenen Caches + Loghistorie, Schutzgebiete ...</li>
 		<li><a href="http://blog.dafb-o.de/opencaching-3-0-version-8-veroeffentlicht/">Version 8</a>: Statuslogs, Listinglayout, Koordinaten für zusätzliche Wegpunkte, Safari-Caches, Kartenfilteroptionen speichern, automatische Archivierung</li>


### PR DESCRIPTION
In alter Tradition von Peter übernommen: Link zum Blogartikel im "Altmetallblog" - redaktionell aufgearbeitete Version des Changelog.

_Test nicht erforderlich, da lediglich ein Link eingefügt wurde!_
