### PR TITLE
fix garmin plugin activation

### DIFF
--- a/htdocs/garmin.php
+++ b/htdocs/garmin.php
@@ -5,6 +5,8 @@
  * Unicode Reminder メモ
  ****************************************************************************/
 
+$disable_oc_https_redirect = true;
+
 require __DIR__ . '/lib2/web.inc.php';
 require_once __DIR__ . '/lib2/logic/labels.inc.php';
 require_once __DIR__ . '/lib2/logic/cache.class.php';

--- a/htdocs/lib2/web.inc.php
+++ b/htdocs/lib2/web.inc.php
@@ -28,19 +28,21 @@ $opt['gui'] = GUI_HTML;
 require_once __DIR__ . '/common.inc.php';
 
 // enforce http or https?
-if ($opt['page']['https']['mode'] == HTTPS_DISABLED) {
-    if ($opt['page']['https']['active']) {
-        $tpl->redirect('http://' . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI']);
-    }
-    $opt['page']['force_https_login'] = false;
-} elseif ($opt['page']['https']['mode'] == HTTPS_ENFORCED) {
-    if (!$opt['page']['https']['active']) {
-        $tpl->redirect('https://' . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI']);
-    }
-    $opt['page']['force_https_login'] = true;
-} elseif (!empty($_COOKIE[$opt['session']['cookiename'] . 'https_session']) && !$opt['page']['https']['active']) {
-    // during login was https active -> session data is https only -> redirect to https
-    $tpl->redirect('https://' . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI']);
+if (!isset($disable_oc_https_redirect) || !$disable_oc_https_redirect) {
+  if ($opt['page']['https']['mode'] == HTTPS_DISABLED) {
+      if ($opt['page']['https']['active']) {
+          $tpl->redirect('http://' . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI']);
+      }
+      $opt['page']['force_https_login'] = false;
+  } elseif ($opt['page']['https']['mode'] == HTTPS_ENFORCED) {
+      if (!$opt['page']['https']['active']) {
+          $tpl->redirect('https://' . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI']);
+      }
+      $opt['page']['force_https_login'] = true;
+  } elseif (!empty($_COOKIE[$opt['session']['cookiename'] . 'https_session']) && !$opt['page']['https']['active']) {
+      // during login was https active -> session data is https only -> redirect to https
+      $tpl->redirect('https://' . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI']);
+  }
 }
 
 


### PR DESCRIPTION
PR nach Stable für direkte Freigabe.

Provisorischer Fix, damit das Garmin-Plugin wieder funktioniert - es muss unter der URL laufen, für die der Garmin-Key registriert ist, darf also nicht nach https weitergeleitet werden.  Die aktuelle URL wird direkt im Plugin-Code geprüft, d.h. wird haben darauf  keinen Einfluss. Garmin bietet leider keine neuen Keys mehr an, es ist also nicht mehr möglich, einen Key für https://www.opencaching.de zu registrieren.

Beim Aufruf von garmin.php besteht dann wieder das Problem, dass der Session-Cookie via http übertragen wird. Scheint mir aber das kleinere Übel zu sein gegenüber einem nicht funktionierenden wichtigen Feature. 