### PR TITLE
option to show new caches or logs for or without the selected country, updates #183

### DIFF
--- a/htdocs/doc/sql/static-data/data.sql
+++ b/htdocs/doc/sql/static-data/data.sql
@@ -875,7 +875,6 @@ INSERT INTO `sys_menu` (`id`, `id_string`, `title`, `title_trans_id`, `menustrin
 INSERT INTO `sys_menu` (`id`, `id_string`, `title`, `title_trans_id`, `menustring`, `menustring_trans_id`, `access`, `href`, `visible`, `parent`, `position`, `color`, `sitemap`, `only_if_parent`) VALUES ('3', 'MNU_START_REGISTER', 'Register', '18', 'Register', '18', '0', 'register.php', '2', '1', '12', '', '1', NULL);
 INSERT INTO `sys_menu` (`id`, `id_string`, `title`, `title_trans_id`, `menustring`, `menustring_trans_id`, `access`, `href`, `visible`, `parent`, `position`, `color`, `sitemap`, `only_if_parent`) VALUES ('4', 'MNU_START_NEWS', 'News', '70', 'News', '70', '0', 'news.php', '0', '1', '1', '', '1', NULL);
 INSERT INTO `sys_menu` (`id`, `id_string`, `title`, `title_trans_id`, `menustring`, `menustring_trans_id`, `access`, `href`, `visible`, `parent`, `position`, `color`, `sitemap`, `only_if_parent`) VALUES ('5', 'MNU_START_NEWCACHES', 'New caches', '122', 'New caches', '122', '0', 'newcaches.php', '1', '1', '2', '', '1', NULL);
-INSERT INTO `sys_menu` (`id`, `id_string`, `title`, `title_trans_id`, `menustring`, `menustring_trans_id`, `access`, `href`, `visible`, `parent`, `position`, `color`, `sitemap`, `only_if_parent`) VALUES ('6', 'MNU_START_NEWCACHESREST', 'Without Germany', '121', 'Without Germany', '121', '0', 'newcachesrest.php', '1', '5', '1', '', '1', NULL);
 INSERT INTO `sys_menu` (`id`, `id_string`, `title`, `title_trans_id`, `menustring`, `menustring_trans_id`, `access`, `href`, `visible`, `parent`, `position`, `color`, `sitemap`, `only_if_parent`) VALUES ('7', 'MNU_START_NEWLOGS', 'New logs', '120', 'New logs', '120', '0', 'newlogs.php', '1', '1', '3', '', '1', NULL);
 INSERT INTO `sys_menu` (`id`, `id_string`, `title`, `title_trans_id`, `menustring`, `menustring_trans_id`, `access`, `href`, `visible`, `parent`, `position`, `color`, `sitemap`, `only_if_parent`) VALUES ('8', 'MNU_START_IMPRINT', 'Imprint', '15', 'Imprint', '15', '0', 'articles.php?page=impressum', '1', '1', '17', '', '1', NULL);
 INSERT INTO `sys_menu` (`id`, `id_string`, `title`, `title_trans_id`, `menustring`, `menustring_trans_id`, `access`, `href`, `visible`, `parent`, `position`, `color`, `sitemap`, `only_if_parent`) VALUES ('9', 'MNU_MYPROFILE', 'My profile', '119', 'My profile', '119', '0', 'myhome.php', '1', '0', '2', '#E8DDE4', '1', NULL);
@@ -936,7 +935,6 @@ INSERT INTO `sys_menu` (`id`, `id_string`, `title`, `title_trans_id`, `menustrin
 INSERT INTO `sys_menu` (`id`, `id_string`, `title`, `title_trans_id`, `menustring`, `menustring_trans_id`, `access`, `href`, `visible`, `parent`, `position`, `color`, `sitemap`, `only_if_parent`) VALUES ('91', 'MNU_START_OPENCACHING', 'About Opencaching', '1963', 'About Opencaching', '1963', '0', 'articles.php?page=opencaching\&wiki', '1', '1', '11', '', '1', NULL);
 INSERT INTO `sys_menu` (`id`, `id_string`, `title`, `title_trans_id`, `menustring`, `menustring_trans_id`, `access`, `href`, `visible`, `parent`, `position`, `color`, `sitemap`, `only_if_parent`) VALUES ('92', 'MNU_MYPROFILE_PUBLIC', 'Public profile', '1952', 'Public profile', '1952', '0', 'viewprofile.php', '1', '9', '2', '', '1', NULL);
 INSERT INTO `sys_menu` (`id`, `id_string`, `title`, `title_trans_id`, `menustring`, `menustring_trans_id`, `access`, `href`, `visible`, `parent`, `position`, `color`, `sitemap`, `only_if_parent`) VALUES ('93', 'MNU_ADMIN_RESTORE', 'Vandalism', '1880', 'Vandalism', '1880', '0', 'restorecaches.php', '1', '12', '6', '', '0', NULL);
-INSERT INTO `sys_menu` (`id`, `id_string`, `title`, `title_trans_id`, `menustring`, `menustring_trans_id`, `access`, `href`, `visible`, `parent`, `position`, `color`, `sitemap`, `only_if_parent`) VALUES ('94', 'MNU_START_NEWLOGSREST', 'Without Germany', '121', 'Without Germany', '121', '0', 'newlogsrest.php', '1', '7', '1', '', '1', NULL);
 INSERT INTO `sys_menu` (`id`, `id_string`, `title`, `title_trans_id`, `menustring`, `menustring_trans_id`, `access`, `href`, `visible`, `parent`, `position`, `color`, `sitemap`, `only_if_parent`) VALUES ('95', 'MNU_MYPROFILE_OKAPI', 'OKAPI Applications', '2008', 'OKAPI Apps', '2009', '0', '!okapi/apps/?langpref=%LANG', '1', '9', '10', '', '1', NULL);
 INSERT INTO `sys_menu` (`id`, `id_string`, `title`, `title_trans_id`, `menustring`, `menustring_trans_id`, `access`, `href`, `visible`, `parent`, `position`, `color`, `sitemap`, `only_if_parent`) VALUES ('96', 'MNU_ADMIN_HISTORY', 'Cache history', '2059', 'Cache history', '2059', '1', 'adminhistory.php', '1', '12', '4', '', '0', NULL);
 INSERT INTO `sys_menu` (`id`, `id_string`, `title`, `title_trans_id`, `menustring`, `menustring_trans_id`, `access`, `href`, `visible`, `parent`, `position`, `color`, `sitemap`, `only_if_parent`) VALUES ('97', 'MNU_CACHES_SEARCH_SELECT_CITY', 'Select city', '1694', 'Select city', '1694', '0', 'search.php', '0', '20', '1', '', '0', NULL);
@@ -2714,6 +2712,13 @@ INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2244', 'Waypoin
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2245', 'without regional reference', '2010-08-28 11:48:04');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2246', '#colonspace#', '2010-08-28 11:48:04');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2247', 'User:', '2010-08-28 11:48:03');
+INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2249', 'Caches without %1', '2010-08-28 11:48:03');
+INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2250', 'All logs', '2010-08-28 11:48:03');
+INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2551', 'Logs in %1', '2010-08-28 11:48:03');
+INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2252', 'Logs without %1', '2010-08-28 11:48:03');
+INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2253', 'Latest caches without %1', '2010-10-21 22:54:23');
+INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2254', 'Latest log entries in %1', '2010-08-28 11:48:03');
+INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2255', 'Latest log entries without %1', '2010-08-28 11:48:03');
 
 -- Table sys_trans_ref
 SET NAMES 'utf8';
