### PR TITLE
Do not clear data_license information when stripping private data.

### DIFF
--- a/local/devel/strip_private_data.php
+++ b/local/devel/strip_private_data.php
@@ -88,8 +88,10 @@ sql(
             `watchmail_hour`=0, `watchmail_nextmail`='', `watchmail_day`=0,
             `activation_code`='', `statpic_logo`=0, `statpic_text`='Opencaching',
             `no_htmledit_flag`=0, `notify_radius`=0, `notify_oconly`=1, `language`='DE',
-            `language_guessed`=1, `domain`=NULL, `admin`=0, `data_license`=0,
+            `language_guessed`=1, `domain`=NULL, `admin`=0,
             `description`='', `desc_htmledit`=1"
+            // `data_license` setting is retained, so that all content stays tagged with
+            // correct license information.
 );
 
 echo "deleting hidden and locked caches\n";


### PR DESCRIPTION
strip_private_data.php dient dazu, eine Produktivdatenbank in eine Testdatenbank umzuwandeln (z.B. für den Testserver). Das Nullen von `user`.`data_license` führte dazu, dass die Caches anschließend z.B. beim Export per GPX oder OKAPI nicht mehr mit korrektem Lizenz-Disclaimer ausgegeben wurden.

Auf test.opencaching.de werde ich  `user`.`data_license` nochmal reimportieren.