### PR TITLE
localized 'other coordinate systems' popup; updates #842

### DIFF
--- a/htdocs/config2/locale.inc.php
+++ b/htdocs/config2/locale.inc.php
@@ -120,6 +120,7 @@
 	$opt['locale']['EN']['page']['license'] = '<a rel="license" href="%1"><img alt="Creative Commons License Terms" style="border-width:0" src="http://i.creativecommons.org/l/by-nc-nd/3.0/de/88x31.png" /></a><div style="text-align:center; margin:8px 0 0 6px;">The Opencaching.de <a href="articles.php?page=impressum#datalicense">content</a> is licensed under Creative Commons <a rel="license" href="%1" target="_blank">BY-BC-ND 3.0 DE</a>.</div>';
 	$opt['locale']['EN']['helpwiki'] = "http://wiki.opencaching.de/index.php/";
 	$opt['locale']['EN']['mostly_translated'] = true;
+	$opt['locale']['EN']['what3words'] = true;
 
 	$opt['locale']['DE']['format']['dm'] = '%d.%m.';
 	$opt['locale']['DE']['format']['dateshort'] = '%d.%m.%y';
@@ -140,6 +141,7 @@
 	$opt['locale']['DE']['page']['license'] = '<a rel="license" href="%1"><img alt="Creative Commons Lizenzvertrag" style="border-width:0" src="http://i.creativecommons.org/l/by-nc-nd/3.0/de/88x31.png" /></a><div style="text-align:center; margin:8px 0 0 6px;">Die <a href="articles.php?page=impressum#datalicense">Inhalte</a> von Opencaching.de stehen unter der Creative-Commons-Lizenz <a rel="license" href="%1">BY-NC-ND 3.0 DE</a>.</div>';
 	$opt['locale']['DE']['helpwiki'] = "http://wiki.opencaching.de/index.php/";
 	$opt['locale']['DE']['mostly_translated'] = true;
+	$opt['locale']['DE']['what3words'] = true;  // "beta"
 
 	$opt['locale']['IT']['format']['dateshort'] = '%d/%m/%y';
 	$opt['locale']['IT']['format']['dm'] = '%d/%m';
@@ -159,6 +161,7 @@
 	$opt['locale']['IT']['page']['license_url'] = 'http://creativecommons.org/licenses/by-nc-nd/3.0/de/deed.it';
 	$opt['locale']['IT']['page']['license'] = '<a rel="license" href="%1" target="_blank"><img alt="Creative Commons License Terms" style="border-width:0" src="http://i.creativecommons.org/l/by-nc-nd/3.0/de/88x31.png" /></a><div style="text-align:center; margin:8px 0 0 6px;">Il <a href="articles.php?page=impressum#datalicense">contenuto</a> di Opencaching.de è rilasciato sotto licenza Creative Commons <a rel="license" href="%1" target="_blank">BY-NC-ND 3.0 DE</a>.</div>';
 	$opt['locale']['IT']['mostly_translated'] = true;
+	$opt['locale']['IT']['what3words'] = false;
 
 	$opt['locale']['ES']['format']['dateshort'] = '%d/%m/%y';
 	$opt['locale']['ES']['format']['dm'] = '%d/%m';
@@ -178,6 +181,7 @@
 	$opt['locale']['ES']['page']['license_url'] = 'http://creativecommons.org/licenses/by-nc-nd/3.0/de/deed.es_ES';
 	$opt['locale']['ES']['page']['license'] = '<a rel="license" href="%1" target="_blank"><img alt="Creative Commons License Terms" style="border-width:0" src="http://i.creativecommons.org/l/by-nc-nd/3.0/de/88x31.png" /></a><div style="text-align:center; margin:8px 0 0 6px;">El <a href="articles.php?page=impressum#datalicense">contenido</a> está disponible bajo Creative Commons <a rel="license" href="%1" target="_blank">BY-NC-ND 3.0 DE</a> licencia.</div>';
 	$opt['locale']['ES']['mostly_translated'] = true;
+	$opt['locale']['ES']['what3words'] = true;
 
 	$opt['locale']['FR']['format']['dm'] = '%d.%m.';
 	$opt['locale']['FR']['format']['dateshort'] = '%d.%m.%y';