@@ -6989,6 +6994,13 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2245', 'DE', 'ohne Regionalbezug', '2010-08-28 11:48:06');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2246', 'DE', '<span></span>', '2010-08-28 11:48:06');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2247', 'DE', 'Benutzer:', '2010-08-28 11:48:06');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2249', 'DE', 'Caches ohne %1', '2010-08-28 11:48:06');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2250', 'DE', 'Alle Logs', '2010-08-28 11:48:06');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2251', 'DE', 'Logs in %1', '2010-08-28 11:48:06');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2252', 'DE', 'Logs ohne %1', '2010-08-28 11:48:06');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2253', 'DE', 'Neueste Caches ohne %1', '2010-08-28 11:48:06');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2254', 'DE', 'Neueste Logeinträge in %1', '2010-08-28 11:48:06');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2255', 'DE', 'Neueste Logeinträge ohne %1', '2010-08-28 11:48:06');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1', 'EN', 'Reorder IDs', '2010-09-02 00:15:30');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'EN', 'The database could not be reconnected.', '2010-08-28 11:48:07');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('3', 'EN', 'Testing – please do not login', '2010-08-28 11:48:07');
@@ -8749,6 +8761,13 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2245', 'EN', 'without regional reference', '2010-08-28 11:48:08');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2246', 'EN', '<span></span>', '2010-08-28 11:48:08');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2247', 'EN', 'User:', '2010-08-28 11:48:07');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2249', 'EN', 'Caches without %1', '2010-08-28 11:48:07');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2250', 'EN', 'All logs', '2010-08-28 11:48:07');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2251', 'EN', 'Logs in %1', '2010-08-28 11:48:07');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2252', 'EN', 'Logs without %1', '2010-08-28 11:48:07');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2253', 'EN', 'Latest caches without %1', '2010-08-28 11:48:07');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2254', 'EN', 'Latest log entries in %1', '2010-08-28 11:48:07');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2255', 'EN', 'Latest log entries without %1', '2010-08-28 11:48:07');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'ES', 'La base de datos no se pudo conectar.', '2010-12-09 00:17:55');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('3', 'ES', 'En pruebas - por favor, no entre.', '2010-12-09 00:17:55');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('4', 'ES', 'Usuario', '2010-12-09 00:17:55');
@@ -10231,6 +10250,13 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2244', 'ES', 'Waypoint:', '2010-12-09 00:17:58');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2246', 'ES', '<span></span>', '2010-12-09 00:17:58');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2247', 'ES', 'Usuario:', '2010-12-09 00:17:55');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2249', 'ES', 'Caches sin %1', '2010-12-09 00:17:55');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2250', 'ES', 'Todos los logs', '2010-12-09 00:17:55');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2251', 'ES', 'Logs en %1', '2010-12-09 00:17:55');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2252', 'ES', 'Logs sin %1', '2010-12-09 00:17:55');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2253', 'ES', 'Últimos caches sin %1', '2010-12-09 00:17:55');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2254', 'ES', 'Últimos logs en %1', '2010-12-09 00:17:55');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2255', 'ES', 'Últimos logs sin %1', '2010-12-09 00:17:55');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1', 'FR', 'Réorganiser des IDs', '2015-08-25 01:28:59');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'FR', 'La base de données n\'a pas pu être connecté.', '2015-08-25 01:28:59');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('3', 'FR', 'Test - Ne vous connectez pas, s\'il vous plaît', '2015-08-25 01:28:59');
@@ -11507,7 +11533,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1707', 'FR', 'Autres OC nodes', '2015-08-25 01:29:00');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1708', 'FR', 'Les prochains événements dans %1', '2015-08-25 01:29:00');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1709', 'FR', 'Géocaches avec les plus récommendations dans les derniers %2 jours à %1.', '2015-08-25 01:29:00');
-INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1710', 'FR', 'Nouveaux caches en %1', '2015-08-25 01:29:00');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1710', 'FR', '	Derniers caches en %1', '2015-08-25 01:29:00');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1711', 'FR', 'Vous avez besion des %1 trouvailles supplémentaires pour faire une autre recommandation.', '2015-08-25 01:29:00');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1713', 'FR', 'Vous avez recommandé cette cache.', '2015-08-25 01:29:00');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1714', 'FR', 'Révoquer la recommandation', '2015-08-25 01:29:00');
@@ -11992,6 +12018,13 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2245', 'FR', 'sans référence régionale', '2010-08-28 11:48:08');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2246', 'FR', '\&nbsp;', '2010-08-28 11:48:08');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2247', 'FR', 'Utilisateur\&nbsp;:', '2015-08-25 01:28:59');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2249', 'FR', 'Caches sans %1', '2015-08-25 01:28:59');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2250', 'FR', 'Tous les logs', '2015-08-25 01:28:59');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2251', 'FR', 'Logs à %1', '2015-08-25 01:28:59');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2252', 'FR', 'Logs sans %1', '2015-08-25 01:28:59');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2253', 'FR', 'Derniers caches sans %1', '2015-08-25 01:28:59');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2254', 'FR', 'Dernies entrées du log á %1', '2015-08-25 01:28:59');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2255', 'FR', 'Dernies entrées du log sans %1', '2015-08-25 01:28:59');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1', 'IT', 'Riordina gli ID', '2010-10-27 18:49:18');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'IT', 'Impossibile riconnettersi al database', '2010-08-28 20:28:01');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('3', 'IT', 'Test - per favore non connettersi', '2010-08-28 20:36:53');
@@ -13684,6 +13717,13 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2244', 'IT', 'Waypoint:', '2010-09-01 23:49:03');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2246', 'IT', '<span></span>', '2010-12-09 00:17:58');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2247', 'IT', 'Utente:', '2010-08-28 20:29:29');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2249', 'IT', 'Caches senza %1', '2010-08-28 20:29:29');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2250', 'IT', 'Tutto logs', '2010-08-28 20:29:29');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2251', 'IT', 'Logs in %1', '2010-08-28 20:29:29');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2252', 'IT', 'Logs senza %1', '2010-08-28 20:29:29');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2253', 'IT', 'Ultime caches senza %1', '2010-08-28 20:29:29');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2254', 'IT', 'Ultime logs in %1', '2010-08-28 20:29:29');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2255', 'IT', 'Ultime logs senza %1', '2010-08-28 20:29:29');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('922', 'JA', 'JA', '2011-05-15 16:04:51');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1', 'NL', 'ID\'s opnieuw sorteren', '2011-02-04 19:49:56');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'NL', 'De verbinding met de database kon niet hersteld worden.', '2011-02-04 19:49:56');

