### PR TITLE
0753 new order on statistic pic selection page, don't dispaly hmtl in short discription updates #753 updates #863

### DIFF
--- a/htdocs/doc/sql/static-data/data.sql
+++ b/htdocs/doc/sql/static-data/data.sql
@@ -1,4 +1,4 @@
--- Content of tables:
+﻿-- Content of tables:
 -- attribute_categories
 -- attribute_groups
 -- cache_attrib
@@ -1458,7 +1458,7 @@ INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('547', 'Choose l
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('548', 'HTML-Code:', '2010-08-28 11:48:04');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('549', 'Text displayed:', '2010-08-28 11:48:04');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('550', 'Text contains invalid charecters!', '2010-08-28 11:48:04');
-INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('551', 'Available logos:', '2010-08-28 11:48:04');
+INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('551', 'Alternavite logos (partly outdated):', '2015-11-24 22:36:00');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('552', 'Cancel', '2010-08-28 11:48:04');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('553', 'Save', '2010-08-28 11:48:04');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('554', 'The following settings are stored for your logo:', '2010-08-28 11:48:04');
@@ -2805,6 +2805,7 @@ INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2519', 'Gauss-K
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2520', 'Show inconsistencies', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2521', 'This table contains some false positives. References from the \"libse\" code (personal cache notes, additional waypoints) are not detected, as well as textes which are passed by variable to translation functions and multiline texts. \"Help\", \"Forum\", \"Teamblog\" and \"Informations\" are referenced in local configuration files. So be very careful before deleting anything.', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2522', 'OConly', '2013-11-03 10:09:14');
+INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2523', 'Official OC logos (up-to-date):', '2015-11-24 23:30:00');
 
 -- Table sys_trans_ref
 SET NAMES 'utf8';
@@ -5993,7 +5994,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('548', 'DE', 'HTML-Code:', '2010-08-28 11:48:06');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('549', 'DE', 'Angezeigter Text:', '2010-08-28 11:48:06');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('550', 'DE', 'Ungültige Zeichen im Text!', '2010-08-28 11:48:06');
-INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('551', 'DE', 'Verfügbare Logos:', '2010-08-28 11:48:06');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('551', 'DE', 'Alternative Logos (teilweise veraltet):', '2015-11-24 22:36:00');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('552', 'DE', 'Abbrechen', '2010-08-28 11:48:06');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('553', 'DE', 'Speichern', '2010-08-28 11:48:06');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('554', 'DE', 'Folgende Einstellungen sind für dein Statistikbild gespeichert:', '2010-08-28 11:48:06');
@@ -7340,6 +7341,8 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2520', 'DE', 'Inkonsistenzen anzeigen', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2521', 'DE', 'Diese Tabelle enthält einige Fehleinträge. Referenzen aus dem \"libse\"-Code (persönliche Cachenotizen, zusätzliche Wegpunkte) werden nicht erkannt, ebenso wie Texte, die als Variable an Übersetzungsfunktionen übergeben werden, und mehrzeilige Texte. \"Help\", \"Forum\", \"Teamblog\" and \"Informations\" werden in lokalen Konfigurationsdateien verwendet. Daher ist beim Löschen von Einträgen Vorsicht geboten.', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2522', 'DE', 'OConly', '2013-11-03 10:09:14');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2523', 'DE', 'Offizielle OC logos (up-to-date):', '2015-11-24 23:30:00');
+
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1', 'EN', 'Reorder IDs', '2010-09-02 00:15:30');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'EN', 'The database could not be reconnected.', '2010-08-28 11:48:07');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('3', 'EN', 'Testing – please do not login', '2010-08-28 11:48:07');
@@ -7842,7 +7845,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('548', 'EN', 'HTML code:', '2010-08-28 11:48:07');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('549', 'EN', 'Text displayed:', '2010-08-28 11:48:07');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('550', 'EN', 'Text contains invalid characters!', '2010-08-28 11:48:07');
-INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('551', 'EN', 'Available logos:', '2010-08-28 11:48:07');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('551', 'EN', 'Alternavite logos (partly outdated):', '2015-11-24 22:36:00');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('552', 'EN', 'Cancel', '2010-08-28 11:48:07');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('553', 'EN', 'Save', '2010-08-28 11:48:07');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('554', 'EN', 'The following settings are stored for your logo:', '2010-08-28 11:48:07');
@@ -9167,6 +9170,8 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2391', 'EN', 'Lausanne', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2392', 'EN', 'Zürich', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2522', 'EN', 'OConly', '2013-11-03 10:09:14');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2523', 'EN', 'Official OC logos (up-to-date):', '2015-11-24 23:30:00');
+
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'ES', 'La base de datos no se pudo conectar.', '2010-12-09 00:17:55');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('3', 'ES', 'En pruebas - por favor, no entre.', '2010-12-09 00:17:55');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('4', 'ES', 'Usuario', '2010-12-09 00:17:55');