@@ -198,6 +202,7 @@
 	$opt['locale']['FR']['page']['license'] = '<a rel="license" href="%1"><img alt="Creative Commons License Terms" style="border-width:0" src="http://i.creativecommons.org/l/by-nc-nd/3.0/de/88x31.png" /></a><div style="text-align:center; margin:8px 0 0 6px;">Le<a  href="articles.php?page=impressum#datalicense">contenu</a> de Opencaching.de sont sous licence Creative Commons <a rel="license" href="%1" target="_blank">BY-BC-ND 3.0 DE</a>.</div>';
 	$opt['locale']['FR']['helpwiki'] = "http://wiki.opencaching.de/index.php/";
 	$opt['locale']['FR']['mostly_translated'] = true;
+	$opt['locale']['FR']['what3words'] = true;
 
 /*
 	$opt['locale']['SV']['format']['dateshort'] = '%y-%m-%d';
@@ -214,6 +219,8 @@
 	$opt['locale']['SV']['country'] = 'SE';
 	$opt['locale']['SV']['page']['subtitle1'] = 'Geocaching med Opencaching';
 	$opt['locale']['SV']['page']['subtitle2'] = '';
+	$opt['locale']['SV']['mostly_translated'] = false;
+	$opt['locale']['SV']['what3words'] = true;  // "beta"
 
 	$opt['locale']['NO']['format']['dateshort'] = '%d.%m.%y';
 	$opt['locale']['NO']['format']['dm'] = '%d.%m.';
@@ -229,6 +236,8 @@
 	$opt['locale']['NO']['country'] = 'NO';
 	$opt['locale']['NO']['page']['subtitle1'] = 'Geocaching med Opencaching';
 	$opt['locale']['NO']['page']['subtitle2'] = '';
+	$opt['locale']['NO']['mostly_translated'] = false;
+	$opt['locale']['NO']['what3words'] = false;
 
 	$opt['locale']['PL']['format']['dm'] = '%d.%m.';
 	$opt['locale']['PL']['format']['dateshort'] = '%d.%m.%y';
@@ -242,6 +251,8 @@
 	$opt['locale']['PL']['format']['phpdatetime'] = 'd-m-Y H:i';
 	$opt['locale']['PL']['format']['colonspace'] = '';
 	$opt['locale']['PL']['country'] = 'PL';
+	$opt['locale']['PL']['mostly_translated'] = false;
+	$opt['locale']['PL']['what3words'] = false;
 
 	$opt['locale']['NL']['format']['dm'] = '%d.%m.';
 	$opt['locale']['NL']['format']['dateshort'] = '%d.%m.%y';
@@ -257,6 +268,8 @@
 	$opt['locale']['NL']['page']['subtitle1'] = 'Geocaching met Opencaching';
 	$opt['locale']['NL']['page']['subtitle2'] = '';
 	$opt['locale']['NL']['country'] = 'NL';
+	$opt['locale']['NL']['mostly_translated'] = false;
+	$opt['locale']['NL']['what3words'] = false;
 
 	$opt['locale']['RU']['format']['dateshort'] = '%d.%m.%y';
 	$opt['locale']['RU']['format']['dm'] = '%d.%m.';
@@ -270,6 +283,8 @@
 	$opt['locale']['RU']['format']['phpdatetime'] = 'd-m-Y H:i';
 	$opt['locale']['RU']['format']['colonspace'] = '';
 	$opt['locale']['RU']['country'] = 'RU';
+	$opt['locale']['RU']['mostly_translated'] = false;
+	$opt['locale']['RU']['what3words'] = true;   // "beta"
 
 	$opt['locale']['DA']['format']['dateshort'] = '%d.%m.%y';
 	$opt['locale']['DA']['format']['dm'] = '%d.%m.';
@@ -285,6 +300,8 @@
 	$opt['locale']['DA']['country'] = 'DK';
 	$opt['locale']['DA']['page']['subtitle1'] = 'Geocaching med Opencaching';
 	$opt['locale']['DA']['page']['subtitle2'] = '';
+	$opt['locale']['DA']['mostly_translated'] = false;
+	$opt['locale']['DA']['what3words'] = false;
 
 	$opt['locale']['PT']['format']['dateshort'] = '%d.%m.%y';
 	$opt['locale']['PT']['format']['dm'] = '%d.%m.';
@@ -300,6 +317,8 @@
 	$opt['locale']['PT']['country'] = 'PT';
 	$opt['locale']['PT']['page']['subtitle1'] = 'Geocaching com Opencaching';
 	$opt['locale']['PT']['page']['subtitle2'] = '';
+	$opt['locale']['PT']['mostly_translated'] = false;
+	$opt['locale']['PT']['what3words'] = true;
 
 	$opt['locale']['JA']['format']['dateshort'] = '%d.%m.%y';
 	$opt['locale']['JA']['format']['dm'] = '%d.%m.';
@@ -315,6 +334,8 @@
 	$opt['locale']['JA']['country'] = 'JP';
 	$opt['locale']['JA']['page']['subtitle1'] = 'Opencachingとジオキャッシング';
 	$opt['locale']['JA']['page']['subtitle2'] = '';
+	$opt['locale']['JA']['mostly_translated'] = false;
+	$opt['locale']['JA']['what3words'] = false;
 */
 
 function set_php_locale()

