### PR TITLE
discontinue Navicache waypoints in OC listings; updates #871

### DIFF
--- a/bin/dbsv-update.php
+++ b/bin/dbsv-update.php
@@ -687,6 +687,11 @@
 			sql("DROP TABLE `search_words`");
 	}
 
+	function dbv_143()   // navicache WP is obsolete
+	{
+		sql("ALTER TABLE `caches` MODIFY `wp_nc` varchar(6) NOT NULL COMMENT 'obsolete'");
+	}
+
 
 	// When adding new mutations, take care that they behave well if run multiple
 	// times. This improves robustness of database versioning.

--- a/htdocs/doc/sql/static-data/data.sql
+++ b/htdocs/doc/sql/static-data/data.sql
@@ -1860,7 +1860,7 @@ INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('1345', 'Only lo
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('1346', 'Time and effort (optional):', '2010-09-07 19:19:44');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('1347', 'Of course, this effort can only be estimated and can vary depending on enviromental influences. If you cannot make sufficiently detailed information, fill both fields up with a O (zero).', '2010-09-07 19:19:44');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('1348', 'Waypoints (optional):', '2010-09-07 19:19:44');
-INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('1349', 'This waypoints will be used to show links in the view cache and the log page.', '2010-09-07 19:19:44');
+INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('1349', 'If the cache was published at another geocaching website, enter the corresponding waypoint here.', '2010-09-07 19:19:44');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('1350', 'No data will be imported automatically from these listing services.', '2010-09-07 19:19:44');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('1351', 'Descriptions', '2010-09-07 19:19:44');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('1352', 'Add description in another language', '2010-09-07 19:19:44');
@@ -6396,7 +6396,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1346', 'DE', 'Aufwand (optional):', '2010-09-11 00:02:20');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1347', 'DE', 'Der Aufwand kann natürlich nur geschätzt werden und kann auch je nach Umwelteinflüssen sehr verschieden sein. Solltest du keine ausreichend genauen Angaben machen können, schreibe in beide Felder 0 (Null).', '2010-09-11 00:02:12');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1348', 'DE', 'Wegpunkte (optional):', '2010-09-11 00:02:03');
-INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1349', 'DE', 'Diese Wegpunkte dienen zur Generierung entsprechender Links in der Cacheansicht bzw. beim Loggen.', '2010-09-11 00:01:54');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1349', 'DE', 'Falls der Cache auch auf einer anderen Website veröffentlicht wurde, gib hier den entsprechenden Wegpunkt an.', '2010-09-11 00:01:54');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1350', 'DE', 'Es werden keine Daten automatisch von diesen Cachedatenbanken übernommen.', '2010-09-11 00:00:58');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1351', 'DE', 'Beschreibungen', '2010-09-11 00:00:49');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1352', 'DE', 'Beschreibung in anderer Sprache hinzuf\&uuml;gen', '2010-09-11 00:00:39');
@@ -8247,7 +8247,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1346', 'EN', 'Time and effort (optional):', '2010-09-11 00:02:20');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1347', 'EN', 'Of course, this effort can only be estimated and can vary depending on enviromental influences. If you cannot make sufficiently detailed information, fill both fields up with a O (zero)', '2010-09-11 00:02:12');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1348', 'EN', 'Waypoints (optional):', '2010-09-11 00:02:03');
-INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1349', 'EN', 'This waypoints will be used to show links in the view cache and the log page.', '2010-09-11 00:01:54');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1349', 'EN', 'If the cache was published at another geocaching website, enter the corresponding waypoint here.', '2010-09-11 00:01:54');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1350', 'EN', 'No data will be imported automatically from these listing services.', '2010-09-11 00:00:58');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1351', 'EN', 'Descriptions', '2010-09-11 00:00:49');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1352', 'EN', 'Add description in another language', '2010-09-11 00:00:39');