--- a/htdocs/editdesc.php
+++ b/htdocs/editdesc.php
@@ -129,7 +129,7 @@
 						else
 							$oldDescMode = $descMode;
 
-						$short_desc = $_POST['short_desc'];  // Ocprop
+						$short_desc = strip_tags($_POST['short_desc']);  // Ocprop
 						$hint = htmlspecialchars($_POST['hints'], ENT_COMPAT, 'UTF-8');
 						$desclang = $_POST['desclang'];
 						$show_all_langs = isset($_POST['show_all_langs_value']) ? $_POST['show_all_langs_value'] : 0;

--- a/htdocs/templates2/ocstyle/change_statpic.tpl
+++ b/htdocs/templates2/ocstyle/change_statpic.tpl
@@ -14,7 +14,7 @@
 
 		<tr>
 			<td colspan="2">
-				{t}The following settings are stored for your logo:{/t}<br />
+				<b>{t}The following settings are stored for your logo:{/t}</b><br />
 			</td>
 		</tr>
 		<tr><td class="spacer" colspan="2"></td></tr>
@@ -33,7 +33,7 @@
 		<tr><td class="spacer" colspan="2"></td></tr>
 
 		<tr>
-			<td>{t}Available logos:{/t}</td>
+			<td><b>{t}Official OC logos (up-to-date):{/t}</b></td>
 			<td class="help"></td>
 			<td style="width:15%"></td>
 			<td style="width:15%"></td>
@@ -41,12 +41,36 @@
 		<tr><td class="spacer" colspan="2"></td></tr>
 
 		{foreach from=$statpics item=statpicItem}
+			{if $statpicItem.id >= 9}
 			<tr>
 				<td>{$statpicItem.description|escape}</td>
 				<td><input type="radio" name="statpic_style" class="radio" value="{$statpicItem.id}" {if $statpic_style==$statpicItem.id}checked="checked"{/if} /><img src="{$statpicItem.previewpath}" align="middle"></td>
 			</tr>
 			<tr><td class="spacer" colspan="2"></td></tr>
+			{/if}
 		{foreachelse}
+			<tr><td></td><td>No logos available</td></tr>
+		{/foreach}
+
+		<tr><td class="spacer" colspan="2"></td></tr>
+
+		<tr>
+			<td><b>{t}Alternavite logos (partly outdated):{/t}</b></td>
+			<td class="help"></td>
+			<td style="width:15%"></td>
+			<td style="width:15%"></td>
+		</tr>
+		<tr><td class="spacer" colspan="2"></td></tr>
+
+		{foreach from=$statpics item=statpicItem}
+			{if $statpicItem.id <= 8}
+				<tr>
+					<td>{$statpicItem.description|escape}</td>
+					<td><input type="radio" name="statpic_style" class="radio" value="{$statpicItem.id}" {if $statpic_style==$statpicItem.id}checked="checked"{/if} /><img src="{$statpicItem.previewpath}" align="middle"></td>
+				</tr>
+				<tr><td class="spacer" colspan="2"></td></tr>
+			{/if}
+			{foreachelse}
 			<tr><td></td><td>No logos available</td></tr>
 		{/foreach}
 


### PR DESCRIPTION
-change: new order on statistic pic selection page, new oclogos are now on top of the list updates #753 
-bugfix: shot discription dosen't contain html-tags anymore, is was possible to include pictures into the searchlist because it displayed the short discription and executed the code  updates #863