### PR TITLE
search caches by language; updates #48

### DIFF
--- a/htdocs/doc/sql/static-data/data.sql
+++ b/htdocs/doc/sql/static-data/data.sql
@@ -584,7 +584,7 @@ INSERT INTO `languages` (`short`, `name`, `trans_id`, `native_name`, `de`, `en`,
 INSERT INTO `languages` (`short`, `name`, `trans_id`, `native_name`, `de`, `en`, `list_default_de`, `list_default_en`) VALUES ('DA', 'Danish', '104', 'Dansk', 'Dänisch', 'Danish', '1', '1');
 INSERT INTO `languages` (`short`, `name`, `trans_id`, `native_name`, `de`, `en`, `list_default_de`, `list_default_en`) VALUES ('DE', 'German', '160', 'Deutsch', 'Deutsch', 'German', '1', '1');
 INSERT INTO `languages` (`short`, `name`, `trans_id`, `native_name`, `de`, `en`, `list_default_de`, `list_default_en`) VALUES ('EL', 'Greek', '103', 'Ελληνικά', 'Griechisch', 'Greek', '0', '0');
-INSERT INTO `languages` (`short`, `name`, `trans_id`, `native_name`, `de`, `en`, `list_default_de`, `list_default_en`) VALUES ('EN', 'English', '159', 'Englisch', 'Englisch', 'English', '1', '1');
+INSERT INTO `languages` (`short`, `name`, `trans_id`, `native_name`, `de`, `en`, `list_default_de`, `list_default_en`) VALUES ('EN', 'English', '159', 'English', 'Englisch', 'English', '1', '1');
 INSERT INTO `languages` (`short`, `name`, `trans_id`, `native_name`, `de`, `en`, `list_default_de`, `list_default_en`) VALUES ('EO', 'Esperanto', '102', 'Esperanto', 'Esperanto', 'Esperanto', '0', '0');
 INSERT INTO `languages` (`short`, `name`, `trans_id`, `native_name`, `de`, `en`, `list_default_de`, `list_default_en`) VALUES ('ES', 'Spanish', '157', 'Español', 'Spanisch', 'Spanish', '1', '1');
 INSERT INTO `languages` (`short`, `name`, `trans_id`, `native_name`, `de`, `en`, `list_default_de`, `list_default_en`) VALUES ('ET', 'Estonian', '101', 'Eesti', 'Estnisch', 'Estonian', '0', '0');
@@ -2714,6 +2714,7 @@ INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2244', 'Waypoin
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2245', 'without regional reference', '2010-08-28 11:48:04');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2246', '#colonspace#', '2010-08-28 11:48:04');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2247', 'User:', '2010-08-28 11:48:03');
+INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2248', 'All languages', '2010-08-28 11:48:03');
 
 -- Table sys_trans_ref
 SET NAMES 'utf8';
