### PR TITLE
migrate developer systems to utf8mb4 charset

### DIFF
--- a/htdocs/config2/settings-dev.inc.php
+++ b/htdocs/config2/settings-dev.inc.php
@@ -62,6 +62,9 @@ $opt['db']['error']['subject'] = 'sql_error';
  */
 $opt['debug'] = DEBUG_DEVELOPER | DEBUG_SQLDEBUGGER | DEBUG_TRANSLATE | DEBUG_FORCE_TRANSLATE;
 
+// database charset
+$opt['charset']['mysql'] = 'utf8mb4';
+
 // node options
 // see settings-dist.inc.php for known node IDs
 $opt['logic']['node']['id'] = 4;


### PR DESCRIPTION
Now that all developers use MySQL or MariaDB 5.5 or higher, the charset can globally be switched to utf8mb4. This is necessary to store full Unicode strings in the database (while the old "utf8" charset can handle only U+0000 to U+FFFF). The productive and test system already use utf8mb4.

If your OC database is utf8, the next `dbupdate` run will migrate it to utf8mb4.