### PR TITLE
add symfony console and phpcs wrapper command

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-require __DIR__.'/../vendor/autoload.php';
+require __DIR__.'/../htdocs/vendor/autoload.php';
 
 use Oc\Console\Command\CodeSnifferCommand;
 use Symfony\Component\Console\Application;

--- a/htdocs/bin/console
+++ b/htdocs/bin/console
@@ -1,0 +1,11 @@
+#!/usr/bin/env php
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+
+use Oc\Console\Command\CodeSnifferCommand;
+use Symfony\Component\Console\Application;
+
+$application = new Application();
+$application->add(new CodeSnifferCommand());
+$application->run();

--- a/htdocs/composer.json
+++ b/htdocs/composer.json
@@ -7,12 +7,15 @@
     "smarty/smarty": "~2.6",
     "symfony/dependency-injection": "~2.6",
     "symfony/yaml": "~2.6",
-    "symfony/config": "~2.6"
+    "symfony/config": "~2.6",
+    "symfony/console": "^2.8",
+    "symfony/process": "^2.8"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.*",
     "behat/mink": "1.7.*",
-    "behat/mink-goutte-driver": "1.2.*"
+    "behat/mink-goutte-driver": "1.2.*",
+    "squizlabs/php_codesniffer": "^2.6"
   },
   "autoload": {
     "psr-4": {

--- a/htdocs/composer.lock
+++ b/htdocs/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "72be2038760c19b3f2b74ec0eac52dc2",
-    "content-hash": "782debc746fe2940dcd4f30b573a0b07",
+    "hash": "81da01cb3e74b7129f34c02be0d756ba",
+    "content-hash": "4b2a2b7bb75447e978f9aac764dbff0a",
     "packages": [
         {
             "name": "ezyang/htmlpurifier",
@@ -156,6 +156,66 @@
             "time": "2016-04-20 18:52:26"
         },
         {
+            "name": "symfony/console",
+            "version": "v2.8.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "48221d3de4dc22d2cd57c97e8b9361821da86609"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/48221d3de4dc22d2cd57c97e8b9361821da86609",
+                "reference": "48221d3de4dc22d2cd57c97e8b9361821da86609",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.1|~3.0.0",
+                "symfony/process": "~2.1|~3.0.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-04-26 12:00:47"
+        },
+        {
             "name": "symfony/dependency-injection",
             "version": "v2.8.5",
             "source": {
@@ -265,6 +325,114 @@
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
             "time": "2016-04-12 18:09:53"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "1289d16209491b584839022f29257ad859b8532d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/1289d16209491b584839022f29257ad859b8532d",
+                "reference": "1289d16209491b584839022f29257ad859b8532d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-01-20 09:13:37"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v2.8.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "1276bd9be89be039748cf753a2137f4ef149cd74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/1276bd9be89be039748cf753a2137f4ef149cd74",
+                "reference": "1276bd9be89be039748cf753a2137f4ef149cd74",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-04-14 15:22:22"
         },
         {
             "name": "symfony/yaml",
@@ -1660,6 +1828,84 @@
             "time": "2015-06-21 13:59:46"
         },
         {
+            "name": "squizlabs/php_codesniffer",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "1bcdf03b068a530ac1962ce671dead356eeba43b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1bcdf03b068a530ac1962ce671dead356eeba43b",
+                "reference": "1bcdf03b068a530ac1962ce671dead356eeba43b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "scripts/phpcs",
+                "scripts/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "CodeSniffer.php",
+                    "CodeSniffer/CLI.php",
+                    "CodeSniffer/Exception.php",
+                    "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
+                    "CodeSniffer/Report.php",
+                    "CodeSniffer/Reporting.php",
+                    "CodeSniffer/Sniff.php",
+                    "CodeSniffer/Tokens.php",
+                    "CodeSniffer/Reports/",
+                    "CodeSniffer/Tokenizers/",
+                    "CodeSniffer/DocGenerators/",
+                    "CodeSniffer/Standards/AbstractPatternSniff.php",
+                    "CodeSniffer/Standards/AbstractScopeSniff.php",
+                    "CodeSniffer/Standards/AbstractVariableSniff.php",
+                    "CodeSniffer/Standards/IncorrectPatternException.php",
+                    "CodeSniffer/Standards/Generic/Sniffs/",
+                    "CodeSniffer/Standards/MySource/Sniffs/",
+                    "CodeSniffer/Standards/PEAR/Sniffs/",
+                    "CodeSniffer/Standards/PSR1/Sniffs/",
+                    "CodeSniffer/Standards/PSR2/Sniffs/",
+                    "CodeSniffer/Standards/Squiz/Sniffs/",
+                    "CodeSniffer/Standards/Zend/Sniffs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2016-04-03 22:58:34"
+        },
+        {
             "name": "symfony/browser-kit",
             "version": "v3.0.5",
             "source": {
@@ -1824,65 +2070,6 @@
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
             "time": "2016-04-12 18:09:53"
-        },
-        {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "1289d16209491b584839022f29257ad859b8532d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/1289d16209491b584839022f29257ad859b8532d",
-                "reference": "1289d16209491b584839022f29257ad859b8532d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2016-01-20 09:13:37"
         }
     ],
     "aliases": [],

--- a/htdocs/src/Oc/Console/Command/AbstractCommand.php
+++ b/htdocs/src/Oc/Console/Command/AbstractCommand.php
@@ -1,0 +1,32 @@
+<?php
+/***************************************************************************
+ *  For license information see doc/license.txt
+ *
+ *  Unicode Reminder メモ
+ ***************************************************************************/
+
+namespace Oc\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+
+class AbstractCommand extends Command
+{
+    const CODE_SUCCESS  = 0;
+    const CODE_ERROR    = 1;
+    const CODE_WARNING  = 2;
+
+    /**
+     * @var string
+     */
+    protected $rootPath;
+
+    /**
+     * @param string|null $name
+     */
+    public function __construct($name = null)
+    {
+        parent::__construct($name);
+
+        $this->rootPath = realpath(__DIR__ . '/../../../../');
+    }
+}

--- a/htdocs/src/Oc/Console/Command/CodeSnifferCommand.php
+++ b/htdocs/src/Oc/Console/Command/CodeSnifferCommand.php
@@ -1,0 +1,52 @@
+<?php
+/***************************************************************************
+ *  For license information see doc/license.txt
+ *
+ *  Unicode Reminder メモ
+ ***************************************************************************/
+
+namespace Oc\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+class CodeSnifferCommand extends AbstractCommand
+{
+    const COMMAND_NAME      = 'code:sniff';
+
+    const OPTION_DRY_RUN    = 'dry';
+    const OPTION_FIX        = 'fix';
+
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName(self::COMMAND_NAME)
+            ->setDescription('Wrapper for phpcs');
+
+        $this->addOption(self::OPTION_DRY_RUN, 'd', InputOption::VALUE_NONE, 'Dry run the command');
+        $this->addOption(self::OPTION_FIX, 'f', InputOption::VALUE_NONE, 'Fix errors that can be fixed automatically');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $command = $input->getOption(self::OPTION_FIX) ? 'phpcbf' : 'phpcs';
+        $cmd = 'vendor/bin/'.($command).' --standard=PSR2 -p -n --colors src/';
+
+        if ($input->getOption(self::OPTION_DRY_RUN)) {
+            $output->writeln($cmd);
+
+            return self::CODE_SUCCESS;
+        }
+
+        $process = new Process($cmd, $this->rootPath, null, null, 9600);
+        $process->run(function ($type, $buffer) {
+            echo $buffer;
+        });
+
+        return $process->getExitCode();
+    }
+}

--- a/provision.sh
+++ b/provision.sh
@@ -29,7 +29,7 @@ firewall-cmd --reload
 yum -y install php epel-release php-devel ImageMagick-devel ImageMagick gcc
 yum -y install php-gd php-odbc php-pear php-xml php-xmlrpc php-mbstring
 yum -y install php-snmp php-soap curl curl-devel php-mysql php-pdo php-pecl-zip
-yum -y install vim vim-common mutt mlocate man-pages zip mod_ssl
+yum -y install vim vim-common mutt mlocate man-pages zip mod_ssl patch
 
 
 label "Adjust Apache and MariaDB configuration"


### PR DESCRIPTION
This adds the symfony console component as preparation for migrating legacy cli scripts e.g. cron scripts
As an example and useful tool, which should be integrated in continuous integration (CI) later, I've added a wrapper command for `phpcs`

**Prerequisites:**
current VM was missing the `patch` command. To test this code you'll have to `sudo yum install patch` , `provison.sh` is adjusted in this commit. Remember to run `composer install`

**How to use:**
`cd /var/www/html/htdocs`
run
`bin/console` to get an overview of possible commands
run
`bin/console code:sniff` this will test the `src/` folder against PSR-2 rules.
![bildschirmfoto 2016-05-19 um 21 46 48](https://cloud.githubusercontent.com/assets/6177906/15408708/d5c82502-1e11-11e6-9c1b-2b4eb8c463c8.png)
violations marked with `[x]` can be fixed automatically.
run
`bin/console code:sniff -f` to fix them

**How to add your own commands**
- Create the command in src/Oc/Console/Command
- register your command in `bin/console` by adding it to the application e.g. `$application->add(new CodeSnifferCommand());`