@@ -6989,6 +6990,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2245', 'DE', 'ohne Regionalbezug', '2010-08-28 11:48:06');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2246', 'DE', '<span></span>', '2010-08-28 11:48:06');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2247', 'DE', 'Benutzer:', '2010-08-28 11:48:06');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2248', 'DE', 'Alle Sprachen', '2010-08-28 11:48:06');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1', 'EN', 'Reorder IDs', '2010-09-02 00:15:30');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'EN', 'The database could not be reconnected.', '2010-08-28 11:48:07');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('3', 'EN', 'Testing – please do not login', '2010-08-28 11:48:07');
@@ -8749,6 +8751,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2245', 'EN', 'without regional reference', '2010-08-28 11:48:08');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2246', 'EN', '<span></span>', '2010-08-28 11:48:08');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2247', 'EN', 'User:', '2010-08-28 11:48:07');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2248', 'EN', 'All languages', '2010-08-28 11:48:07');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'ES', 'La base de datos no se pudo conectar.', '2010-12-09 00:17:55');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('3', 'ES', 'En pruebas - por favor, no entre.', '2010-12-09 00:17:55');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('4', 'ES', 'Usuario', '2010-12-09 00:17:55');
@@ -10231,6 +10234,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2244', 'ES', 'Waypoint:', '2010-12-09 00:17:58');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2246', 'ES', '<span></span>', '2010-12-09 00:17:58');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2247', 'ES', 'Usuario:', '2010-12-09 00:17:55');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2248', 'ES', 'Todos los idiomas', '2010-12-09 00:18:00');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1', 'FR', 'Réorganiser des IDs', '2015-08-25 01:28:59');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'FR', 'La base de données n\'a pas pu être connecté.', '2015-08-25 01:28:59');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('3', 'FR', 'Test - Ne vous connectez pas, s\'il vous plaît', '2015-08-25 01:28:59');
@@ -11992,6 +11996,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2245', 'FR', 'sans référence régionale', '2010-08-28 11:48:08');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2246', 'FR', '\&nbsp;', '2010-08-28 11:48:08');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2247', 'FR', 'Utilisateur\&nbsp;:', '2015-08-25 01:28:59');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2248', 'FR', 'Tous les langues', '2015-08-25 01:28:59');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1', 'IT', 'Riordina gli ID', '2010-10-27 18:49:18');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'IT', 'Impossibile riconnettersi al database', '2010-08-28 20:28:01');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('3', 'IT', 'Test - per favore non connettersi', '2010-08-28 20:36:53');
@@ -12233,7 +12238,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('263', 'IT', 'Singapore', '2010-08-30 11:31:29');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('264', 'IT', 'Svezia', '2010-08-30 11:31:35');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('265', 'IT', 'Sudan', '2010-08-30 11:31:40');
-INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('266', 'IT', 'Seicelle (Repubblica delle Seychelles)', '2010-08-30 11:32:07');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('266', 'IT', 'Seicelle', '2010-08-30 11:32:07');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('267', 'IT', 'Salomone, Isole', '2010-08-30 11:32:24');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('268', 'IT', 'Arabia Saudita', '2010-08-30 11:32:36');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('269', 'IT', 'Ruanda', '2010-08-30 11:32:47');
@@ -13684,6 +13689,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2244', 'IT', 'Waypoint:', '2010-09-01 23:49:03');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2246', 'IT', '<span></span>', '2010-12-09 00:17:58');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2247', 'IT', 'Utente:', '2010-08-28 20:29:29');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2248', 'IT', 'Tutte le linguaggi', '2010-08-28 20:29:29');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('922', 'JA', 'JA', '2011-05-15 16:04:51');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1', 'NL', 'ID\'s opnieuw sorteren', '2011-02-04 19:49:56');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'NL', 'De verbinding met de database kon niet hersteld worden.', '2011-02-04 19:49:56');

