### PR TITLE
removed blank lines from .loc files

### DIFF
--- a/htdocs/lib2/search/search.loc.inc.php
+++ b/htdocs/lib2/search/search.loc.inc.php
@@ -22,8 +22,7 @@ function search_output()
     $locHead = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><loc version="1.0" src="' . $server_domain . '">' . "\n";
 
     $locLine =
-        '
-<waypoint>
+        '<waypoint>
     <name id="{waypoint}"><![CDATA[{archivedflag}{name} by {username}]]></name>
     <coord lat="{lat}" lon="{lon}"/>
     <type>Geocache</type>


### PR DESCRIPTION
When downloading search results in LOC format, blank lines were inserted between the waypoint records. This is unusual in XML files, and GSAK also does not insert blank lines; therefore I think they should be discarded.