### PR TITLE
sort search result on search.php updates #865

### DIFF
--- a/htdocs/doc/sql/static-data/data.sql
+++ b/htdocs/doc/sql/static-data/data.sql
@@ -2806,6 +2806,7 @@ INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2520', 'Show in
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2521', 'This table contains some false positives. References from the \"libse\" code (personal cache notes, additional waypoints) are not detected, as well as textes which are passed by variable to translation functions and multiline texts. \"Help\", \"Forum\", \"Teamblog\" and \"Informations\" are referenced in local configuration files. So be very careful before deleting anything.', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2522', 'OConly', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2523', 'Official OC logos (up-to-date):', '2015-11-24 23:30:00');
+INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2524', 'Stored querie', '2015-01-20 20:37:00');
 
 -- Table sys_trans_ref
 SET NAMES 'utf8';
@@ -7342,7 +7343,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2521', 'DE', 'Diese Tabelle enthält einige Fehleinträge. Referenzen aus dem \"libse\"-Code (persönliche Cachenotizen, zusätzliche Wegpunkte) werden nicht erkannt, ebenso wie Texte, die als Variable an Übersetzungsfunktionen übergeben werden, und mehrzeilige Texte. \"Help\", \"Forum\", \"Teamblog\" and \"Informations\" werden in lokalen Konfigurationsdateien verwendet. Daher ist beim Löschen von Einträgen Vorsicht geboten.', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2522', 'DE', 'OConly', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2523', 'DE', 'Offizielle OC logos (up-to-date):', '2015-11-24 23:30:00');
-
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2524', 'DE', 'Gespeicherte Suche', '2015-01-20 20:37:00');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1', 'EN', 'Reorder IDs', '2010-09-02 00:15:30');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'EN', 'The database could not be reconnected.', '2010-08-28 11:48:07');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('3', 'EN', 'Testing – please do not login', '2010-08-28 11:48:07');
@@ -9171,7 +9172,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2392', 'EN', 'Zürich', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2522', 'EN', 'OConly', '2013-11-03 10:09:14');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2523', 'EN', 'Official OC logos (up-to-date):', '2015-11-24 23:30:00');
-
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2524', 'EN', 'Stored querie', '2015-01-20 20:37:00');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2', 'ES', 'La base de datos no se pudo conectar.', '2010-12-09 00:17:55');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('3', 'ES', 'En pruebas - por favor, no entre.', '2010-12-09 00:17:55');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('4', 'ES', 'Usuario', '2010-12-09 00:17:55');

--- a/htdocs/templates2/ocstyle/search.result.caches.row.tpl
+++ b/htdocs/templates2/ocstyle/search.result.caches.row.tpl
@@ -8,25 +8,33 @@
 ***************************************************************************}
 <!--m-->
 <tr>
-  <td width="18" class="{$listcolor}">&nbsp;{$position}&nbsp;&nbsp;</td>
-  <td width="45" class="{$listcolor}">{if $cache.distance !== null}{$cache.distance|sprintf:"%1.1f"|escape}&nbsp;{/if}</td>
-  <td width="32" class="{$listcolor}" rowspan="2"><img src="resource2/{$opt.template.style}/images/cacheicon/{$cache.icon}" title="{$cache.cacheTypeName}" /></td>
-  <td width="46" class="{$listcolor}" rowspan="2"><nobr>{include file="res_difficon.tpl" difficulty=$cache.difficulty}{include file="res_terricon.tpl" terrain=$cache.terrain}</nobr></td>
-  <td width="448" class="{$listcolor}">{if $cache.isnew}<b class="newsymbol">&nbsp;{t}NEW{/t}&nbsp;</b>&nbsp; {/if}<span style="{include file="res_cachestatus_span.tpl" status=$cache.status}"><a href="viewcache.php?cacheid={$cache.cache_id|escape}"><span style="{if $cache.redname}color: #e00000{/if}">{$cache.name|escape}</span></a></span> &nbsp;{t}by{/t} <a href="viewprofile.php?userid={$cache.user_id|escape}">{$cache.username|escape}</a><!-- Ocprop: <a href="viewcache.php?cacheid={$cache.cache_id|escape}">{$cache.name|escape}</a> {t}by{/t} <a href="viewprofile.php?userid={$cache.user_id|escape}">{$cache.username|escape}</a> --></td>
-  <td width="74" class="{$listcolor}" rowspan="2" style="padding: 0px">{if $cache.oconly}<img src="resource2/ocstyle/images/misc/is_oconly.png" alt="OConly" title="OConly" style="margin:0px; padding:0px" width="64" height="35" />{/if}</td>
-  <td width="110" valign="top" class="{$listcolor}"><nobr>
+	<td class="{$listcolor}">&nbsp;</td>
+  	<td class="{$listcolor}">{if $cache.distance !== null}{$cache.distance|sprintf:"%1.1f"|escape}&nbsp;{/if}</td>
+  	<td class="{$listcolor}" rowspan="2"><img src="resource2/{$opt.template.style}/images/cacheicon/{$cache.icon}" title="{$cache.cacheTypeName}" /></td>
+  	<td class="{$listcolor}" rowspan="2"><nobr>{include file="res_difficon.tpl" difficulty=$cache.difficulty}</nobr></td>
+	<td class="{$listcolor}" rowspan="2"><nobr>{include file="res_terricon.tpl" terrain=$cache.terrain}</nobr></td>
+	<td class="{$listcolor}" colspan="2">{if $cache.isnew}<b class="newsymbol">&nbsp;{t}NEW{/t}&nbsp;</b>&nbsp; {/if}<span style="{include file="res_cachestatus_span.tpl" status=$cache.status}"><a href="viewcache.php?cacheid={$cache.cache_id|escape}"><span style="{if $cache.redname}color: #e00000{/if}">{$cache.name|escape}</span></a></span> &nbsp;{t}by{/t} <a href="viewprofile.php?userid={$cache.user_id|escape}">{$cache.username|escape}</a><!-- Ocprop: <a href="viewcache.php?cacheid={$cache.cache_id|escape}">{$cache.name|escape}</a> {t}by{/t} <a href="viewprofile.php?userid={$cache.user_id|escape}">{$cache.username|escape}</a> --></td>
+	{if $sbycreated}
+		<td class="{$listcolor}">{$cache.date_created|date_format:$opt.format.date}</td>
+	{else}
+		<td class="{$listcolor}" rowspan="2" style="padding: 0px">
+			&nbsp;{if $cache.oconly}<img src="resource2/ocstyle/images/misc/is_oconly.png" alt="OConly" title="OConly" style="margin:0px; padding:0px" width="64" height="35" />{/if}
+		</td>
+	{/if}
+	<td class="{$listcolor}" valign="top"><nobr>
 		{if $cache.firstlog}