--- a/htdocs/lib2/OcSmarty.class.php
+++ b/htdocs/lib2/OcSmarty.class.php
@@ -229,24 +229,26 @@ class OcSmarty extends Smarty
 			$optn['template']['title'] = $menu->GetMenuTitle();
 
 		// build address for switching locales
-		$locale_pageadr = $_SERVER['REQUEST_URI'];
+		$base_pageadr = $_SERVER['REQUEST_URI'];
 		// workaround for http://redmine.opencaching.de/issues/703
-		$strange_things_pos = strpos($locale_pageadr,".php/");
+		$strange_things_pos = strpos($base_pageadr,".php/");
 		if ($strange_things_pos)
-			$locale_pageadr = substr($locale_pageadr,0,$strange_things_pos + 4);
-		$lpos = strpos($locale_pageadr,"locale=");
+			$base_pageadr = substr($base_pageadr,0,$strange_things_pos + 4);
+		$lpos = strpos($base_pageadr,"locale=");
+		if (!$lpos) $lpos = strpos($base_pageadr,"usercountry=");
+		if (!$lpos) $lpos = strpos($base_pageadr,"country=");
 		if ($lpos)
-			$locale_pageadr = substr($locale_pageadr,0,$lpos);
+			$base_pageadr = substr($base_pageadr,0,$lpos);
 		else
 		{
-			$urx = explode('#', $locale_pageadr);
-			$locale_pageadr = $urx[0];
-			if (strpos($locale_pageadr,'?') == 0)
-				$locale_pageadr .= '?';
+			$urx = explode('#', $base_pageadr);
+			$base_pageadr = $urx[0];
+			if (strpos($base_pageadr,'?') == 0)
+				$base_pageadr .= '?';
 			else
-				$locale_pageadr .= '&';
+				$base_pageadr .= '&';
 		}
