### PR TITLE
Feature/improve codesniffer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,3 +1,20 @@
+build:
+    environment:
+        php:
+            version: 5.6
+    dependencies:
+        before:
+            - cd htdocs/
+            - composer install
+            - cd ..
+    tests:
+        override:
+            -
+                command: './bin/console code:sniff --xml'
+                analysis:
+                    file: './tests/cs-data'
+                    format: 'php-cs-checkstyle'
+
 filter:
     paths:
         - 'htdocs/*'
@@ -12,110 +29,5 @@ filter:
         - 'htdocs/vendor/*'
 
 checks:
-    php:
-        fix_php_opening_tag: false
-        remove_php_closing_tag: false
-        avoid_closing_tag: true
-        one_class_per_file: true
-        side_effects_or_types: true
-        no_mixed_inline_html: false
-        require_braces_around_control_structures: true
-        php5_style_constructor: true
-        no_global_keyword: true
-        avoid_usage_of_logical_operators: true
-        psr2_class_declaration: true
-        no_underscore_prefix_in_properties: true
-        no_underscore_prefix_in_methods: true
-        blank_line_after_namespace_declaration: true
-        single_namespace_per_use: true
-        psr2_switch_declaration: true
-        psr2_control_structure_declaration: true
-        avoid_superglobals: false
-        security_vulnerabilities: true
-        no_exit: false
-        uppercase_constants: true
-        return_doc_comments: true
-        remove_extra_empty_lines: true
-        properties_in_camelcaps: true
-        prefer_while_loop_over_for_loop: true
-        phpunit_assertions: true
-        parameter_doc_comments: true
-        optional_parameters_at_the_end: true
-        no_long_variable_names:
-            maximum: '20'
-        no_goto: true
-        function_in_camel_caps: true
-        fix_use_statements:
-            remove_unused: true
-            preserve_multiple: false
-            preserve_blanklines: false
-            order_alphabetically: true
-        encourage_single_quotes: true
-        encourage_postdec_operator: true
-        classes_in_camel_caps: true
-        avoid_multiple_statements_on_same_line: true
-        avoid_fixme_comments: true
-
-    javascript:
-        valid_typeof: true
-        yoda:
-            setting: 'Disallow Yoda Conditions'
-        wrap_iife: true
-        no_use_before_define: true
-        no_unused_vars: true
-        no_unreachable: true
-        no_undef: true
-        no_trailing_spaces: true
-        no_space_before_semi: true
-        no_shadow: true
-        no_self_compare: true
-        no_script_url: true
-        no_return_assign: true
-        no_reserved_keys: true
-        no_redeclare: true
-        no_mixed_spaces_and_tabs: true
-        no_loop_func: true
-        no_irregular_whitespace: true
-
-coding_style:
-    php:
-        spaces:
-            around_operators:
-                concatenation: false
-            ternary_operator:
-                before_condition: true
-                after_condition: true
-                before_alternative: true
-                after_alternative: true
-            other:
-                after_type_cast: false
-        braces:
-            classes_functions:
-                class: new-line
-                function: new-line
-                closure: end-of-line
-            if:
-                opening: end-of-line
-            for:
-                opening: end-of-line
-            while:
-                opening: end-of-line
-            do_while:
-                opening: end-of-line
-            switch:
-                opening: end-of-line
-            try:
-                opening: end-of-line
-        upper_lower_casing:
-            keywords:
-                general: lower
-            constants:
-                true_false_null: lower
-
-tools:
-    php_code_sniffer:
-        config:
-            standard: "PSR2"
-    php_cs_fixer:
-        enabled: true
-        config: { level: psr2 }
+    php: true
+    javascript: true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,6 +32,7 @@ Vagrant.configure(2) do |config|
 	config.vm.synced_folder "doc/", 	"/var/www/html/doc",	type: SYNCED_FOLDER_TYPE
 	config.vm.synced_folder "local/", 	"/var/www/html/local",	type: SYNCED_FOLDER_TYPE
 	config.vm.synced_folder "sql/", 	"/var/www/html/sql",	type: SYNCED_FOLDER_TYPE
+	config.vm.synced_folder "tests/", 	"/var/www/html/tests",	type: SYNCED_FOLDER_TYPE
 	if SYNCED_FOLDER_TYPE == "nfs"
 		config.nfs.map_uid = Process.uid
 		config.nfs.map_gid = Process.gid