--- a/htdocs/doc/sql/tables/caches.sql
+++ b/htdocs/doc/sql/tables/caches.sql
@@ -25,7 +25,7 @@ CREATE TABLE `caches` (
   `way_length` float unsigned NOT NULL default '0',
   `wp_gc` varchar(7) NOT NULL,
   `wp_gc_maintained` varchar(7) NOT NULL,
-  `wp_nc` varchar(6) NOT NULL,
+  `wp_nc` varchar(6) NOT NULL COMMENT 'obsolete',
   `wp_oc` varchar(7) NOT NULL,
   `desc_languages` varchar(60) NOT NULL COMMENT 'via Trigger (cache_desc)',
   `default_desclang` char(2) NOT NULL,

--- a/htdocs/doc/xml/xml11.htm
+++ b/htdocs/doc/xml/xml11.htm
@@ -58,6 +58,10 @@
 			Gleichzeitig wurde auch die Darstellung auf opencaching.de geändert: Bei Mehrfach-Fundlogs erscheint der grüne Stern nur noch an einem der Logs.<br /> 
 			Bei Anwendungen, die das <em>recommended</em>-Flag verwenden wird ein kompletter Neuabruf aller Logs per Version 1.4 empfohlen, weil die alten Daten fehlerhaft sein können. Außerdem sollte die Handhabung von Mehrfachlogs geprüft werden.</li>
 		</ul>
+		<p>Ab ca. Februar 2016 gibt es folgende Änderungen:</p>
+		<ul>
+			<li>Navicache-Wegpunkte in OC-Listings werden nicht mehr unterstützt. Das caches-Attribut "nccom" enthält nun immer einen Leerstring.</li>
+		</ul>
 
 		<p>Der XML-Doctype lautet in allen Versionen "oc11xml".</p>
 		<h2>Ausgabeformat</h2>

--- a/htdocs/editcache.php
+++ b/htdocs/editcache.php
@@ -85,7 +85,7 @@ function getWaypoints($cacheid)
 		}
 		else
 		{
-			$cache_rs = sql("SELECT `caches`.`uuid`, `caches`.`user_id`, `caches`.`name`, `stat_caches`.`picture`, `caches`.`type`, `caches`.`size`, `caches`.`date_hidden`, `caches`.`date_activate`, `caches`.`longitude`, `caches`.`latitude`, `caches`.`country`, `caches`.`terrain`, `caches`.`difficulty`, `caches`.`desc_languages`, `caches`.`status`, `caches`.`search_time`, `caches`.`way_length`, `caches`.`logpw`, `caches`.`wp_oc`, `caches`.`wp_gc`, `caches`.`wp_nc`, `caches`.`show_cachelists`, `caches`.`node`, `user`.`username` FROM `caches` INNER JOIN `user` ON `caches`.`user_id`=`user`.`user_id` LEFT JOIN `stat_caches` ON `caches`.`cache_id`=`stat_caches`.`cache_id` WHERE `caches`.`cache_id`='&1'", $cache_id);
+			$cache_rs = sql("SELECT `caches`.`uuid`, `caches`.`user_id`, `caches`.`name`, `stat_caches`.`picture`, `caches`.`type`, `caches`.`size`, `caches`.`date_hidden`, `caches`.`date_activate`, `caches`.`longitude`, `caches`.`latitude`, `caches`.`country`, `caches`.`terrain`, `caches`.`difficulty`, `caches`.`desc_languages`, `caches`.`status`, `caches`.`search_time`, `caches`.`way_length`, `caches`.`logpw`, `caches`.`wp_oc`, `caches`.`wp_gc`, `caches`.`show_cachelists`, `caches`.`node`, `user`.`username` FROM `caches` INNER JOIN `user` ON `caches`.`user_id`=`user`.`user_id` LEFT JOIN `stat_caches` ON `caches`.`cache_id`=`stat_caches`.`cache_id` WHERE `caches`.`cache_id`='&1'", $cache_id);
 			$cache_record = sql_fetch_array($cache_rs);
 			sql_free_result($cache_rs);
 
@@ -221,7 +221,6 @@ function getWaypoints($cacheid)
 					$log_pw = isset($_POST['log_pw']) ? mb_substr($_POST['log_pw'], 0, 20) : $cache_record['logpw'];
 					// fix #4356: gc waypoints are frequently copy&pasted with leading spaces
 					$wp_gc = isset($_POST['wp_gc']) ? strtoupper(trim($_POST['wp_gc'])) : $cache_record['wp_gc'];  // Ocprop
-					$wp_nc = isset($_POST['wp_nc']) ? strtoupper(trim($_POST['wp_nc'])) : $cache_record['wp_nc'];
 					$showlists = isset($_POST['showlists']) ? 1 : $cache_record['show_cachelists'] + 0;
 
 					// name
@@ -492,7 +491,7 @@ function getWaypoints($cacheid)
 							// Status change via editcache.php is no longer available via the user interface,
 							// but still used by Ocprop and maybe other tools.
 							sql("SET @STATUS_CHANGE_USER_ID='&1'", $usr['userid']);
-							sql("UPDATE `caches` SET `name`='&1', `longitude`='&2', `latitude`='&3', `type`='&4', `date_hidden`='&5', `country`='&6', `size`='&7', `difficulty`='&8', `terrain`='&9', `status`='&10', `search_time`='&11', `way_length`='&12', `logpw`='&13', `wp_gc`='&14', `wp_nc`='&15', `show_cachelists`='&16', `date_activate` = $activation_date WHERE `cache_id`='&17'", $cache_name, $cache_lon, $cache_lat, $cache_type, date('Y-m-d', mktime(0, 0, 0, $cache_hidden_month, $cache_hidden_day, $cache_hidden_year)), $cache_country, $sel_size, $cache_difficulty, $cache_terrain, $status, $search_time, $way_length, $log_pw, $wp_gc, $wp_nc, $showlists, $cache_id);
+							sql("UPDATE `caches` SET `name`='&1', `longitude`='&2', `latitude`='&3', `type`='&4', `date_hidden`='&5', `country`='&6', `size`='&7', `difficulty`='&8', `terrain`='&9', `status`='&10', `search_time`='&11', `way_length`='&12', `logpw`='&13', `wp_gc`='&14', `show_cachelists`='&15', `date_activate` = $activation_date WHERE `cache_id`='&16'", $cache_name, $cache_lon, $cache_lat, $cache_type, date('Y-m-d', mktime(0, 0, 0, $cache_hidden_month, $cache_hidden_day, $cache_hidden_year)), $cache_country, $sel_size, $cache_difficulty, $cache_terrain, $status, $search_time, $way_length, $log_pw, $wp_gc, $showlists, $cache_id);
 
 							// send notification on admin intervention
 							if ($cache_record['user_id'] != $usr['userid'] &&
@@ -928,7 +927,6 @@ function getWaypoints($cacheid)
 					tpl_set_var('way_length', $way_length);
 					tpl_set_var('log_pw', htmlspecialchars($log_pw, ENT_COMPAT, 'UTF-8'));
 					tpl_set_var('wp_gc', htmlspecialchars($wp_gc, ENT_COMPAT, 'UTF-8'));
-					tpl_set_var('wp_nc', htmlspecialchars($wp_nc, ENT_COMPAT, 'UTF-8'));
 					tpl_set_var('showlists_checked', $showlists ? 'checked="checked"' : '');
 
 					tpl_set_var('reset', $reset);  // obsolete

--- a/htdocs/garmin.php
+++ b/htdocs/garmin.php
@@ -70,7 +70,6 @@
 				`caches`.`date_hidden` AS `datehidden`,
 				`caches`.`wp_oc` AS `wpoc`,
 				`caches`.`wp_gc` AS `wpgc`,
-				`caches`.`wp_nc` AS `wpnc`,
 				`caches`.`date_created` AS `datecreated`,
 				`caches`.`difficulty` AS `difficulty`,
 				`caches`.`terrain` AS `terrain`,

--- a/htdocs/lang/de/ocstyle/editcache.tpl.php
+++ b/htdocs/lang/de/ocstyle/editcache.tpl.php
@@ -226,15 +226,13 @@ function toggleAttr(id)
 		<!-- allow wp_gc copy&paste with leading spaces; will be trimmed later -->
 		<td>geocaching.com: <input type="text" name="wp_gc" value="{wp_gc}" maxlength="12" class="input70 waypoint" />
 			{wpgc_message}
-			navicache.com: <input type="text" name="wp_nc" value="{wp_nc}" maxlength="6" class="input50 waypoint" />
 		</td>
 	</tr>
 	<tr>
 		<td>&nbsp;</td>
 		<td class="help">
 			<img src="lang/de/ocstyle/images/misc/hint.gif" border="0" width="15" height="11" alt="{t}Notice{/t}" title="{t}Notice{/t}" />
-			{t}This waypoints will be used to show links in the view cache and the log page.{/t}<br />
-			{t}No data will be imported automatically from these listing services.{/t}
+			{t}If the cache was published at another geocaching website, enter the corresponding waypoint here.{/t}<br />
 		</td>
 	</tr>
 	<tr><td class="spacer" colspan="2"></td></tr>

--- a/htdocs/lang/de/ocstyle/newcache.tpl.php
+++ b/htdocs/lang/de/ocstyle/newcache.tpl.php
@@ -225,14 +225,12 @@ function toggleAttr(id)
 		<!-- allow wp_gc copy&paste with leading spaces; will be trimmed later -->
 		<td>geocaching.com: <input type="text" name="wp_gc" value="{wp_gc}" maxlength="12" class="input70w waypoint" />
 			{wpgc_message}
-			navicache.com: <input type="text" name="wp_nc" value="{wp_nc}" maxlength="6" class="input50 waypoint" />
 		</td>
 	</tr>
 	<tr>
 		<td>&nbsp;</td>
 		<td class="help"><img src="lang/de/ocstyle/images/misc/hint.gif" border="0" width="15" height="11" alt="{t}Notice{/t}" title="{t}Notice{/t}" />
-		{t}This waypoints will be used to show links in the view cache and the log page.{/t}<br />
-		{t}No data will be imported automatically from these listing services.{/t}
+			{t}If the cache was published at another geocaching website, enter the corresponding waypoint here.{/t}<br />
 		</td>
 	</tr>
 	<tr><td class="spacer" colspan="2">&nbsp;</td></tr>

--- a/htdocs/lib2/logic/cache.class.php
+++ b/htdocs/lib2/logic/cache.class.php
@@ -33,19 +33,6 @@ class cache
 
 			$cacheid = $r['cache_id'];
 		}
-		else if (mb_strtoupper(mb_substr($wp, 0, 1)) == 'N')
-		{
-			$rs = sql("SELECT `cache_id` FROM `caches` WHERE `wp_nc`='&1'", $wp);
-			if (sql_num_rows($rs) != 1)
-			{
-				sql_free_result($rs);
-				return null;
-			}
-			$r = sql_fetch_assoc($rs);
-			sql_free_result($rs);
-
-			$cacheid = $r['cache_id'];
-		}
 		else
 		{
 			$cacheid = sql_value("SELECT `cache_id` FROM `caches` WHERE `wp_oc`='&1'", 0, $wp);
@@ -166,10 +153,6 @@ class cache
 	function getWPGC()
 	{
 		return $this->reCache->getValue('wp_gc');
-	}
-	function getWPNC()
-	{
-		return $this->reCache->getValue('wp_nc');
 	}
 
 	function getUUID()

--- a/htdocs/map2.php
+++ b/htdocs/map2.php
@@ -304,7 +304,7 @@ function output_cachexml($sWaypoint)
 	                   LEFT JOIN `sys_trans_text` AS `trans_size_text` ON `trans_size`.`id`=`trans_size_text`.`trans_id` AND `trans_size_text`.`lang`='&2'
 	                   LEFT JOIN `caches_attributes` ON `caches_attributes`.`cache_id`=`caches`.`cache_id` AND `caches_attributes`.`attrib_id`=6
 	                   LEFT JOIN `pictures` ON `pictures`.`object_id`=`caches`.`cache_id` AND `pictures`.`object_type`='&4' AND `pictures`.`mappreview`=1
-	                       WHERE (`caches`.`wp_oc`='&3' OR (`caches`.`wp_oc`!='&3' AND `caches`.`wp_gc_maintained`='&3') OR (`caches`.`wp_oc`!='&3' AND `caches`.`wp_nc`='&3')) AND 
+	                       WHERE (`caches`.`wp_oc`='&3' OR (`caches`.`wp_oc`!='&3' AND `caches`.`wp_gc_maintained`='&3')) AND 
 	                             (`cache_status`.`allow_user_view`=1 OR `caches`.`user_id`='&1')
 	                       LIMIT 1",  // for the case of illegal duplicates in pictures.mappreview etc.
 	                              $login->userid, $opt['template']['locale'], $sWaypoint, OBJECT_CACHE);

--- a/htdocs/newcache.php
+++ b/htdocs/newcache.php
@@ -292,9 +292,6 @@
 			$wp_gc = isset($_POST['wp_gc']) ? strtoupper(trim($_POST['wp_gc'])) : '';  // Ocprop
 			tpl_set_var('wp_gc', htmlspecialchars($wp_gc, ENT_COMPAT, 'UTF-8'));
 
-			$wp_nc = isset($_POST['wp_nc']) ? strtoupper(trim($_POST['wp_nc'])) : '';
-			tpl_set_var('wp_nc', htmlspecialchars($wp_nc, ENT_COMPAT, 'UTF-8'));
-
 			//difficulty
 			$difficulty = isset($_POST['difficulty']) ? $_POST['difficulty'] : 1;  // Ocprop
 			$difficulty_options = '<option value="1">'.$sel_message.'</option>';
@@ -867,11 +864,10 @@
 												`search_time`,
 												`way_length`,
 												`wp_gc`,
-												`wp_nc`,
 												`node`
 											) VALUES (
 												'', '&1', '&2', '&3', '&4', '&5', '&6', '&7', '&8', $activation_date, 
-												'&9', '&10', '&11', '&12', '&13', '&14', '&15', '&16', '&17')",
+												'&9', '&10', '&11', '&12', '&13', '&14', '&15', '&16')",
 											$usr['userid'],
 											$name,
 											$longitude,