-		$this->assign('locale_pageadr', $locale_pageadr);
+		$this->assign('base_pageadr', $base_pageadr);
 
 		if ($opt['logic']['license']['disclaimer'])
 		{

--- a/htdocs/newcaches.php
+++ b/htdocs/newcaches.php
@@ -10,7 +10,8 @@
 	$tpl->menuitem = MNU_START_NEWCACHES;
 
 	$startat = isset($_REQUEST['startat']) ? $_REQUEST['startat']+0 : 0;
-	$country = isset($_REQUEST['country']) ? $_REQUEST['country'] : '';
+	$country = isset($_REQUEST['country']) ? $_REQUEST['country'] :
+	           (isset($_REQUEST['usercountry']) ? $_REQUEST['usercountry'] : '');
 	$cachetype = isset($_REQUEST['cachetype']) ? $_REQUEST['cachetype']+0 : 0;
 	$bEvents = ($cachetype == 6);
 
@@ -75,17 +76,17 @@
 
 		$tpl->assign('defaultcountry', $opt['template']['default']['country']);
 		$tpl->assign('countryCode', $country);
-		if ($country != '')
-		{
-			$tpl->assign(
-				'countryName',
-				sql_value("SELECT IFNULL(`sys_trans_text`.`text`, `countries`.`name`) 
-		                FROM `countries`
-		           LEFT JOIN `sys_trans` ON `countries`.`trans_id`=`sys_trans`.`id`
-		           LEFT JOIN `sys_trans_text` ON `sys_trans`.`id`=`sys_trans_text`.`trans_id` AND `sys_trans_text`.`lang`='&2'
-		               WHERE `countries`.`short`='&1'", '', $country, $opt['template']['locale'])
+		$tpl->assign(
+			'countryName',
+			sql_value("SELECT IFNULL(`sys_trans_text`.`text`, `countries`.`name`) 
+	                FROM `countries`
+	           LEFT JOIN `sys_trans` ON `countries`.`trans_id`=`sys_trans`.`id`
+	           LEFT JOIN `sys_trans_text` ON `sys_trans`.`id`=`sys_trans_text`.`trans_id` AND `sys_trans_text`.`lang`='&2'
+	               WHERE `countries`.`short`='&1'",
+	              '',
+	              $country ? $country : $login->getUserCountry(),
+	              $opt['template']['locale'])
 			);
-   	}
 
 		$tpl->assign('events', $bEvents);
 	}

--- a/htdocs/newcachesrest.php
+++ b/htdocs/newcachesrest.php
@@ -7,10 +7,12 @@
 
 	require('./lib2/web.inc.php');
 	$tpl->name = 'newcachesrest';
-	$tpl->menuitem = MNU_START_NEWCACHESREST;
+	$tpl->menuitem = MNU_START_NEWCACHES;
 
 	$tpl->caching = true;
 	$tpl->cache_lifetime = 3600;
+
+	$country = isset($_REQUEST['country']) ? $_REQUEST['country'] : $login->getUserCountry();
 
 	if (!$tpl->is_cached())
 	{
@@ -19,7 +21,7 @@
 		$newCaches = array();
 
 		sql_temp_table_slave('cachelist');
-		sql_slave("CREATE TEMPORARY TABLE &cachelist (`cache_id` INT(11) PRIMARY KEY) SELECT `cache_id` FROM `caches` INNER JOIN `cache_status` ON `caches`.`status`=`cache_status`.`id` WHERE `cache_status`.`allow_user_view`=1 AND `country`!='DE' ORDER BY `date_created` DESC LIMIT 200");
+		sql_slave("CREATE TEMPORARY TABLE &cachelist (`cache_id` INT(11) PRIMARY KEY) SELECT `cache_id` FROM `caches` INNER JOIN `cache_status` ON `caches`.`status`=`cache_status`.`id` WHERE `cache_status`.`allow_user_view`=1 AND `country`!='". sql_escape($country) . "' ORDER BY `date_created` DESC LIMIT 200");
 
 		$rsNewCaches = sql_slave("SELECT IFNULL(`sys_trans_text`.`text`, `countries`.`name`) `country_name`, `caches`.`cache_id` `cacheid`, `caches`.`wp_oc` `wpoc`, `user`.`user_id` `userid`, `caches`.`country` `country`, `caches`.`name` `cachename`, `caches`.`type`, `caches`.`country` `country`, `user`.`username` `username`, `caches`.`date_created` `date_created`, `cache_type`.`icon_large` `icon_large`, `ca`.`attrib_id` IS NOT NULL AS `oconly`
 		                            FROM `caches`
@@ -43,6 +45,19 @@
 		sql_drop_temp_table_slave('cachelist');
 
 		$tpl->assign('newCaches', $newCaches);
+
+		$tpl->assign('countryCode',  $country);
+		$tpl->assign(
+			'countryName',
+			sql_value("SELECT IFNULL(`sys_trans_text`.`text`, `countries`.`name`) 
+	                FROM `countries`
+	           LEFT JOIN `sys_trans` ON `countries`.`trans_id`=`sys_trans`.`id`
+	           LEFT JOIN `sys_trans_text` ON `sys_trans`.`id`=`sys_trans_text`.`trans_id` AND `sys_trans_text`.`lang`='&2'
+	               WHERE `countries`.`short`='&1'",
+	              '',
+	              $country,
+	              $opt['template']['locale'])
+			);
 	}
 
 	$tpl->display();

--- a/htdocs/newlogs.php
+++ b/htdocs/newlogs.php
@@ -15,7 +15,9 @@
 	if (isset($ownerid))
 	{
 		// all logs for caches of one owner
+		$country = false;
 		$exclude_country = '*';
+		$include_country = '%';
 		$add_where = "AND `caches`.`user_id`='" . sql_escape($ownerid) . "' ";
 		if (!$show_own_logs)
 			$add_where .= "AND `cache_logs`.`user_id`<>'" . sql_escape($login->userid) . "' ";
@@ -30,7 +32,9 @@
 	elseif (isset($userid))
 	{
 		// all logs by one user
+		$country = false;
 		$exclude_country = '*';
+		$include_country = '%';
 		$add_where = "AND `cache_logs`.`user_id`='" . sql_escape($userid) . "' ";
 		$tpl->caching = false;
 		$logcount = 100;
@@ -42,9 +46,9 @@
 	{
 		// latest logs for all countries but Germany
 		$tpl->name = 'newlogsrest';
-		$tpl->menuitem = MNU_START_NEWLOGSREST;
-		$exclude_country = 'DE';
-
+		$tpl->menuitem = MNU_START_NEWLOGS;
+		$country = $exclude_country = $login->getUserCountry();
+    $include_country = '%';
 		// As nearly all logs are from Germany, retrieving non-German logs is
 		// expensive -> longer cache lifetime.
 		$tpl->caching = true;
@@ -55,10 +59,19 @@
 	}
 	else
 	{
-		// latest logs for all countries
+		// latest logs for all countries or for one country
 		$tpl->name = 'newlogs';
 		$tpl->menuitem = MNU_START_NEWLOGS;
 		$exclude_country = '*';
+		if (isset($_REQUEST['country']))
+			$country = $include_country = $_REQUEST['country'];
+		else if (isset($_REQUEST['usercountry']))
+			$country = $include_country = $_REQUEST['usercountry'];
+		else
+		{
+			$country = '';
+			$include_country = '%';
+		}
 		$tpl->caching = true;
 		$tpl->cache_lifetime = 300;
 		$logcount = 250;
@@ -79,11 +92,13 @@
 			     INNER JOIN `cache_status` ON `caches`.`status`=`cache_status`.`id`
 			     INNER JOIN `user` ON `cache_logs`.`user_id`=`user`.`user_id`
 			          WHERE `cache_status`.`allow_user_view`=1
-			                AND `caches`.`country`<>'&1'
-			                AND `username`<>'&2'".
+			                AND `caches`.`country` LIKE '&1'
+			                AND `caches`.`country`<>'&2'
+			                AND `username`<>'&3'".
 			                $add_where."
 			       ORDER BY " . $orderByDate . "`cache_logs`.`date_created` DESC
-			          LIMIT &3, &4",
+			          LIMIT &4, &5",
+			                $include_country,
 			                $exclude_country,
 			                isset($_GET['showsyslogs']) ? '' : $opt['logic']['systemuser']['user'],
 			                $startat,
@@ -191,6 +206,19 @@
 		$tpl->assign('newLogs', $newLogs);
 		$tpl->assign('addpiclines', max($pics-1,0));
 		$tpl->assign('newLogsPerCountry', $newLogsPerCountry);
+
+		$tpl->assign('countryCode', $country);
+		$tpl->assign(
+			'countryName',
+			sql_value("SELECT IFNULL(`sys_trans_text`.`text`, `countries`.`name`) 
+	                FROM `countries`
+	           LEFT JOIN `sys_trans` ON `countries`.`trans_id`=`sys_trans`.`id`
+	           LEFT JOIN `sys_trans_text` ON `sys_trans`.`id`=`sys_trans_text`.`trans_id` AND `sys_trans_text`.`lang`='&2'
+	               WHERE `countries`.`short`='&1'",
+	              '',
+	              $country ? $country : $login->getUserCountry(),
+	              $opt['template']['locale'])
+			);
 
 		$tpl->assign('paging', $paging);
 		if ($paging)

--- a/htdocs/resource2/ocstyle/css/style_screen.css
+++ b/htdocs/resource2/ocstyle/css/style_screen.css
@@ -339,6 +339,7 @@ td.content-title-flag {
 .content-subtitle { color: #426d7e; } 
 .subtitle { font-weight:bold; }
 .subtitle-header { font-weight:bold; line-height: 1.6em }
+p.subtitle-select { line-height:2.5em; }
 
 /* Headings */
 h1 {margin: 1.0em 0px 0.5em 0px; font-weight: bold; font-size: 160%;}

--- a/htdocs/templates2/ocstyle/newcaches.tpl
+++ b/htdocs/templates2/ocstyle/newcaches.tpl
@@ -9,9 +9,19 @@
 	{if $events}{t}Planned events{/t}{elseif $countryCode == ''}{t}Latest caches{/t}{else}{t 1=$countryName|escape}Newest caches in %1{/t}{/if}
 </div>
 
+{if !$events}
+<p class="subtitle-select">
+	[{if $countryCode == ''}<b>{else}<a href="newcaches.php" class="systemlink">{/if}{t}All caches{/t}{if $countryCode == ''}</b>{else}</a>{/if}]
+	&nbsp;&ndash;&nbsp;
+	[{if $countryCode != ''}<b>{else}<a href="newcaches.php?country={$opt.template.country}" class="systemlink">{/if}{t 1=$countryName}Caches in %1{/t}{if $countryCode != ''}</b>{else}</a>{/if}]
+	&nbsp;&ndash;&nbsp;
+	[<a href="newcachesrest.php{if $countryCode != ''}?country={$countryCode}{/if}" class="systemlink">{t 1=$countryName}Caches without %1{/t}</a>]
+</p>
+{/if}
+
 <table width="100%" class="table">
 	<tr>
-		<td colspan="3" class="header-small">
+		<td colspan="3" class="header-small" >
 			{include file="res_pager.tpl"}
 		</td>
 	</tr>
@@ -20,7 +30,7 @@
 	{foreach name=newCaches from=$newCaches item=newCache}
 		<tr>
 			<td style="width:1%; vertical-align:center">{$newCache.date_created|date_format:$opt.format.date}</td>
-			<td class="listicon"><img src="resource2/{$opt.template.style}/images/cacheicon/16x16-{$newCache.type}.gif" width="16" height="16" border="0" /></td><td style="vertical-align:center"> <a href="viewcache.php?wp={$newCache.wpoc}">{$newCache.cachename|escape}</a> {include file="res_oconly.tpl" oconly=$newCache.oconly} {t}by{/t} <a href="viewprofile.php?userid={$newCache.userid}">{$newCache.username|escape}</a> {if $countryCode == '' && $newCache.country != $defaultcountry}&nbsp;&nbsp;<img src="images/flags/{$newCache.country|lower}.gif" alt="({$newCache.country_name})" title="{$newCache.country_name}" />{/if} </td>
+			<td class="listicon">{if $events}<img src="resource2/{$opt.template.style}/images/cacheicon/event-rand{rand min=1 max=4}.gif" alt="{t}Event Geocache{/t}" border="0" width="22" height="22" align="left" style="margin-right: 5px;" />{else}<img src="resource2/{$opt.template.style}/images/cacheicon/16x16-{$newCache.type}.gif" width="16" height="16" border="0" />{/if}</td><td style="vertical-align:center"> <a href="viewcache.php?wp={$newCache.wpoc}">{$newCache.cachename|escape}</a> {include file="res_oconly.tpl" oconly=$newCache.oconly} {t}by{/t} <a href="viewprofile.php?userid={$newCache.userid}">{$newCache.username|escape}</a> {if $countryCode == '' && $newCache.country != $defaultcountry}&nbsp;&nbsp;<img src="images/flags/{$newCache.country|lower}.gif" alt="({$newCache.country_name})" title="{$newCache.country_name}" />{/if} </td>
 		</tr>
 	{/foreach}
 

--- a/htdocs/templates2/ocstyle/newcachesrest.tpl
+++ b/htdocs/templates2/ocstyle/newcachesrest.tpl
@@ -5,9 +5,17 @@
  ***************************************************************************}
 {* OCSTYLE *}
 <div class="content2-pagetitle">
-	<img src="resource2/{$opt.template.style}/images/cacheicon/traditional.gif" style="margin-right: 10px;" width="32" height="32" alt="{t}Latest caches without germany{/t}" />
-	{t}Latest caches without germany{/t}
+	<img src="resource2/{$opt.template.style}/images/cacheicon/traditional.gif" style="margin-right: 10px;" width="32" height="32" alt="" />
+	{t}{t 1=$countryName}Latest caches without %1{/t}
 </div>
+
+<p class="subtitle-select">
+	[<a href="newcaches.php" class="systemlink">{t}All caches{/t}</a>]
+	&nbsp;&ndash;&nbsp;
+	[<a href="newcaches.php?country={$opt.template.country}" class="systemlink">{t 1=$countryName}Caches in %1{/t}</a>]
+	&nbsp;&ndash;&nbsp;
+	[<b>{t 1=$countryName}Caches without %1{/t}</b>]
+</p>
 
 <table width="100%" class="table">
 	{assign var='lastCountry' value=''}

--- a/htdocs/templates2/ocstyle/newlogs.tpl
+++ b/htdocs/templates2/ocstyle/newlogs.tpl
@@ -16,10 +16,31 @@
 	{elseif $ownlogs}
 		{t}Your log entries{/t}
 	{else}
-		{t}Latest logs entries{/t} {if $rest}{t}Without Germany{/t}{/if}
+		{if $rest}{t 1=$countryName}Latest log entries without %1{/t}{elseif $countryCode}{t 1=$countryName}Latest log entries in %1{/t}{else}{t}Latest logs entries{/t}{/if}
 	{/if}
 </div>
 
+{if $rest}
+	<p class="subtitle-select">
+		[<a href="newlogs.php" class="systemlink">{t}All logs{/t}</a>]
+		&nbsp;&ndash;&nbsp;
+		[<a href="newlogs.php?country={$opt.template.country}" class="systemlink">{t 1=$countryName}Logs in %1{/t}</a>]
+		&nbsp;&ndash;&nbsp;
+		[<b>{t 1=$countryName}Logs without %1{/t}</b>]
+	</p>
+{elseif $countryCode !== false}
+	<p class="subtitle-select">
+		[{if $countryCode == ''}<b>{else}<a href="newlogs.php" class="systemlink">{/if}{t}All logs{/t}{if $countryCode == ''}</b>{else}</a>{/if}]
+		&nbsp;&ndash;&nbsp;
+		[{if $countryCode != ''}<b>{else}<a href="newlogs.php?country={$opt.template.country}" class="systemlink">{/if}{t 1=$countryName}Logs in %1{/t}{if $countryCode != ''}</b>{else}</a>{/if}]
+		&nbsp;&ndash;&nbsp;
+		[<a href="newlogsrest.php" class="systemlink">{t 1=$countryName}Logs without %1{/t}</a>]
+	</p>
+{/if}
+
+{if !$rest && $countryCode}
+	<div style="height:4px"></div>
+{/if}
 <p style="line-height:2em">
 	{if $paging}
 		{include file="res_pager.tpl"}
@@ -38,7 +59,7 @@
 	{assign var='lastCountry' value=''}
 
 	{foreach name=newLogs from=$newLogs item=newLog}
-		{if $newLogsPerCountry}
+		{if $newLogsPerCountry && ($rest || !$countryCode)}
 			{if $newLog.country_name!=$lastCountry}
 				<tr><td class="spacer"></td></tr>
 				<tr><td colspan="3">

--- a/htdocs/templates2/ocstyle/ownerlogs.tpl
+++ b/htdocs/templates2/ocstyle/ownerlogs.tpl
@@ -5,4 +5,4 @@
 ***************************************************************************}
 {* OCSTYLE *}
 
-{include file="newlogs.tpl" ownerlogs=true}
+{include file="newlogs.tpl" ownerlogs=true countryCode=false}

--- a/htdocs/templates2/ocstyle/ownlogs.tpl
+++ b/htdocs/templates2/ocstyle/ownlogs.tpl
@@ -5,4 +5,4 @@
 ***************************************************************************}
 {* OCSTYLE *}
 
-{include file="newlogs.tpl" ownlogs=true}
+{include file="newlogs.tpl" ownlogs=true countryCode=false}

--- a/htdocs/templates2/ocstyle/start.tpl
+++ b/htdocs/templates2/ocstyle/start.tpl
@@ -146,8 +146,8 @@
 <div class="content2-container bg-blue02">
 	<p class="content-title-noshade-size3">
 		<img src="resource2/{$opt.template.style}/images/cacheicon/traditional.gif" style="margin-right: 10px;" width="24" height="24" alt="" />
-		<a href="newcaches.php" style="color:rgb(88,144,168); text-decoration: none;">{t 1=$usercountry|escape}Newest caches in %1{/t}</a>
-	&nbsp; <span class="content-title-link">[<a href="newcaches.php?country={$usercountryCode}">{t}more{/t}...</a>]</span>
+		<a href="newcaches.php?country={$usercountryCode}" style="color:rgb(88,144,168); text-decoration: none;">{t 1=$usercountry|escape}Newest caches in %1{/t}</a>
+	&nbsp; <span class="content-title-link">[<a href="newcaches.php">{t}more{/t}...</a>]</span>
 	</p>
 </div>
 <p style="line-height: 1.6em;">({t 1=$count_hiddens 2=$count_founds 3=$count_users}Total of %1 active Caches and %2 founds by %3 users{/t})</p>

--- a/htdocs/templates2/ocstyle/sys_main.tpl
+++ b/htdocs/templates2/ocstyle/sys_main.tpl
@@ -54,7 +54,7 @@
 
 					if (sCurrentOption!=oUserCountryCombo.value)
 					{
-						window.location = 'index.php?usercountry=' + oUserCountryCombo.value;
+						window.location = '{/literal}{$base_pageadr}{literal}usercountry=' + oUserCountryCombo.value;
 					}
 				}
 
@@ -146,7 +146,7 @@
 						<td>
 							{foreach from=$opt.template.locales key=localeKey item=localeItem}
 								{if $localeItem.show}
-								<a style="text-decoration: none;" href="{$locale_pageadr}locale={$localeKey}"><img src="{$localeItem.flag}" alt="{$localeItem.name|escape}" width="24px" height="18px" /></a>
+								<a style="text-decoration: none;" href="{$base_pageadr}locale={$localeKey}"><img src="{$localeItem.flag}" alt="{$localeItem.name|escape}" width="24px" height="18px" /></a>
 							{/if}
 							{/foreach}
 						</td>


### PR DESCRIPTION
- Menüpunkte "... ohne Deutschland" auf der Startseite entfallen
- auf de Seite "Neueste Caches" und "Neueste Logs" gibt es ein Untermenü, mit dem man zwischen allen Einträgen, den Einträgen im (oben rechts) gewählten Land und Einträgen in allen anderen Ländern wählen kann
- kleine kosmetische Verbesserung in der "mehr...-Liste" für Events
