### PR TITLE
Ergänzung .de

### DIFF
--- a/htdocs/templates2/ocstyle/articles/DE/impressum.tpl
+++ b/htdocs/templates2/ocstyle/articles/DE/impressum.tpl
@@ -30,7 +30,7 @@
 	</p>
 	<p>
 		Um die Entwicklung von Anwendungen und Diensten f&uuml;r das Geocaching zu 
-		f&ouml;rdern, bietet Opencaching alle Stammdaten in einer einfach zu 
+		f&ouml;rdern, bietet Opencaching.de alle Stammdaten in einer einfach zu 
 		verarbeitenden Form zum Download an. Dabei sind die geltenden Datenschutzhinweise 
 		sowie Nutzungsbedingungen zu beachten.
 	</p>


### PR DESCRIPTION
Zum einen ist das ein Test der neuen Entwicklungsumgebung ^^, zum anderen ein kleiner Typo. Wir sprechen auf der Seite überall von Opencaching.de - nur an dieser Stelle nicht, daher um .de ergänzt