### PR TITLE
removed redundancy from cronjob path / made it consistent for all jobs

### DIFF
--- a/htdocs/util2/cron/modules/autoarchive_caches.class.php
+++ b/htdocs/util2/cron/modules/autoarchive_caches.class.php
@@ -7,11 +7,7 @@
  *  Automatic archiving of disabled caches
  ***************************************************************************/
 
-require_once(__DIR__ . '/../../../lib2/logic/cache.class.php');
-require_once(__DIR__ . '/../../../lib2/logic/cachelog.class.php');
-
 checkJob(new autoarchive());
-
 
 class autoarchive
 {

--- a/htdocs/util2/cron/modules/cache_location.class.php
+++ b/htdocs/util2/cron/modules/cache_location.class.php
@@ -10,8 +10,6 @@
  *
  ***************************************************************************/
 
-require_once(__DIR__ . '/../../../lib2/logic/gis.class.php');
-
 checkJob(new cache_location());
 
 class cache_location

--- a/htdocs/util2/cron/modules/cache_npa_areas.class.php
+++ b/htdocs/util2/cron/modules/cache_npa_areas.class.php
@@ -10,8 +10,6 @@
  *
  ***************************************************************************/
 
-require_once(__DIR__ . '/../../../lib2/logic/gis.class.php');
-
 checkJob(new cache_npa_areas());
 
 class cache_npa_areas

--- a/htdocs/util2/cron/modules/geokrety.class.php
+++ b/htdocs/util2/cron/modules/geokrety.class.php
@@ -12,7 +12,6 @@
 
 checkJob(new geokrety());
 
-
 class geokrety
 {
     public $name = 'geokrety';

--- a/htdocs/util2/cron/modules/maillog.class.php
+++ b/htdocs/util2/cron/modules/maillog.class.php
@@ -9,7 +9,6 @@
 
 checkJob(new maillog());
 
-
 class maillog
 {
     public $name = 'maillog';

--- a/htdocs/util2/cron/modules/sitemaps.class.php
+++ b/htdocs/util2/cron/modules/sitemaps.class.php
@@ -8,8 +8,6 @@
  *  And send ping to search engines
  ***************************************************************************/
 
-require_once($opt['rootpath'] . 'lib2/logic/sitemapxml.class.php');
-
 checkJob(new sitemaps());
 
 class sitemaps

--- a/htdocs/util2/cron/runcron.php
+++ b/htdocs/util2/cron/runcron.php
@@ -12,7 +12,7 @@
  ***************************************************************************/
 
 $opt['rootpath'] = __DIR__ . '/../../';
-require(__DIR__ . '/../../lib2/cli.inc.php');
+require($opt['rootpath'] . 'lib2/cli.inc.php');
 
 // test for user who runs the cronjob
 $processUser = posix_getpwuid(posix_geteuid());
@@ -34,7 +34,7 @@ if ($process_sync->Enter()) {
         }
     }
 
-    $modules_dir = __DIR__ . '/../../util2/cron/modules/';
+    $modules_dir = $opt['rootpath'] . 'util2/cron/modules/';
     $param = count($argv) > 1 ? $argv[1] : '';
 
     if ($param != '' && substr($param, 0, 1) != '-' && !strstr('/', $param)) {


### PR DESCRIPTION
* Redundancy is always evil. :)
* Made the include statements consistent for all cronjobs.
* If the cronjob files are moved somewhere else, only one line of code needs to me modified => more robust.

If you don't like the `$opt['rootpath']` variable name, any other variable name would do as well. (Though "rootpath" so far has been the term used for this throughout the whole OC code).