--- a/htdocs/doc/sql/static-data/data.sql
+++ b/htdocs/doc/sql/static-data/data.sql
@@ -2870,6 +2870,7 @@ INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2515', 'north-n
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2516', 'unbookmark', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2517', 'share public list', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2518', 'total recommendations', '2013-11-03 10:09:14');
+INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2519', 'Gauss-Krüger', '2013-11-03 10:09:14');
 
 -- Table sys_trans_ref
 SET NAMES 'utf8';
@@ -7290,6 +7291,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2516', 'DE', 'entmerken', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2517', 'DE', 'öffentliche Liste teilen', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2518', 'DE', 'Empfehlungen gesamt', '2013-11-03 10:09:14');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2519', 'DE', 'Gauß-Krüger', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1', 'EN', 'Reorder IDs', '2010-09-02 00:15:30');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'EN', 'The database could not be reconnected.', '2010-08-28 11:48:07');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('3', 'EN', 'Testing – please do not login', '2010-08-28 11:48:07');
@@ -10791,6 +10793,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2390', 'ES', 'Neuchâtel', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2391', 'ES', 'Lausana', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2392', 'ES', 'Zúrich', '2013-11-03 10:09:14');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2519', 'ES', 'Gauß-Krüger', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1', 'FR', 'Réorganiser des IDs', '2015-08-25 01:28:59');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'FR', 'La base de données n\'a pas pu être connecté.', '2015-08-25 01:28:59');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('3', 'FR', 'Test - Ne vous connectez pas, s\'il vous plaît', '2015-08-25 01:28:59');
@@ -12705,6 +12708,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2516', 'FR', 'ne pas signet', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2517', 'FR', 'partager liste publique', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2518', 'FR', 'recommandations total', '2013-11-03 10:09:14');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2519', 'FR', 'Gauß-Krüger', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1', 'IT', 'Riordina gli ID', '2010-10-27 18:49:18');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'IT', 'Impossibile riconnettersi al database', '2010-08-28 20:28:01');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('3', 'IT', 'Test - per favore non connettersi', '2010-08-28 20:36:53');
@@ -14538,6 +14542,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2513', 'IT', 'ovest-nord-ovest', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2514', 'IT', 'nord-ovest', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2515', 'IT', 'nord-nord-ovest', '2013-11-03 10:09:14');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2519', 'IT', 'Gauß-Krüger', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('922', 'JA', 'JA', '2011-05-15 16:04:51');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1', 'NL', 'ID\'s opnieuw sorteren', '2011-02-04 19:49:56');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'NL', 'De verbinding met de database kon niet hersteld worden.', '2011-02-04 19:49:56');

--- a/htdocs/lib2/logic/coordinate.class.php
+++ b/htdocs/lib2/logic/coordinate.class.php
@@ -554,9 +554,9 @@ class coordinate
 		return $lon;
 	}
 