-			<a href="viewcache.php?cacheid={$cache.cache_id}&log=A#log{$cache.firstlog.id}">{include file="res_logtype.tpl" type=$cache.firstlog.type}</a><a href="viewcache.php?cacheid={$cache.cache_id}&log=A#log{$cache.firstlog.id}">{$cache.firstlog.date|date_format:$opt.format.date}</a>&nbsp;
+			<nobr><a href="viewcache.php?cacheid={$cache.cache_id}&log=A#log{$cache.firstlog.id}">{include file="res_logtype.tpl" type=$cache.firstlog.type}</a>&nbsp;<a href="viewcache.php?cacheid={$cache.cache_id}&log=A#log{$cache.firstlog.id}">{$cache.firstlog.date|date_format:$opt.format.date}</a>&nbsp;&nbsp;&nbsp;&nbsp;</nobr>
 		{else}
-			<img src="resource2/{$opt.template.style}/images/log/16x16-none.png" width="16" height="16" /> --.--.----&nbsp;
+			<img src="resource2/{$opt.template.style}/images/log/16x16-none.png" width="16" height="16" />&nbsp;--.--.----&nbsp;
 		{/if}
-	</nobr></td>
+	</nobr>
+  	</td>
 </tr>
 <!--n-->
 <tr>
-  <td width="25" class="{$listcolor}">&nbsp;</td>
-  <td width="32" class="{$listcolor}" valign="top">{if $cache.direction_deg !== false}<img src="resource2/ocstyle/images/direction/16x16-{$cache.direction_deg}deg.png" title="{t}Cardinal direction:{/t} {$cache.direction_txt}" />&nbsp;{/if}</td>
-  <td width="448" class="{$listcolor}" valign="top">
+  	<td class="{$listcolor}">&nbsp;</td>
+  	<td class="{$listcolor}" valign="top">{if $cache.direction_deg !== false}<img src="resource2/ocstyle/images/direction/16x16-{$cache.direction_deg}deg.png" title="{t}Cardinal direction:{/t} {$cache.direction_txt}" />&nbsp;{/if}</td>
+  	<td class="{$listcolor}" colspan="2" valign="top">
 		<p>
 			{strip}
 				{if $cache.topratings<4}
@@ -42,6 +50,10 @@
 		{foreach from=$cache.desclangs item=desclang}
 			<a href="viewcache.php?cacheid={$cache.cache_id}&desclang={$desclang|escape}" style="text-decoration:none"><b><span style="color:blue">{$desclang|escape}</span></b></a>
 		{/foreach}