--- a/bin/provision.sh
+++ b/bin/provision.sh
@@ -221,8 +221,9 @@ else
 	exit 1;
 fi
 
-echo "export PS1='\[\033[1;33m\]OCdev:\[\033[m\w\$ '" >> /home/vagrant/.bashrc
-echo "cd /var/www/html/htdocs/" >> /home/vagrant/.bashrc
+echo "export PS1='\[\033[38;5;11m\]OCdev:\[$(tput sgr0)\]\[\033[38;5;15m\] \[$(tput sgr0)\]\[\033[38;5;14m\]\w\[$(tput sgr0)\]\[\033[38;5;15m\]\\$ \[$(tput sgr0)\]'" >> /home/vagrant/.bashrc
+echo "cd /var/www/html/" >> /home/vagrant/.bashrc
 echo "alias la='ls -alh'" >> /home/vagrant/.bashrc
+echo "alias ..='cd ..'" >> /home/vagrant/.bashrc
 
 label "All done, have fun."

--- a/htdocs/composer.json
+++ b/htdocs/composer.json
@@ -15,7 +15,8 @@
     "phpunit/phpunit": "4.8.*",
     "behat/mink": "1.7.*",
     "behat/mink-goutte-driver": "1.2.*",
-    "squizlabs/php_codesniffer": "^2.6"
+    "squizlabs/php_codesniffer": "^2.6",
+    "fig-r/psr2r-sniffer": "^0.3.0"
   },
   "autoload": {
     "psr-4": {

--- a/htdocs/composer.lock
+++ b/htdocs/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "81da01cb3e74b7129f34c02be0d756ba",
-    "content-hash": "4b2a2b7bb75447e978f9aac764dbff0a",
+    "hash": "fc8b2bb73316a296d577e9a5d6fc3230",
+    "content-hash": "7edc3a94d5d109e9ea2b516c9b0b2d3f",
     "packages": [
         {
             "name": "ezyang/htmlpurifier",
@@ -756,6 +756,48 @@
                 "scraper"
             ],
             "time": "2015-11-05 12:58:44"
+        },
+        {
+            "name": "fig-r/psr2r-sniffer",
+            "version": "0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig-rectified/psr2r-sniffer.git",
+                "reference": "a152ec876bae77c918cc940944daf2e1baa14a76"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig-rectified/psr2r-sniffer/zipball/a152ec876bae77c918cc940944daf2e1baa14a76",
+                "reference": "a152ec876bae77c918cc940944daf2e1baa14a76",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.16",
+                "squizlabs/php_codesniffer": "~2.3"
+            },
+            "bin": [
+                "bin/tokenize",
+                "bin/sniff"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PSR2R\\": "PSR2R"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Scherer",
+                    "homepage": "http://www.dereuromark.de",
+                    "role": "Contributor"
+                }
+            ],
+            "description": "Code-Sniffer, Auto-Fixer and Tokenizer for PSR2-R",
+            "time": "2016-04-13 14:06:16"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/htdocs/src/Oc/Console/Command/CodeSnifferCommand.php
+++ b/htdocs/src/Oc/Console/Command/CodeSnifferCommand.php
@@ -14,11 +14,16 @@ use Symfony\Component\Process\Process;
 
 class CodeSnifferCommand extends AbstractCommand
 {
-    const COMMAND_NAME      = 'code:sniff';
+    const COMMAND_NAME = 'code:sniff';
 
-    const OPTION_DRY_RUN    = 'dry';
-    const OPTION_FIX        = 'fix';
+    const OPTION_DRY_RUN = 'dry';
+    const OPTION_FIX = 'fix';
+    const OPTION_XML = 'xml';
+    const OPTION_DIR = 'dir';
 
+    /**
+     * @return void
+     */
     protected function configure()
     {
         parent::configure();
@@ -27,14 +32,28 @@ class CodeSnifferCommand extends AbstractCommand
             ->setName(self::COMMAND_NAME)
             ->setDescription('Wrapper for phpcs');
 
-        $this->addOption(self::OPTION_DRY_RUN, 'd', InputOption::VALUE_NONE, 'Dry run the command');
+        $this->addOption(self::OPTION_DRY_RUN, 't', InputOption::VALUE_NONE, 'Dry run the command');
         $this->addOption(self::OPTION_FIX, 'f', InputOption::VALUE_NONE, 'Fix errors that can be fixed automatically');
+        $this->addOption(self::OPTION_XML, 'x', InputOption::VALUE_NONE, 'Write to checkstyle xml file');
+        $this->addOption(self::OPTION_DIR, 'd', InputOption::VALUE_REQUIRED, 'Specify directory or file to check');
     }
 
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     *
+     * @return int|null
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $command = $input->getOption(self::OPTION_FIX) ? 'phpcbf' : 'phpcs';
-        $cmd = 'vendor/bin/'.($command).' --standard=PSR2 -p -n --colors src/';
+        $cmd = 'vendor/bin/' . ($command) . ' -s --standard=../tests/ruleset.xml';
+        if ($input->getOption(self::OPTION_DIR)) {
+            $cmd .= ' ' . $input->getOption(self::OPTION_DIR);
+        }
+        if ($input->getOption(self::OPTION_XML)) {
+            $cmd .= ' --report=checkstyle --report-file=../tests/cs-data';
+        }
 
         if ($input->getOption(self::OPTION_DRY_RUN)) {
             $output->writeln($cmd);

--- a/tests/ruleset.xml
+++ b/tests/ruleset.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<ruleset name="Opencaching">
+
+    <!--
+       The name attribute of the ruleset tag is displayed
+       when running PHP_CodeSniffer with the -v command line
+       argument. The description tag below is not displayed anywhere
+       except in this file, so it can contain information for
+       developers who may change this file in the future.
+    -->
+    <description>Opencaching coding standard</description>
+
+    <!--
+        If no files or directories are specified on the command line
+        your custom standard can specify what files should be checked
+        instead.
+
+        Note that specifying any file or directory path
+        on the command line will ignore all file tags.
+     -->
+    <file>../htdocs/</file>
+    <file>../local/</file>
+    <file>../bin/</file>
+    <file>./Frontend/</file>
+    <file>./Modules/</file>
+
+    <exclude-pattern>*/cache/*</exclude-pattern>
+    <exclude-pattern>*/cache2/*</exclude-pattern>
+    <exclude-pattern>*/images/*</exclude-pattern>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+
+    <exclude-pattern>*/htdocs/okapi/*</exclude-pattern>
+    <exclude-pattern>*/htdocs/resource2/tinymce/*</exclude-pattern>
+    <exclude-pattern>*/htdocs/templates2/*</exclude-pattern>
+
+    <!--
+    You can hard-code command line values into your custom standard.
+     -->
+    <arg value="p"/>
+    <arg value="n"/>
+    <arg name="colors"/>
+
+    <!--
+       You can hard-code custom php.ini settings into your custom standard.
+       The following tag sets the memory limit to 64M.
+    -->
+    <ini name="memory_limit" value="256M"/>
+    <ini name="error_reporting" value="(E_ALL &amp; ~E_NOTICE)"/>
+
+    <!--
+       Include all sniffs in the PSR2 standard. Note that the
+       path to the standard does not have to be specified as the
+       PSR2 standard exists inside the PHP_CodeSniffer install
+       directory.
+    -->
+    <rule ref="PSR2"/>
+
+    <rule ref="../htdocs/vendor/fig-r/psr2r-sniffer/PSR2R/ruleset.xml">
+        <exclude name="PSR2R.Classes.BraceOnSameLine"/>
+        <exclude name="PSR2R.WhiteSpace.TabAndSpace"/>
+        <exclude name="PSR2R.WhiteSpace.TabIndent"/>
+        <exclude name="PSR2R.WhiteSpace.EmptyEnclosingLine"/>
+    </rule>
+
+    <rule ref="Squiz.Commenting.FunctionComment">
+        <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
+        <exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType"/>
+        <exclude name="Squiz.Commenting.FunctionComment.InvalidReturn"/>
+    </rule>
+
+</ruleset>


### PR DESCRIPTION
see http://forum.opencaching.de/index.php?topic=4570.0
I also added some rules for docblocks.
There is now a `ruleset.xml` in the `tests` folder, so you may setup it up as an inspection in PhpStorm as described [here](https://www.jetbrains.com/help/phpstorm/2016.1/using-php-code-sniffer-tool.html)

I also removed the checks settings for scrutinizer to fall back to the defaults, because some may interfere with our code styles and I found no documentation about them. One will have to use the settings tool inside scrutinizer to verify which one to enable or disable.