-	function getW3W($language = "de")
+	function getW3W($language)
 	{
-        global $opt;
+		global $opt;
 
 		if (!$opt['lib']['w3w']['apikey'])
 			return false;
@@ -564,7 +564,7 @@ class coordinate
 		$params = array(
 			'key' => $opt['lib']['w3w']['apikey'],
 			'position' => sprintf('%f,%f', $this->nLat, $this->nLon),
-			'lang' => $language,
+			'lang' => strtolower($language),
 		);
 		$params_str = http_build_query($params);
 		$context = stream_context_create( array(

--- a/htdocs/templates2/ocstyle/coordinates.tpl
+++ b/htdocs/templates2/ocstyle/coordinates.tpl
@@ -28,7 +28,7 @@
 		{$coordUTM.zone|escape}{$coordUTM.letter|escape} {$coordUTM.north|escape} {$coordUTM.east|escape} </p>
 	</div>
 	<div style="margin-top:4px;">
-		<p style="color: 5890a8"><b>Gau&szlig;-Kr&uuml;ger</b> <small>(Potsdam-Datum)</small><br />
+		<p style="color: 5890a8"><b>{t}Gauss-Krüger{/t}</b>{if $opt.template.locale=='DE'} <small>(Potsdam-Datum)</small>{/if}<br />
 		{$coordGK|escape}</p>
 	</div>
 	<div style="margin-top:4px;">
@@ -45,15 +45,15 @@
 		{$coordRD|escape}</p>
 	</div>
     {/if}
-	{if $coordW3Wde}
+	{if $coordW3W1}
 	<div style="margin-top:4px;">
-		<p style="color: 5890a8"><b>what3words</b> <small>(deutsch)</small><br />
-		<a href="http://what3words.com/{$coordW3Wde|escape}" target="w3w">{$coordW3Wde|escape}</a></p>
+		<p style="color: 5890a8"><b>what3words</b> <small>({$W3Wlang1})</small><br />
+		<a href="http://what3words.com/{$coordW3W1|escape}" target="w3w">{$coordW3W1|escape}</a></p>
 	</div>
 	{/if}
-	{if $coordW3Wen}
+	{if $coordW3W2}
 	<div style="margin-top:4px;">
-		<p style="color: 5890a8"><b>what3words</b> <small>(english)</small><br />
-		<a href="http://what3words.com/{$coordW3Wen|escape}" target="w3w">{$coordW3Wen|escape}</a></p>
+		<p style="color: 5890a8"><b>what3words</b> <small>({$W3Wlang2})</small><br />
+		<a href="http://what3words.com/{$coordW3W2|escape}" target="w3w">{$coordW3W2|escape}</a></p>
 	</div>
 	{/if}

--- a/htdocs/templates2/ocstyle/viewcache.tpl
+++ b/htdocs/templates2/ocstyle/viewcache.tpl
@@ -195,7 +195,7 @@
 					</td></tr>
 					<tr><td style="vertical-align:top; width:370px">
 		<p style="line-height: 1.6em;">
-			<img src="resource2/{$opt.template.style}/images/viewcache/map.png" class="icon16" alt="" title="" align="middle" />&nbsp;<a href="#" onclick="window.open('coordinates.php?lat={$cache.latitude}&lon={$cache.longitude}&popup=y&wp={$cache.wpoc}','{t escape=js}Coordinates{/t}','width=280,height=550,resizable=no,scrollbars=1')">{t}Convert coordinates{/t}</a><br />
+			<img src="resource2/{$opt.template.style}/images/viewcache/map.png" class="icon16" alt="" title="" align="middle" />&nbsp;<a href="#" onclick="window.open('coordinates.php?lat={$cache.latitude}&lon={$cache.longitude}&popup=y&wp={$cache.wpoc}&country={$cache.countryCode}&desclang={$cache.desclanguage}','{t escape=js}Coordinates{/t}','width=280,height=550,resizable=no,scrollbars=1')">{t}Convert coordinates{/t}</a><br />
 			<!-- <img src="resource2/{$opt.template.style}/images/viewcache/box.png" class="icon16" alt="" title="" align="middle" />&nbsp;Cache type: <b>Traditional</b><br /> -->
 			<img src="resource2/{$opt.template.style}/images/viewcache/package_green.png" class="icon16" alt="" title="" align="middle" />&nbsp;{t}Size:{/t} <b>{$cache.sizeName|escape}</b><br />
 			<img src="resource2/{$opt.template.style}/images/viewcache/page.png" class="icon16" alt="" title="" align="middle" />


### PR DESCRIPTION
In dem Fenster "andere Koordinatensysteme" erschienen bislang immer deutsche und englische What3words-Koordinaten. Mit dieser Änderung richten sich die W3W-Koordinaten nach der gewählten Sprache, der Sprache der Cachebeschreibung, dem Land in dem der Cache liegt sowie den eingestellten Default-Sprachen für die OC-Website. Zu beachten ist, dass es keine italienischen W3W-Koordinaten gibt.