-		{$cache.short_desc} &nbsp;</p></td>
-  <td width="110" class="{$listcolor}" valign="top">{foreach from=$cache.logs item=log}<a href="viewcache.php?cacheid={$cache.cache_id}&log=A#log{$log.id}">{include file="res_logtype.tpl" type=$log.type}</a>&nbsp;{/foreach}</td>
+		{$cache.short_desc} &nbsp;</p>
+	</td>
+	{if $sbycreated}
+		<td  class="{$listcolor}" valign="top">{if $cache.oconly}<img src="resource2/ocstyle/images/misc/15x15-oc.png"/>{/if}&nbsp;</td>
+	{/if}
+  	<td  class="{$listcolor}" valign="top"><nobr>{foreach from=$cache.logs item=log}<a href="viewcache.php?cacheid={$cache.cache_id}&log=A#log{$log.id}">{include file="res_logtype.tpl" type=$log.type}</a>&nbsp;{/foreach}&nbsp;&nbsp;&nbsp;</nobr></td>
 </tr>

--- a/htdocs/templates2/ocstyle/search.result.caches.tpl
+++ b/htdocs/templates2/ocstyle/search.result.caches.tpl
@@ -9,11 +9,16 @@
 
 <script type="text/javascript" src="resource2/{$opt.template.style}/js/wz_tooltip.js"></script>
 
-{if $cachelist}
+{if $cachelist || $userid}
 	<div class="content2-container cachelistinfo" style="margin-top:10px" >
 	<p style="margin-top:0.5em; padding-left:10px; padding-right:8px">
-		<img src="resource2/ocstyle/images/misc/16x16-list.png" />
-		<a class="systemlink" href="cachelists.php">{t}Cache list{/t}</a> <b>{$cachelist.name|escape}</b>
+		{if $userid}
+			<img src="resource2/ocstyle/images/misc/32x32-search.png" width="16px" height="16px" />
+			<a class="systemlink" href="query.php">{t}Stored querie{/t}</a> <b>{$query_name|escape}</b> {* TODO: Translation Stored querie *}
+		{/if}
+		{if $cachelist}
+			<img src="resource2/ocstyle/images/misc/16x16-list.png" />
+			<a class="systemlink" href="cachelists.php">{t}Cache list{/t}</a> <b>{$cachelist.name|escape}</b>
 		{if $cachelist.bookmarked}<a href="mylists.php#bookmarks"><img src="resource2/{$opt.template.style}/images/viewcache/cache-rate.png" title="{t}I have bookmarked this list.{/t}" /></a>{/if}
 		{if $cachelist.watched_by_me}<img src="resource2/{$opt.template.style}/images/viewcache/16x16-watch.png" title="{t}I am watching this list.{/t}" />{/if}
 		{if $cachelist.user_id != $login.userid}{t}by{/t} <a href="viewprofile.php?userid={$cachelist.user_id}">{$cachelist.username|escape}</a>{elseif $cachelist.visibility<=1}({if $cachelist.password}<a class="jslink" onclick="cl = getElementById('sharelist_{$cachelist.id}'); cl.style.display = (cl.style.display=='none'?'block':'none'); getElementById('permalink_text_{$cachelist.id}').select();" {if $cachelist.user_id==$login.userid}title="{t}List has password; click here to share it{/t}"{/if} >{t}private{/t} <img src="resource2/{$opt.template.style}/images/action/18x16-offer.png" /></a>{else}{t}private{/t}{/if}){/if}
