### PR TITLE
0815 correct sort of recommendations in search results; updates #815

### DIFF
--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -1291,7 +1291,8 @@
 							 `caches`.`size`,
 							 `caches`.`longitude`, `caches`.`latitude`,
 							 `caches`.`user_id`,
-							 IF(IFNULL(`stat_caches`.`toprating`,0)>3, 4, IFNULL(`stat_caches`.`toprating`, 0)) `ratingvalue`' .
+							 IFNULL(`stat_caches`.`toprating`, 0) `ratingvalue`'.
+
 							 $sAddFields
 			 . ' FROM `caches`
 		  LEFT JOIN `stat_caches` ON `caches`.`cache_id`=`stat_caches`.`cache_id`' .

--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -1292,8 +1292,7 @@
 							 `caches`.`longitude`, `caches`.`latitude`,
 							 `caches`.`user_id`,
 							 IFNULL(`stat_caches`.`toprating`, 0) `ratingvalue`'.
-
-							 $sAddFields
+			  				 $sAddFields
 			 . ' FROM `caches`
 		  LEFT JOIN `stat_caches` ON `caches`.`cache_id`=`stat_caches`.`cache_id`' .
 			          $sAddJoin


### PR DESCRIPTION
update #796 shows: if "Show caches recommended by other users first" is aktiv, caches with more than 3 recommendation aren't sorted in any obvious way