### PR TITLE
Scrutinizer Code Analyse

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,4 +1,6 @@
 filter:
+    paths:
+        - 'htdocs/*'
     excluded_paths:
         - 'bin/*'
         - 'doc/*'

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,87 @@
+filter:
+    excluded_paths:
+        - 'bin/*'
+        - 'doc/*'
+        - 'local/*'
+    dependency_paths:
+        - 'htdocs/vendor/*'
+checks:
+    php:
+        fix_php_opening_tag: false
+        remove_php_closing_tag: false
+        one_class_per_file: true
+        side_effects_or_types: true
+        no_mixed_inline_html: false
+        require_braces_around_control_structures: false
+        php5_style_constructor: true
+        no_global_keyword: false
+        avoid_usage_of_logical_operators: true
+        psr2_class_declaration: true
+        no_underscore_prefix_in_properties: false
+        no_underscore_prefix_in_methods: false
+        blank_line_after_namespace_declaration: true
+        single_namespace_per_use: false
+        psr2_switch_declaration: true
+        psr2_control_structure_declaration: false
+        avoid_superglobals: false
+        security_vulnerabilities: true
+        no_exit: false
+        uppercase_constants: true
+        return_doc_comments: true
+        remove_extra_empty_lines: true
+        properties_in_camelcaps: true
+        prefer_while_loop_over_for_loop: true
+        phpunit_assertions: true
+        parameter_doc_comments: true
+        optional_parameters_at_the_end: true
+        no_long_variable_names:
+            maximum: '20'
+        no_goto: true
+        function_in_camel_caps: true
+        fix_use_statements:
+            remove_unused: true
+            preserve_multiple: false
+            preserve_blanklines: false
+            order_alphabetically: true
+        encourage_single_quotes: true
+        encourage_postdec_operator: true
+        classes_in_camel_caps: true
+        avoid_multiple_statements_on_same_line: true
+        avoid_fixme_comments: true
+
+coding_style:
+    php:
+        spaces:
+            around_operators:
+                concatenation: false
+            ternary_operator:
+                before_condition: false
+                after_condition: false
+                before_alternative: false
+                after_alternative: false
+            other:
+                after_type_cast: false
+        braces:
+            classes_functions:
+                class: new-line
+                function: new-line
+                closure: end-of-line
+            if:
+                opening: end-of-line
+            for:
+                opening: end-of-line
+            while:
+                opening: end-of-line
+            do_while:
+                opening: end-of-line
+            switch:
+                opening: end-of-line
+            try:
+                opening: end-of-line
+        upper_lower_casing:
+            keywords:
+                general: lower
+            constants:
+                true_false_null: lower
+
+

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -12,6 +12,7 @@ checks:
     php:
         fix_php_opening_tag: false
         remove_php_closing_tag: false
+        avoid_closing_tag: true
         one_class_per_file: true
         side_effects_or_types: true
         no_mixed_inline_html: false

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -52,6 +52,27 @@ checks:
         avoid_multiple_statements_on_same_line: true
         avoid_fixme_comments: true
 
+    javascript:
+        valid_typeof: true
+        yoda:
+            setting: 'Disallow Yoda Conditions'
+        wrap_iife: true
+        no_use_before_define: true
+        no_unused_vars: true
+        no_unreachable: true
+        no_undef: true
+        no_trailing_spaces: true
+        no_space_before_semi: true
+        no_shadow: true
+        no_self_compare: true
+        no_script_url: true
+        no_return_assign: true
+        no_reserved_keys: true
+        no_redeclare: true
+        no_mixed_spaces_and_tabs: true
+        no_loop_func: true
+        no_irregular_whitespace: true
+
 coding_style:
     php:
         spaces:
@@ -88,10 +109,9 @@ coding_style:
                 true_false_null: lower
 
 tools:
-    php_mess_detector: true
-    php_code_sniffer: true
-    sensiolabs_security_checker: true
-    php_code_coverage: false
+    php_code_sniffer:
+        config:
+            standard: "PSR2"
     php_pdepend: true
     php_cs_fixer:
         enabled: true

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -112,14 +112,7 @@ tools:
     php_code_sniffer:
         config:
             standard: "PSR2"
-    php_pdepend: true
     php_cs_fixer:
         enabled: true
         config: { level: psr2 }
-    php_loc:
-        enabled: true
-        excluded_dirs: []
-    php_cpd:
-        enabled: true
-        excluded_dirs: []
 

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,6 +7,7 @@ filter:
         - 'local/*'
     dependency_paths:
         - 'htdocs/vendor/*'
+
 checks:
     php:
         fix_php_opening_tag: false
@@ -16,7 +17,7 @@ checks:
         no_mixed_inline_html: false
         require_braces_around_control_structures: false
         php5_style_constructor: true
-        no_global_keyword: false
+        no_global_keyword: true
         avoid_usage_of_logical_operators: true
         psr2_class_declaration: true
         no_underscore_prefix_in_properties: false
@@ -86,4 +87,19 @@ coding_style:
             constants:
                 true_false_null: lower
 
+tools:
+    php_mess_detector: true
+    php_code_sniffer: true
+    sensiolabs_security_checker: true
+    php_code_coverage: false
+    php_pdepend: true
+    php_cs_fixer:
+        enabled: true
+        config: { level: psr2 }
+    php_loc:
+        enabled: true
+        excluded_dirs: []
+    php_cpd:
+        enabled: true
+        excluded_dirs: []
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 Opencaching.de Code Repository
 ==============================
 
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/mbirth/oc-server3/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/mbirth/oc-server3/?branch=master)
+[![Code Coverage](https://scrutinizer-ci.com/g/mbirth/oc-server3/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/mbirth/oc-server3/?branch=master)
+[![Build Status](https://scrutinizer-ci.com/g/mbirth/oc-server3/badges/build.png?b=master)](https://scrutinizer-ci.com/g/mbirth/oc-server3/build-status/master)
+
 [Opencaching.de](http://www.opencaching.de) is a major Geocaching website in Germany.
 This repository contains the website's code, including all third-party libraries
 needed to run it. It is one of two major


### PR DESCRIPTION
Scrutinizer liefert Informationen über die Code Qualität, -Kompatibilität und auch mögliche Sicherheitsprobleme vom Code. Für OpenSource-Projekte ist dieser Dienst gratis. Die Konfiguration hier entspricht gängigen Regeln. Außerdem liefert Scrutinizer auch Patches, die einfache Problemchen beheben (z.B. Einrückung, Klammern, etc.) und direkt in einen Pull Request gewandelt werden können.

Nach dem Merge hier muss jemand einen offiziellen OC-Account unter https://scrutinizer-ci.com/ anlegen und mit dem Repository bei GitHub verknüpfen (SSH-Key hinterlegen).

Wenn der Scrutinizer läuft, müssen die Badges in der README.md umgebogen werden. Die URLs erhält man in der Scrutinizer-Oberfläche, wenn man auf die kleinen (i)-Symbole hinter den Badges klickt.

Code Coverage ist nicht konfiguriert - das Badge kann also gelöscht werden.

Aktuell zeigt der bei mir übrigens knapp 4000 Probleme und Problemchen.