@@ -23,6 +28,7 @@
 		{if $login.userid}[<a class="systemlink" href="cachelist.php?id={$cachelist.id}&{if $cachelist.watched_by_me}dont{/if}watch">{if $cachelist.watched_by_me}{t}don't watch{/t}{else}{t}watch{/t}{/if}</a>]{/if}
 		{if $login.userid && !$cachelist.bookmarked && $cachelist.user_id!=$login.userid}[<a class="systemlink" href="cachelist.php?id={$cachelist.id}&key={$cachelist_pw|urlencode}&bookmark">{t}bookmark{/t}</a>]{/if}
 		{if $login.userid && $cachelist.bookmarked && $cachelist.user_id!=$login.userid}[<a class="systemlink" href="cachelist.php?id={$cachelist.id}&unbookmark">{t}unbookmark{/t}</a>]{/if}
+		{/if}
 	</p>
 		<div id="sharelist_{$cachelist.id}" class="cachelist-popup mapboxframe mapboxshadow" style="display:none" >
 			<table>
@@ -106,21 +112,71 @@
 			<td colspan="2" style="padding-left: 0px; padding-right: 0px;">
 				<table class="searchtable" border="0" cellspacing="0" cellpadding="0" width="98.5%">
 					<tr>
-					<th width="18">&nbsp;#&nbsp;</th>
-					<th width="45">{$distanceunit|escape}</th>
-					<th width="32">{t}Type{/t}</th>
-					<th width="46">&nbsp;{t}D/T{/t}</th>
-					<th width="460">{t}Name{/t}</th>
-					<th width="48">&nbsp;</th>
-					<th width="106">{if $displayownlogs}{t}Own logs{/t}{else}{t}Last logs{/t}{/if}</th>
+					<th width="10">&nbsp;</th>
+					<th width="40">
+						{if $bydistance}
+							<a href="search.php?queryid={$queryid}&showresult=1&sortby=bydistance&sortorder=ASC{if $startat}&startat={$startat}{/if}{if $sbycreated}&bycreated=true{/if}">
+							{else}<a href="search.php?queryid={$queryid}&showresult=1&sortby=bydistance&sortorder=DESC{if $startat}&startat={$startat}{/if}{if $sbycreated}&bycreated=true{/if}">
+						{/if}
+						{$distanceunit|escape}
+						{if $sortby=='bydistance'}
+							{if $sortorder=='DESC'}&#x25B2;{else}&#x25BC;{/if}
+						{/if}</a>
+					</th>
+					<th width="40">{t}Type{/t}</th>
+					<th width="25">&nbsp;{t}D{/t}</th>
+					<th width="28">&nbsp;{t}T{/t}</th>
+					<th width="450" colspan="2">
+						{if $byname}
+							<a href="search.php?queryid={$queryid}&showresult=1&sortby=byname&sortorder=ASC{if $startat}&startat={$startat}{/if}{if $sbycreated}&bycreated=true{/if}">
+							{else}<a href="search.php?queryid={$queryid}&showresult=1&sortby=byname&sortorder=DESC{if $startat}&startat={$startat}{/if}{if $sbycreated}&bycreated=true{/if}">
+						{/if}
+						{t}Name{/t}
+						{if $sortby=='byname'}
+							{if $sortorder=='DESC'}&#x25B2;{else}&#x25BC;{/if}
+						{/if}</a>
+					</th>
+					<th width="90">
+						{if $sbycreated}
+							{if $bycreated}
+								<a href="search.php?queryid={$queryid}&showresult=1&sortby=bycreated&sortorder=DESC{if $startat}&startat={$startat}{/if}{if $sbycreated}&bycreated=true{/if}">
+								{else}<a href="search.php?queryid={$queryid}&showresult=1&sortby=bycreated&sortorder=ASC&bycreated=true{if $startat}&startat={$startat}{/if}{if $sbycreated}&bycreated=true{/if}">
+							{/if}
+							{t}Listed since{/t}
+							{if $sortby=='bycreated'}
+								{if $sortorder=='DESC'||$sortorder==""}&#x25B2;{else}&#x25BC;{/if}
+							{/if}</a>
+						{else}
+							&nbsp;
+						{/if}
+					</th>
+					<th width="90">
+						{if $displayownlogs}
+							{if $bymylastlog}
+								<a href="search.php?queryid={$queryid}&showresult=1&sortby=bymylastlog&sortorder=DESC{if $startat}&startat={$startat}{/if}{if $sbycreated}&bycreated=true{/if}">
+								{else}<a href="search.php?queryid={$queryid}&showresult=1&sortby=bymylastlog&sortorder=ASC{if $startat}&startat={$startat}{/if}{if $sbycreated}&bycreated=true{/if}">
+							{/if}
+							{t}Own logs{/t}
+							{if $sortby=='bymylastlog'}
+								{if $sortorder=='DESC'}&#x25B2;{else}&#x25BC;{/if}
+							{/if}</a>
+						{else}
+							{if $bylastlog}
+								<a href="search.php?queryid={$queryid}&showresult=1&sortby=bylastlog&sortorder=DESC{if $startat}&startat={$startat}{/if}{if $sbycreated}&bycreated=true{/if}">
+								{else}<a href="search.php?queryid={$queryid}&showresult=1&sortby=bylastlog&sortorder=ASC{if $startat}&startat={$startat}{/if}{if $sbycreated}&bycreated=true{/if}">
+							{/if}
+							{t}Last logs{/t}
+							{if $sortby=='bylastlog'}
+								{if $sortorder=='DESC'}&#x25B2;{else}&#x25BC;{/if}
+							{/if}</a>
+						{/if}
+					</th>
 					</tr>
 					<tr><td></td></tr>
 					<!--a-->
-					{assign var=position value=$startat+1}
 					{foreach from=$caches item=cache}
 						{cycle assign=listcolor values="search_listcolor1,search_listcolor2"}
 						{include file="search.result.caches.row.tpl"}
-						{assign var=position value=$position+1}
 					{/foreach}
 					<!--z-->
 				</table>


### PR DESCRIPTION
- added possibility on search.php to sort search result by distance, name, created_date and mylastlog or lastlog. Titel of some rows are clickable: sort by distance,name(asc) and created_date,mylastlog,lastlog(desc) first (after a second click on the rowtitel: other way round).
- added name of Stored querie to "cachelist box" in top of search results

updates #865