### PR TITLE
transklation and KML improvements; updates #817, updates #32

### DIFF
--- a/htdocs/doc/sql/static-data/data.sql
+++ b/htdocs/doc/sql/static-data/data.sql
@@ -189,7 +189,7 @@ INSERT INTO `cache_status` (`id`, `name`, `trans_id`, `de`, `en`, `allow_user_vi
 -- Table cache_type
 SET NAMES 'utf8';
 TRUNCATE TABLE `cache_type`;
-INSERT INTO `cache_type` (`id`, `name`, `trans_id`, `ordinal`, `short`, `de`, `en`, `icon_large`, `short2`, `short2_trans_id`, `kml_name`) VALUES ('1', 'unknown cachetyp', '535', '10', 'Other', 'unbekannter Cachetyp', 'Unknown cache type', 'unknown.gif', 'Unknown', '862', 'other');
+INSERT INTO `cache_type` (`id`, `name`, `trans_id`, `ordinal`, `short`, `de`, `en`, `icon_large`, `short2`, `short2_trans_id`, `kml_name`) VALUES ('1', 'unknown cachetyp', '535', '10', 'Other', 'unbekannter Cachetyp', 'Unknown cache type', 'unknown.gif', 'Unknown', '862', 'unknown');
 INSERT INTO `cache_type` (`id`, `name`, `trans_id`, `ordinal`, `short`, `de`, `en`, `icon_large`, `short2`, `short2_trans_id`, `kml_name`) VALUES ('2', 'Traditional Cache', '536', '1', 'Trad.', 'normaler Cache', 'Traditional Cache', 'traditional.gif', 'Traditional', '1855', 'tradi');
 INSERT INTO `cache_type` (`id`, `name`, `trans_id`, `ordinal`, `short`, `de`, `en`, `icon_large`, `short2`, `short2_trans_id`, `kml_name`) VALUES ('3', 'Multicache', '514', '3', 'Multi', 'Multicache', 'Multicache', 'multi.gif', 'Multicache', '514', 'multi');
 INSERT INTO `cache_type` (`id`, `name`, `trans_id`, `ordinal`, `short`, `de`, `en`, `icon_large`, `short2`, `short2_trans_id`, `kml_name`) VALUES ('4', 'virtual Cache', '537', '7', 'Virt.', 'virtueller Cache', 'Virtual Cache', 'virtual.gif', 'Virtual', '1857', 'virtual');

--- a/htdocs/lib2/search/search.kml.inc.php
+++ b/htdocs/lib2/search/search.kml.inc.php
@@ -17,6 +17,7 @@ function search_output()
 	global $state_temporarily_na, $state_archived, $state_locked;
 	global $t_showdesc, $t_by, $t_type, $t_size, $t_difficulty, $t_terrain;
 
+	// see also util2/google-earth/caches.php
 	$kmlLine =
 '
 <Placemark>
@@ -91,7 +92,7 @@ function search_output()
 	while ($r = sql_fetch_array($rs))
 	{
 		$thisline = $kmlLine;
-		$typeimgurl = '<img src="http://www.opencaching.de/resource2/'.$style.'/images/cacheicon/'.$r['icon_large'].'" alt="'.$r['typedesc'].'" title="'.$r['typedesc'].'" />';
+		$typeimgurl = '<img src="{urlbase}resource2/'.$style.'/images/cacheicon/'.$r['icon_large'].'" alt="'.$r['typedesc'].'" title="'.$r['typedesc'].'" />';
 
 		$thisline = mb_ereg_replace('{icon}', $r['kml_name'], $thisline);
 		$thisline = mb_ereg_replace('{typeimgurl}', $typeimgurl, $thisline);
@@ -133,6 +134,8 @@ function search_output()
 
 		$thisline = mb_ereg_replace('{username}', xmlentities($r['username']), $thisline);
 		$thisline = mb_ereg_replace('{cacheid}', xmlentities($r['cacheid']), $thisline);
+
+		$thisline = mb_ereg_replace('{urlbase}', xmlentities($opt['page']['absolute_url']), $thisline);
 
 		append_output($thisline);
 	}

--- a/htdocs/lib2/search/search.ov2.inc.php
+++ b/htdocs/lib2/search/search.ov2.inc.php
@@ -40,7 +40,7 @@ function search_output()
 			`caches`.`terrain`,
 			`caches`.`difficulty`,
 			`cache_type`.`short` `typedesc`,
-			`cache_size`.`de` `sizedesc`,
+			`cache_size`.`name` `sizedesc`,
 			`user`.`username`
 		FROM
 			&searchtmp,

--- a/htdocs/newlogs.php
+++ b/htdocs/newlogs.php
@@ -113,7 +113,7 @@
 		}
 
 		if ($newLogsPerCountry)
-			$orderByCountry = '`countries`.`de` ASC, ';
+			$orderByCountry = '`country_name` ASC, ';
 		else
 			$orderByCountry = '';
 		

--- a/htdocs/resource2/misc/google-earth/search.result.caches.kml.head.xml
+++ b/htdocs/resource2/misc/google-earth/search.result.caches.kml.head.xml
@@ -100,7 +100,7 @@
 			<scale>0.6</scale>
 		</LabelStyle>
 	</Style>
-	<Style id="other">
+	<Style id="unknown">
 		<IconStyle>
 			<scale>1</scale>
 			<Icon>

--- a/htdocs/util2/google-earth/caches-en.php
+++ b/htdocs/util2/google-earth/caches-en.php
@@ -1,0 +1,4 @@
+<?
+	$_REQUEST['locale'] = 'EN';
+	include "caches.php";
+?>

--- a/htdocs/util2/google-earth/caches.php
+++ b/htdocs/util2/google-earth/caches.php
@@ -10,6 +10,7 @@
   $opt['rootpath'] = '../../';
   header('Content-type: text/html; charset=utf-8');
   require($opt['rootpath'] . 'lib2/web.inc.php');
+  require($opt['rootpath'] . 'templates2/ocstyle/search.tpl.inc.php');
 
   $bbox = isset($_REQUEST['BBOX']) ? $_REQUEST['BBOX'] : '0,0,0,0';
   $abox = mb_split(',', $bbox);
@@ -30,10 +31,11 @@
    kml processing
   */
 
+  // see also lib2/search/search.kml.inc.php
   $kmlLine = 
 '
 <Placemark>
-  <description><![CDATA[<a href="{urlbase}viewcache.php?cacheid={cacheid}">Beschreibung ansehen</a><br>Von {username}<br>&nbsp;<br><table cellspacing="0" cellpadding="0" border="0"><tr><td>{typeimgurl} </td><td>Art: {type}<br>Gr&ouml;&szlig;e: {size}</td></tr><tr><td colspan="2">Schwierigkeit: {difficulty} von 5.0<br>Gel&auml;nde: {terrain} von 5.0</td></tr></table>]]></description>
+  <description><![CDATA['.$t_by.' {username}<br><br><a href="{urlbase}viewcache.php?cacheid={cacheid}">'.$t_showdesc.'</a><br>&nbsp;<br><table cellspacing="0" cellpadding="0" border="0"><tr><td>{typeimgurl} </td><td>'.$t_type.' {type}<br>'.$t_size.' {size}</td></tr><tr><td colspan="2">'.$t_difficulty.'<br>'.$t_terrain.'</td></tr></table>]]></description>
   <name>{name}</name>
   <LookAt>
     <longitude>{lon}</longitude>
@@ -49,79 +51,120 @@
 </Placemark>
 ';
 
+	// see also resource2/misc/google-earth/search.result.caches.kml.head.xml
   $kmlHead =
 '<?xml version="1.0" encoding="UTF-8"?>
 <kml xmlns="http://earth.google.com/kml/2.0">
 	<Document>
 		<Style id="tradi">
 			<IconStyle>
+				<scale>1</scale>
 				<Icon>
-					<href>{urlbase}resource2/misc/google-earth/tradi.png</href>
+					<href>http://www.opencaching.de/resource2/ocstyle/images/map/caches2/cachetype-2.png</href>
 				</Icon>
 			</IconStyle>
+			<LabelStyle>
+				<scale>0.6</scale>
+			</LabelStyle>
 		</Style>
 		<Style id="multi">
 			<IconStyle>
+				<scale>1</scale>
 				<Icon>
-					<href>{urlbase}resource2/misc/google-earth/multi.png</href>
+					<href>http://www.opencaching.de/resource2/ocstyle/images/map/caches2/cachetype-3.png</href>
 				</Icon>
 			</IconStyle>
-		</Style>
-		<Style id="myst">
-			<IconStyle>
-				<Icon>
-					<href>{urlbase}resource2/misc/google-earth/myst.png</href>
-				</Icon>
-			</IconStyle>
-		</Style>
-		<Style id="math">
-			<IconStyle>
-				<Icon>
-					<href>{urlbase}resource2/misc/google-earth/math.png</href>
-				</Icon>
-			</IconStyle>
-		</Style>
-		<Style id="drivein">
-			<IconStyle>
-				<Icon>
-					<href>{urlbase}resource2/misc/google-earth/drivein.png</href>
-				</Icon>
-			</IconStyle>
+			<LabelStyle>
+				<scale>0.6</scale>
+			</LabelStyle>
 		</Style>
 		<Style id="virtual">
 			<IconStyle>
+				<scale>1</scale>
 				<Icon>
-					<href>{urlbase}resource2/misc/google-earth/virtual.png</href>
+					<href>http://www.opencaching.de/resource2/ocstyle/images/map/caches2/cachetype-4.png</href>
 				</Icon>
 			</IconStyle>
+			<LabelStyle>
+				<scale>0.6</scale>
+			</LabelStyle>
 		</Style>
 		<Style id="webcam">
 			<IconStyle>
+				<scale>1</scale>
 				<Icon>
-					<href>{urlbase}resource2/misc/google-earth/webcam.png</href>
+					<href>http://www.opencaching.de/resource2/ocstyle/images/map/caches2/cachetype-5.png</href>
 				</Icon>
 			</IconStyle>
+			<LabelStyle>
+				<scale>0.6</scale>
+			</LabelStyle>
 		</Style>
 		<Style id="event">
 			<IconStyle>
+				<scale>1</scale>
 				<Icon>
-					<href>{urlbase}resource2/misc/google-earth/event.png</href>
+					<href>http://www.opencaching.de/resource2/ocstyle/images/map/caches2/cachetype-6.png</href>
 				</Icon>
 			</IconStyle>
+			<LabelStyle>
+				<scale>0.6</scale>
+			</LabelStyle>
+		</Style>
+		<Style id="mystery">
+			<IconStyle>
+				<scale>1</scale>
+				<Icon>
+					<href>http://www.opencaching.de/resource2/ocstyle/images/map/caches2/cachetype-7.png</href>
+				</Icon>
+			</IconStyle>
+			<LabelStyle>
+				<scale>0.6</scale>
+			</LabelStyle>
+		</Style>
+		<Style id="mathe">
+			<IconStyle>
+				<scale>1</scale>
+				<Icon>
+					<href>http://www.opencaching.de/resource2/ocstyle/images/map/caches2/cachetype-8.png</href>
+				</Icon>
+			</IconStyle>
+			<LabelStyle>
+				<scale>0.6</scale>
+			</LabelStyle>
+		</Style>
+		<Style id="drivein">
+			<IconStyle>
+				<scale>1</scale>
+				<Icon>
+					<href>http://www.opencaching.de/resource2/ocstyle/images/map/caches2/cachetype-10.png</href>
+				</Icon>
+			</IconStyle>
+			<LabelStyle>
+				<scale>0.6</scale>
+			</LabelStyle>
 		</Style>
 		<Style id="moving">
 			<IconStyle>
-				<Icon>
-					<href>{urlbase}resource2/misc/google-earth/moving.png</href>
+				<scale>1</scale>
+				q<Icon>
+					<href>http://www.opencaching.de/resource2/ocstyle/images/map/caches2/cachetype-9.png</href>
 				</Icon>
 			</IconStyle>
+			<LabelStyle>
+				<scale>0.6</scale>
+			</LabelStyle>
 		</Style>
 		<Style id="unknown">
 			<IconStyle>
+				<scale>1</scale>
 				<Icon>
-					<href>{urlbase}resource2/misc/google-earth/unknown.png</href>
+					<href>http://www.opencaching.de/resource2/ocstyle/images/map/caches2/cachetype-1.png</href>
 				</Icon>
 			</IconStyle>
+			<LabelStyle>
+				<scale>0.6</scale>
+			</LabelStyle>
 		</Style>
 		<Folder>
 			<name>Geocaches (Opencaching)</name>
@@ -146,17 +189,34 @@
 	}
 	else
 	{
-		$rs = sql("SELECT `caches`.`cache_id` AS `cacheid`, `caches`.`longitude` AS `longitude`, `caches`.`latitude` AS `latitude`, `caches`.`type` AS `type`, `caches`.`date_hidden` AS `date_hidden`, `caches`.`name` AS `name`, `cache_type`.`de` AS `typedesc`, `cache_size`.`de` AS `sizedesc`, `caches`.`terrain` AS `terrain`, `caches`.`difficulty` AS `difficulty`, `user`.`username` AS `username`
+		$rs = sql("SELECT `caches`.`cache_id` AS `cacheid`,
+		                  `caches`.`longitude` AS `longitude`,
+		                  `caches`.`latitude` AS `latitude`,
+		                  `caches`.`type` AS `type`,
+		                  `caches`.`status`,
+		                  `caches`.`date_hidden` AS `date_hidden`,
+		                  `caches`.`name` AS `name`,
+		                  IFNULL(`stt_type`.`text`, `cache_type`.`en`) `typedesc`,
+		                  `cache_type`.`kml_name`,
+		                  `cache_type`.`icon_large`,
+		                  IFNULL(`stt_size`.`text`, `cache_size`.`en`) `sizedesc`,
+		                  `caches`.`terrain` AS `terrain`,
+		                  `caches`.`difficulty` AS `difficulty`,
+		                  `user`.`username` AS `username`
 		             FROM `caches`
 		       INNER JOIN `cache_type` ON `caches`.`type`=`cache_type`.`id`
 		       INNER JOIN `cache_size` ON `caches`.`size`=`cache_size`.`id`
 		       INNER JOIN `user` ON `caches`.`user_id`=`user`.`user_id`
+		        LEFT JOIN `sys_trans_text` `stt_type` ON `stt_type`.`trans_id`=`cache_type`.`trans_id`
+		        LEFT JOIN `sys_trans_text` `stt_size` ON `stt_size`.`trans_id`=`cache_size`.`trans_id`
 		            WHERE `caches`.`status`=1 AND
 		                  `caches`.`longitude`>='&1' AND 
 											`caches`.`longitude`<='&2' AND 
 											`caches`.`latitude`>='&3' AND 
-											`caches`.`latitude`<='&4'",
-											$lon_from, $lon_to, $lat_from, $lat_to);
+											`caches`.`latitude`<='&4' AND
+											`stt_type`.`lang`='&5' and `stt_size`.`lang`='&5'",
+											$lon_from, $lon_to, $lat_from, $lat_to,
+											$opt['template']['locale']);
 
 		$nCount = 0;
 		while ($r = sql_fetch_array($rs))
@@ -164,51 +224,9 @@
 			$nCount = $nCount + 1;
 			$thisline = $kmlLine;
 			
-			// icon suchen
-			switch ($r['type'])
-			{
-				case 2:
-					$icon = 'tradi';
-					$typeimgurl = '<img src="{urlbase}lang/de/ocstyle/images/cache/traditional.gif" alt="Normaler Cache" title="Normaler Cache" />';
-					break;
-				case 3:
-					$icon = 'multi';
-					$typeimgurl = '<img src="{urlbase}lang/de/ocstyle/images/cache/multi.gif" alt="Multicache" title="Multicache" />';
-					break;
-				case 4:
-					$icon = 'virtual';
-					$typeimgurl = '<img src="{urlbase}lang/de/ocstyle/images/cache/virtual.gif" alt="virtueller Cache" title="virtueller Cache" />';
-					break;
-				case 5:
-					$icon = 'webcam';
-					$typeimgurl = '<img src="{urlbase}lang/de/ocstyle/images/cache/webcam.gif" alt="Webcam Cache" title="Webcam Cache" />';
-					break;
-				case 6:
-					$icon = 'event';
-					$typeimgurl = '<img src="{urlbase}lang/de/ocstyle/images/cache/event.gif" alt="Event Cache" title="Event Cache" />';
-					break;
-				case 7:
-					$icon = 'myst';
-					$typeimgurl = '<img src="{urlbase}lang/de/ocstyle/images/cache/mystery.gif" alt="Event Cache" title="Event Cache" />';
-					break;
-				case 8:
-					$icon = 'math';
-					$typeimgurl = '<img src="{urlbase}lang/de/ocstyle/images/cache/mathe.gif" alt="Event Cache" title="Event Cache" />';
-					break;
-				case 9:
-					$icon = 'moving';
-					$typeimgurl = '<img src="{urlbase}lang/de/ocstyle/images/cache/moving.gif" alt="Event Cache" title="Event Cache" />';
-					break;
-				case 10:
-					$icon = 'drivein';
-					$typeimgurl = '<img src="{urlbase}lang/de/ocstyle/images/cache/drivein.gif" alt="Event Cache" title="Event Cache" />';
-					break;
-				default:
-					$icon = 'unknown';
-					$typeimgurl = '<img src="{urlbase}lang/de/ocstyle/images/cache/unknown.gif" alt="unbekannter Cachetyp" title="unbekannter Cachetyp" />';
-					break;
-			}
-			$thisline = mb_ereg_replace('{icon}', $icon, $thisline);
+			$typeimgurl = '<img src="http://www.opencaching.de/resource2/'.$opt['template']['style'].'/images/cacheicon/'.$r['icon_large'].'" alt="'.$r['typedesc'].'" title="'.$r['typedesc'].'" />';
+
+			$thisline = mb_ereg_replace('{icon}', $r['kml_name'], $thisline);
 			$thisline = mb_ereg_replace('{typeimgurl}', $typeimgurl, $thisline);
 			
 			$lat = sprintf('%01.5f', $r['latitude']);
@@ -221,16 +239,6 @@
 			$thisline = mb_ereg_replace('{time}', $time, $thisline);
 
 			$thisline = mb_ereg_replace('{name}', xmlentities($r['name']), $thisline);
-			
-			if (($r['status'] == 2) || ($r['status'] == 3))
-			{
-				if ($r['status'] == 2)
-					$thisline = mb_ereg_replace('{archivedflag}', 'Momentan nicht verf&uuml;gbar', $thisline);
-				else
-					$thisline = mb_ereg_replace('{archivedflag}', 'Archiviert!, ', $thisline);
-			}
-			else
-				$thisline = mb_ereg_replace('{archivedflag}', '', $thisline);
 			
 			$thisline = mb_ereg_replace('{type}', xmlentities($r['typedesc']), $thisline);
 			$thisline = mb_ereg_replace('{size}', xmlentities($r['sizedesc']), $thisline);

--- a/htdocs/util2/google-earth/opencaching-en.kml
+++ b/htdocs/util2/google-earth/opencaching-en.kml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://earth.google.com/kml/2.0">
+<Document>
+  <LookAt>
+    <longitude>10.8</longitude>
+    <latitude>50.8</latitude>
+    <range>909966</range>
+    <tilt>0</tilt>
+    <heading>-2</heading>
+  </LookAt>
+  <NetworkLink>
+    <name>Opencaching</name>
+    <Url>
+      <href>http://www.opencaching.de/util2/google-earth/caches-en.php</href>
+      <viewRefreshTime>1</viewRefreshTime>
+      <viewRefreshMode>onStop</viewRefreshMode>
+    </Url>
+  </NetworkLink>
+</Document>
+</kml>

--- a/htdocs/viewprofile.php
+++ b/htdocs/viewprofile.php
@@ -40,7 +40,7 @@
 										`user`.`latitude`, 
 										`user`.`longitude`,
 										`user`.`data_license`, 
-										IFNULL(`sys_trans_text`.`text`,`countries`.`de`) AS `country`,
+										IFNULL(`sys_trans_text`.`text`,`countries`.`name`) AS `country`,
 										`stat_user`.`hidden`, 
 										`stat_user`.`found`, 
 										`stat_user`.`notfound`, 


### PR DESCRIPTION
* OV2-Datenexport einheitlich in Englisch, bislang war (nur) die Cachegröße in Deutsch
* Ländersortierung der Liste neuer Logs entsprechend den Ländernamen in der gewählten Sprache
* neue Kartenicons und Mehrsprachigkeit auch für util2/google-earth/opencaching.kml

Letzteres hab ich getestet per 
  http://local.opencaching.de/oc-server/server-3.0/htdocs/util2/google-earth/caches.php?BBOX=8,49,9,50
(Download als .kml-Datei mit `wget` und dann in Google Earth geöffnet). Für die verschiedenen Sprachen hab ich "&locale=EN" etc. angehängt, und auch mal ein caches-en.php bereitgestellt. Wird aber wohl kaum noch jemand nutzen.