--- a/htdocs/doc/sql/tables/languages.sql
+++ b/htdocs/doc/sql/tables/languages.sql
@@ -5,7 +5,7 @@ CREATE TABLE `languages` (
   `name` varchar(60) NOT NULL,
   `trans_id` int(10) unsigned NOT NULL,
   `de` varchar(60) NOT NULL COMMENT 'obsolete',
-  `en` varchar(60) NOT NULL COMMENT 'obsolete',
+  `en` varchar(60) NOT NULL,
   `list_default_de` tinyint(1) NOT NULL default '0' COMMENT 'obsolete',
   `list_default_en` tinyint(1) NOT NULL default '0' COMMENT 'obsolete',
   PRIMARY KEY  (`short`),

--- a/htdocs/templates2/ocstyle/error.tpl
+++ b/htdocs/templates2/ocstyle/error.tpl
@@ -31,7 +31,7 @@
 		{elseif $id==ERROR_INVALID_OPERATION}
 			({$id}) {t}Sorry, the requested operation cannot be performed.{/t}
 		{elseif $id==ERROR_LOGIN_REQUIRED}
-			({$id}) {t}Please login to continue:{/t}
+			({$id}) {t}Please login to continue:{/t}&nbsp; <a href="login.php">{t}Login{/t}
 		{elseif $id==ERROR_USER_NOT_EXISTS}
 			({$id}) {t}Sorry, the requested user does not exist.{/t}
 		{elseif $id==ERROR_USER_NOT_ACTIVE}

--- a/htdocs/templates2/ocstyle/search.tpl
+++ b/htdocs/templates2/ocstyle/search.tpl
@@ -195,6 +195,7 @@ function sync_options(element)
 		document.forms[formnames[i]].f_otherPlatforms.value = document.optionsform.f_otherPlatforms.checked ? 1 : 0;
 		document.forms[formnames[i]].f_geokrets.value = document.optionsform.f_geokrets.checked ? 1 : 0;
 		document.forms[formnames[i]].country.value = document.optionsform.country.value;
+		document.forms[formnames[i]].language.value = document.optionsform.language.value;
 		document.forms[formnames[i]].difficultymin.value = document.optionsform.difficultymin.value;
 		document.forms[formnames[i]].difficultymax.value = document.optionsform.difficultymax.value;
 		document.forms[formnames[i]].terrainmin.value = document.optionsform.terrainmin.value;
@@ -398,10 +399,18 @@ function switchAttributeCat2()
 		<tr>
 			<td class="formlabel">{t}Country:{/t}&nbsp;&nbsp;</td>
 			<td>
-				<select name="country" class="input200" onchange="sync_options(this)">
+				<select name="country" onchange="sync_options(this)">
 					<option value="" selected="selected">{t}All countries{/t}</option>
 					{foreach from=$countryoptions item=countryoption}
 						<option value="{$countryoption.short|escape}" {if $countryoption.selected}selected="selected"{/if}>{$countryoption.name|escape}</option> 
+					{/foreach}
+				</select>
+				&nbsp; &nbsp; &nbsp; &nbsp;
+				<span class="formlabel">{t}Language:{/t}&nbsp;&nbsp;</span>
+				<select name="language" onchange="sync_options(this)">
+					<option value="" selected="selected">{t}All languages{/t}</option>
+					{foreach from=$languageoptions item=languageoption}
+						<option value="{$languageoption.short|escape}" {if $languageoption.selected}selected="selected"{/if}>{$languageoption.name|escape}</option> 
 					{/foreach}
 				</select>
 			</td>
@@ -492,6 +501,7 @@ function switchAttributeCat2()
 		<input type="hidden" name="f_otherPlatforms" value="{$hidopt_otherPlatforms}" />
 		<input type="hidden" name="f_geokrets" value="{$hidopt_geokrets}" />
 		<input type="hidden" name="country" value="{$country}" />
+		<input type="hidden" name="language" value="{$language}" />
 		<input type="hidden" name="difficultymin" value="{$difficultymin}" />
 		<input type="hidden" name="difficultymax" value="{$difficultymax}" />
 		<input type="hidden" name="terrainmin" value="{$terrainmin}" />
@@ -526,6 +536,7 @@ function switchAttributeCat2()
 		<input type="hidden" name="f_otherPlatforms" value="{$hidopt_otherPlatforms}" />
 		<input type="hidden" name="f_geokrets" value="{$hidopt_geokrets}" />
 		<input type="hidden" name="country" value="{$country}" />
+		<input type="hidden" name="language" value="{$language}" />
 		<input type="hidden" name="cachetype" value="{$cachetype}" />
 		<input type="hidden" name="cachesize" value="{$cachesize}" />
 		<input type="hidden" name="difficultymin" value="{$difficultymin}" />
@@ -562,6 +573,7 @@ function switchAttributeCat2()
 		<input type="hidden" name="f_otherPlatforms" value="{$hidopt_otherPlatforms}" />
 		<input type="hidden" name="f_geokrets" value="{$hidopt_geokrets}" />
 		<input type="hidden" name="country" value="{$country}" />
+		<input type="hidden" name="language" value="{$language}" />
 		<input type="hidden" name="cachetype" value="{$cachetype}" />
 		<input type="hidden" name="cachesize" value="{$cachesize}" />
 		<input type="hidden" name="difficultymin" value="{$difficultymin}" />
@@ -622,6 +634,7 @@ function switchAttributeCat2()
 		<input type="hidden" name="f_otherPlatforms" value="{$hidopt_otherPlatforms}" />
 		<input type="hidden" name="f_geokrets" value="{$hidopt_geokrets}" />
 		<input type="hidden" name="country" value="{$country}" />
+		<input type="hidden" name="language" value="{$language}" />
 		<input type="hidden" name="cachetype" value="{$cachetype}" />
 		<input type="hidden" name="cachesize" value="{$cachesize}" />
 		<input type="hidden" name="difficultymin" value="{$difficultymin}" />
@@ -657,6 +670,7 @@ function switchAttributeCat2()
 		<input type="hidden" name="f_otherPlatforms" value="{$hidopt_otherPlatforms}" />
 		<input type="hidden" name="f_geokrets" value="{$hidopt_geokrets}" />
 		<input type="hidden" name="country" value="{$country}" />
+		<input type="hidden" name="language" value="{$language}" />
 		<input type="hidden" name="difficultymin" value="{$difficultymin}" />
 		<input type="hidden" name="difficultymax" value="{$difficultymax}" />
 		<input type="hidden" name="terrainmin" value="{$terrainmin}" />
@@ -702,6 +716,7 @@ function switchAttributeCat2()
 		<input type="hidden" name="f_otherPlatforms" value="{$hidopt_otherPlatforms}" />
 		<input type="hidden" name="f_geokrets" value="{$hidopt_geokrets}" />
 		<input type="hidden" name="country" value="{$country}" />
+		<input type="hidden" name="language" value="{$language}" />
 		<input type="hidden" name="difficultymin" value="{$difficultymin}" />
 		<input type="hidden" name="difficultymax" value="{$difficultymax}" />
 		<input type="hidden" name="terrainmin" value="{$terrainmin}" />
@@ -737,6 +752,7 @@ function switchAttributeCat2()
 		<input type="hidden" name="f_otherPlatforms" value="{$hidopt_otherPlatforms}" />
 		<input type="hidden" name="f_geokrets" value="{$hidopt_geokrets}" />
 		<input type="hidden" name="country" value="{$country}" />
+		<input type="hidden" name="language" value="{$language}" />
 		<input type="hidden" name="difficultymin" value="{$difficultymin}" />
 		<input type="hidden" name="difficultymax" value="{$difficultymax}" />
 		<input type="hidden" name="terrainmin" value="{$terrainmin}" />
@@ -783,6 +799,7 @@ function switchAttributeCat2()
 		<input type="hidden" name="f_otherPlatforms" value="{$hidopt_otherPlatforms}" />
 		<input type="hidden" name="f_geokrets" value="{$hidopt_geokrets}" />
 		<input type="hidden" name="country" value="{$country}" />
+		<input type="hidden" name="language" value="{$language}" />
 		<input type="hidden" name="difficultymin" value="{$difficultymin}" />
 		<input type="hidden" name="difficultymax" value="{$difficultymax}" />
 		<input type="hidden" name="terrainmin" value="{$terrainmin}" />

--- a/htdocs/templates2/ocstyle/viewcache.tpl
+++ b/htdocs/templates2/ocstyle/viewcache.tpl
@@ -342,7 +342,8 @@ function showalllists()
 				{if $smarty.foreach.desclanguagesItem.first==false} &nbsp;&middot;&nbsp; {/if}
 				{if $cache.desclanguage==$desclanguagesItem.code}
 					<span class="txt-black" >{$desclanguagesItem.native_name|escape}</span>
-					{if $desclanguagesItem.name != $desclanguagesItem.native_name}
+					{if $desclanguagesItem.name != $desclanguagesItem.native_name &&
+					    !($desclanguagesItem.name == 'Englisch' && $desclanguagesItem.native_name == 'English')}
 						<span style="font-weight:normal" class="txt-black">({$desclanguagesItem.name})</span>
 					{/if}
 				{else}


### PR DESCRIPTION
Ein kleiner Anfang. Im nächsten Schritt könnte man Sprachen von Cachebeschreibungen per Wörterbuch automatisch ermitteln.