@@ -887,7 +883,6 @@
 											$search_time,
 											$way_length,
 											$wp_gc,
-											$wp_nc,
 											$oc_nodeid);
 					$cache_id = mysql_insert_id($dblink);
 

--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -1056,8 +1056,6 @@
 			if (!isset($options['f_otherPlatforms'])) $options['f_otherPlatforms']='0';
 			if ($options['f_otherPlatforms'] != 0)
 			{
-				// $sql_where[] = '`caches`.`wp_nc`=\'\' AND `caches`.`wp_gc`=\'\'';
-				// ignore NC listings, which are mostly unmaintained or dead
 				$sql_where[] = "`caches`.`wp_gc_maintained`=''";
 			}
 

--- a/htdocs/searchplugin.php
+++ b/htdocs/searchplugin.php
@@ -91,12 +91,10 @@
 						$target = 'oc';
 					}
 					
-					if ((($target == 'oc') || ($target == 'nc') || ($target == 'gc')) && mb_ereg_match('(('.$opt['logic']['ocprefixes'].'|gc)([a-z0-9]){4,5}|n([a-f0-9]){5,5})$', mb_strtolower($searchfor)))
+					if ((($target == 'oc') || ($target == 'gc')) && mb_ereg_match('(('.$opt['logic']['ocprefixes'].'|gc)([a-z0-9]){4,5}|n([a-f0-9]){5,5})$', mb_strtolower($searchfor)))
 					{
 						if ($target == 'gc')
 							$wpfield = "IF(`wp_gc_maintained`='',`wp_gc`,`wp_gc_maintained`)";
-						else if ($target == 'nc')
-							$wpfield = "`wp_nc`";
 						else
 							$wpfield = "`wp_oc`";
 						// get cache_id from DB

--- a/htdocs/templates2/ocstyle/viewcache.tpl
+++ b/htdocs/templates2/ocstyle/viewcache.tpl
@@ -216,13 +216,10 @@
 			<img src="resource2/{$opt.template.style}/images/viewcache/date.png" class="icon16" alt="" title="" align="middle" />&nbsp;{t}Last update:{/t} {$cache.lastmodified|date_format:$opt.format.datelong}<br />  {* Ocprop: <br />\s*Wegpunkt: (OC[A-Z0-9]+)\s*<br /> -- Waypoint: <b>(OC[A-Z0-9]+)<\/b><br \/> *}
 			<!-- Ocprop: <br /> Wegpunkt: <b>{$cache.wpoc}</b><br /> -->
 			<img src="resource2/{$opt.template.style}/images/viewcache/arrow_in.png" class="icon16" alt="" title="" align="middle" />&nbsp;{t}Listing{/t}{t}#colonspace#{/t}: {if $shortlink_url !== false}{$shortlink_url}{/if}<b>{$cache.wpoc}</b><br />
-			{if $cache.wpgc!='' || $cache.wpnc!=''}<img src="resource2/{$opt.template.style}/images/viewcache/link.png" class="icon16" alt="" title="" align="middle" />
+			{if $cache.wpgc!=''}<img src="resource2/{$opt.template.style}/images/viewcache/link.png" class="icon16" alt="" title="" align="middle" />
 				{t}Also listed at:{/t}  {* Ocprop: Auch gelistet auf: <a href=\"http://www\.geocaching\.com/seek/cache_details\.aspx\?wp=(GC[0-9A-Z]{1,5})\" target=\"_blank\">geocaching.com</a> *}
 				{if $cache.wpgc!=''}
 					<a href="http://www.geocaching.com/seek/cache_details.aspx?wp={$cache.wpgc}" target="_blank">geocaching.com&nbsp;</a>
-				{/if}
-				{if $cache.wpnc!=''}
-					<a href="http://www.navicache.com/cgi-bin/db/displaycache2.pl?CacheID={nccacheid wp=$cache.wpnc}" target="_blank">navicache.com</a>
 				{/if}
 			{/if}
 		</p>

--- a/htdocs/templates2/ocstyle/viewcache_print.tpl
+++ b/htdocs/templates2/ocstyle/viewcache_print.tpl
@@ -85,13 +85,10 @@
 						<tr><td>{if $cache.is_publishdate==0}{t}Listed since:{/t}{else}{t}Published on:{/t}{/if}</td><td>{$cache.datecreated|date_format:$opt.format.datelong}</td></tr>
 						<tr><td>{t}Last update:{/t}</td><td>{$cache.lastmodified|date_format:$opt.format.datelong}</td></tr>
 						
-						{if $cache.wpgc!='' || $cache.wpnc!=''}
+						{if $cache.wpgc!=''}
 							<tr>
 							<td>{t}Also listed as:{/t}</td>
-							<td>
-								{if $cache.wpgc!=''}{$cache.wpgc}{if $cache.wpnc!=''}, {/if}{/if}
-								{if $cache.wpnc!=''}{$cache.wpnc}{/if}
-							</td>
+							<td>{$cache.wpgc}</td>
 						{/if}
 
 						<tr><td class="spacer-print"></td></td>

--- a/htdocs/viewcache.php
+++ b/htdocs/viewcache.php
@@ -103,7 +103,6 @@ function getChildWaypoints($cacheid)
 				`caches`.`date_hidden` AS `datehidden`,
 				`caches`.`wp_oc` AS `wpoc`,
 				`caches`.`wp_gc` AS `wpgc`,
-				`caches`.`wp_nc` AS `wpnc`,
 				`caches`.`date_created` AS `datecreated`,
 				`caches`.`is_publishdate` AS `is_publishdate`,
 				`caches`.`difficulty` AS `difficulty`,
@@ -301,8 +300,7 @@ function getChildWaypoints($cacheid)
 	/* geokrets
 	 */
 	$rsGeoKret = sql("SELECT `gk_item`.`id`, `gk_item`.`name` AS `itemname`, `gk_user`.`name` AS `username` FROM `gk_item` INNER JOIN `gk_item_waypoint` ON `gk_item`.`id`=`gk_item_waypoint`.`id` INNER JOIN `gk_user` ON `gk_item`.`userid`=`gk_user`.`id` INNER JOIN `caches` ON `gk_item_waypoint`.`wp`=`caches`.`wp_oc` WHERE `caches`.`cache_id`='&1' AND `gk_item`.`typeid`!=2 AND `gk_item`.`stateid` IN (0, 3) AND `gk_item_waypoint`.`wp`!='' UNION 
-	             SELECT `gk_item`.`id`, `gk_item`.`name` AS `itemname`, `gk_user`.`name` AS `username` FROM `gk_item` INNER JOIN `gk_item_waypoint` ON `gk_item`.`id`=`gk_item_waypoint`.`id` INNER JOIN `gk_user` ON `gk_item`.`userid`=`gk_user`.`id` INNER JOIN `caches` ON `gk_item_waypoint`.`wp`=`caches`.`wp_gc` WHERE `caches`.`cache_id`='&1' AND `gk_item`.`typeid`!=2 AND `gk_item`.`stateid` IN (0, 3) AND `gk_item_waypoint`.`wp`!='' UNION 
-	             SELECT `gk_item`.`id`, `gk_item`.`name` AS `itemname`, `gk_user`.`name` AS `username` FROM `gk_item` INNER JOIN `gk_item_waypoint` ON `gk_item`.`id`=`gk_item_waypoint`.`id` INNER JOIN `gk_user` ON `gk_item`.`userid`=`gk_user`.`id` INNER JOIN `caches` ON `gk_item_waypoint`.`wp`=`caches`.`wp_nc` WHERE `caches`.`cache_id`='&1' AND `gk_item`.`typeid`!=2 AND `gk_item`.`stateid` IN (0, 3) AND `gk_item_waypoint`.`wp`!='' ORDER BY `itemname`", $cacheid);
+	             SELECT `gk_item`.`id`, `gk_item`.`name` AS `itemname`, `gk_user`.`name` AS `username` FROM `gk_item` INNER JOIN `gk_item_waypoint` ON `gk_item`.`id`=`gk_item_waypoint`.`id` INNER JOIN `gk_user` ON `gk_item`.`userid`=`gk_user`.`id` INNER JOIN `caches` ON `gk_item_waypoint`.`wp`=`caches`.`wp_gc` WHERE `caches`.`cache_id`='&1' AND `gk_item`.`typeid`!=2 AND `gk_item`.`stateid` IN (0, 3) AND `gk_item_waypoint`.`wp`!='' ORDER BY `itemname`", $cacheid);
 	$tpl->assign_rs('geokret', $rsGeoKret);
 	$tpl->assign('geokret_count', sql_num_rows($rsGeoKret));
 	sql_free_result($rsGeoKret);

--- a/htdocs/xml/csv/cache.php
+++ b/htdocs/xml/csv/cache.php
@@ -45,6 +45,6 @@
 		echo ';';
 		echo '"' . mb_ereg_replace('"', '\"', $cache->getWPGC()) . '"';
 		echo ';';
-		echo '"' . mb_ereg_replace('"', '\"', $cache->getWPNC()) . '"';
+		echo '""';  // obsolete Navicache WP
 	}
 ?>

--- a/htdocs/xml/ocxml11.php
+++ b/htdocs/xml/ocxml11.php
@@ -453,7 +453,7 @@ function outputXmlFile($sessionid, $filenr, $bXmlDecl, $bOcXmlTag, $bDocType, $z
 	                                    `caches`.`longitude` `longitude`, `caches`.`latitude` `latitude`, `caches`.`type` `type`, 
 	                                    `caches`.`country` `country`, `caches`.`size` `size`, `caches`.`desc_languages` `desclanguages`,
 	                                    `caches`.`difficulty` `difficulty`, `caches`.`terrain` `terrain`, `caches`.`way_length` `way_length`, 
-	                                    `caches`.`search_time` `search_time`, `caches`.`wp_gc` `wp_gc`, `caches`.`wp_nc` `wp_nc`,
+	                                    `caches`.`search_time` `search_time`, `caches`.`wp_gc` `wp_gc`,
 	                                    /* we deliberatly do not use gc_wp_maintained here */
 	                                    `caches`.`wp_oc` `wp_oc`, `caches`.`date_hidden` `date_hidden`, `caches`.`date_created` `date_created`, `caches`.`is_publishdate` `is_publishdate`, 
 	                                    `caches`.`last_modified` `last_modified`, `caches`.`status` `status`, `caches`.`node` `node`,
@@ -484,7 +484,7 @@ function outputXmlFile($sessionid, $filenr, $bXmlDecl, $bOcXmlTag, $bDocType, $z
 		fwrite($f, $t2 . '<difficulty>' . sprintf('%01.1f', $r['difficulty'] / 2) . '</difficulty>' . "\n");
 		fwrite($f, $t2 . '<terrain>' . sprintf('%01.1f', $r['terrain'] / 2) . '</terrain>' . "\n");
 		fwrite($f, $t2 . '<rating waylength="' . $r['way_length'] . '" needtime="' . $r['search_time'] . '" />' . "\n");
-		fwrite($f, $t2 . '<waypoints gccom="' . xmlentities($r['wp_gc']) . '" nccom="' . xmlentities($r['wp_nc']) . '" oc="' . xmlentities($r['wp_oc']) . '" />' . "\n");
+		fwrite($f, $t2 . '<waypoints gccom="' . xmlentities($r['wp_gc']) . '" nccom="" oc="' . xmlentities($r['wp_oc']) . '" />' . "\n");
 		fwrite($f, $t2 . '<datehidden>' . date($sDateformat, strtotime($r['date_hidden'])) . '</datehidden>' . "\n");
 		if ($ocxmlversion >= 12) $pd = ' ispublishdate="' . $r['is_publishdate'] . '"';
 		else $pd = "";

--- a/local/ocxml11client/index.php
+++ b/local/ocxml11client/index.php
@@ -689,7 +689,7 @@ function ImportCacheArray($r)
 			                         `status`=&7, `country`='&8', `date_hidden`='&9', 
 			                         `size`=&10, `difficulty`=&11, `terrain`=&12, 
 			                         `search_time`=&13, `way_length`=&14, `wp_gc`='&15', 
-			                         `wp_nc`='&16', `wp_oc`='&17' WHERE `uuid`='&18' LIMIT 1",
+			                         `wp_oc`='&16' WHERE `uuid`='&17' LIMIT 1",
 			                     $r['NAME']['__DATA'],
 			                     $r['LONGITUDE']['__DATA'],
 			                     $r['LATITUDE']['__DATA'],
@@ -705,7 +705,6 @@ function ImportCacheArray($r)
 			                     $r['RATING']['__ATTR']['NEEDTIME'],
 			                     $r['RATING']['__ATTR']['WAYLENGTH'],
 			                     $r['WAYPOINTS']['__ATTR']['GCCOM'],
-			                     $r['WAYPOINTS']['__ATTR']['NCCOM'],
 			                     $r['WAYPOINTS']['__ATTR']['OC'],
 			                     $r['ID']['__DATA']);
 
@@ -738,7 +737,7 @@ function ImportCacheArray($r)
 		                         `date_hidden`,  
 		                         `size`, `difficulty`, 
 		                         `terrain`, `uuid`, `search_time`, 
-		                         `way_length`, `wp_gc`, `wp_nc`, 
+		                         `way_length`, `wp_gc`,
 		                         `wp_oc`) 
 		                 VALUES (  &1 ,  '&2',   &3 ,
 		                           &4 ,  '&5',  '&6',
@@ -746,14 +745,14 @@ function ImportCacheArray($r)
 		                         '&10', 
 		                          &11 ,  &12 ,
 		                          &13 , '&14',  &15 ,
-		                          &16 , '&17', '&18',
-		                         '&19')",
+		                          &16 , '&17',
+		                         '&18')",
 		                         $rUser['user_id'], $r['NAME']['__DATA'], $r['LONGITUDE']['__DATA'],
 		                         $r['LATITUDE']['__DATA'], $r['LASTMODIFIED']['__DATA'], $r['DATECREATED']['__DATA'],
 		                         $r['TYPE']['__ATTR']['ID'], $r['STATUS']['__ATTR']['ID'], $r['COUNTRY']['__ATTR']['ID'],
 		                         $r['DATEHIDDEN']['__DATA'], $r['SIZE']['__ATTR']['ID'], $r['DIFFICULTY']['__DATA'] * 2,
 		                         $r['TERRAIN']['__DATA'] * 2, $r['ID']['__DATA'], $r['RATING']['__ATTR']['NEEDTIME'],
-		                         $r['RATING']['__ATTR']['WAYLENGTH'], $r['WAYPOINTS']['__ATTR']['GCCOM'], $r['WAYPOINTS']['__ATTR']['NCCOM'],
+		                         $r['RATING']['__ATTR']['WAYLENGTH'], $r['WAYPOINTS']['__ATTR']['GCCOM'],
 		                         $r['WAYPOINTS']['__ATTR']['OC']);
 	}
 	mysql_free_result($rs);


### PR DESCRIPTION
betrifft
- neue Caches anlegen
- Caches bearbeiten
- Caches anzeigen, auch als Druckansicht
- Suche nach Wegpunkten über die Box oben rechts, über die Karte und via Firefox-Plugin
- XML-Schnittstelle