### PR TITLE
fixed replicate-delete of locked/hidden caches

### DIFF
--- a/htdocs/util2/cron/modules/replicate.class.php
+++ b/htdocs/util2/cron/modules/replicate.class.php
@@ -25,6 +25,7 @@ class replicate
             $hidden_caches = file_get_contents($opt['cron']['replicate']['delete_hidden_caches']['url']);
             $hc = explode("\n", trim($hidden_caches));
             $hc_imploded_and_escaped = "'" . implode("','", array_map('sql_escape', $hc)) . "'";
+            sql("SET @allowdelete = 1");
             sql("DELETE FROM `caches` WHERE `wp_oc` IN (" . $hc_imploded_and_escaped . ")");
             // All dependent data in other tables is deleted via trigger.
         }


### PR DESCRIPTION
This should mute the latest database error messages from test server. It's an old bug, not related to refactoring, and I wonder why it did not appear earlier.

Have temporarily disabled runcron.php on the test server.