### PR TITLE
OKAPI Project update (r1366)

### DIFF
--- a/htdocs/okapi/controller.php
+++ b/htdocs/okapi/controller.php
@@ -3,9 +3,6 @@
 namespace okapi;
 
 use Exception;
-use okapi\Okapi;
-use okapi\Settings;
-use okapi\views\menu\OkapiMenu;
 
 #
 # All HTTP requests within the /okapi/ path are redirected through this

--- a/htdocs/okapi/core.php
+++ b/htdocs/okapi/core.php
@@ -20,7 +20,7 @@ use okapi\oauth\OAuthServer400Exception;
 use okapi\oauth\OAuthServerException;
 use okapi\oauth\OAuthSignatureMethod_HMAC_SHA1;
 use okapi\oauth\OAuthToken;
-use Pdo;
+use PDO;
 use PDOException;
 
 /** Return an array of email addresses which always get notified on OKAPI errors. */
@@ -716,8 +716,7 @@ class OkapiConsumer extends OAuthConsumer
 
     public function __construct($key, $secret, $name, $url, $email, $bflags=0)
     {
-        $this->key = $key;
-        $this->secret = $secret;
+        parent::__construct($key, $secret, null);
         $this->name = $name;
         $this->url = $url;
         $this->email = $email;
@@ -1105,8 +1104,8 @@ class Okapi
     public static $server;
 
     /* These two get replaced in automatically deployed packages. */
-    public static $version_number = null;
-    public static $git_revision = null;
+    public static $version_number = 1366;
+    public static $git_revision = 'f56cefa0146496096f748d06e277798b27a0a75b';
 
     private static $okapi_vars = null;
 
@@ -1362,6 +1361,7 @@ class Okapi
                 $urls = array(
                     "http://opencaching.pl/okapi/",
                     "http://www.opencaching.pl/okapi/",
+                    "https://opencaching.pl/okapi/",
                 );
                 break;
             case 'OCDE':
@@ -1390,6 +1390,7 @@ class Okapi
             case 'OCUK':
                 $urls = array(
                     "http://opencache.uk/okapi/",
+                    "https://opencache.uk/okapi/",
                 );
                 break;
             case 'OCUS':
@@ -1869,7 +1870,7 @@ class Okapi
         else
         {
             # That's a bug.
-            throw new Exception("Cannot encode as xmlmap: " + print_r($obj, true));
+            throw new Exception("Cannot encode as xmlmap: " . print_r($obj, true));
         }
     }
 

--- a/htdocs/okapi/cronjobs.php
+++ b/htdocs/okapi/cronjobs.php
@@ -622,7 +622,8 @@ class ChangeLogCheckerJob extends Cron24Job
     public function execute()
     {
         require_once($GLOBALS['rootpath']."okapi/services/replicate/replicate_common.inc.php");
-        ReplicateCommon::verify_clog_consistency();
+        $ignored_fields = array('url');
+        ReplicateCommon::verify_clog_consistency(false, $ignored_fields);
     }
 }
 

--- a/htdocs/okapi/datastore.php
+++ b/htdocs/okapi/datastore.php
@@ -2,6 +2,7 @@
 
 namespace okapi;
 
+use Exception;
 use okapi\oauth\OAuthDataStore;
 
 class OkapiDataStore extends OAuthDataStore

--- a/htdocs/okapi/facade.php
+++ b/htdocs/okapi/facade.php
@@ -29,13 +29,6 @@ namespace okapi;
 # \okapi\Facade::disable_error_handling();
 
 
-use Exception;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
-use okapi\OkapiFacadeConsumer;
-use okapi\OkapiFacadeAccessToken;
-use okapi\Cache;
-
 require_once($GLOBALS['rootpath']."okapi/core.php");
 OkapiErrorHandler::$treat_notices_as_errors = true;
 require_once($GLOBALS['rootpath']."okapi/service_runner.php");

--- a/htdocs/okapi/lib/ocpl_access_logs.php
+++ b/htdocs/okapi/lib/ocpl_access_logs.php
@@ -22,7 +22,7 @@ class OCPLAccessLogs
         // traverse PHP call stack to find out who originally called us
         // first, find first service_runner.php invocation
         // then, find previous class invocation
-        for ($i = count($trace) - 1; $i >= 0; $i--)
+        for($i = count($trace)-1; $i >= 0; $i--)
         {
             $frame = $trace[$i];
             if ($break_next && isset($frame['class']))

--- a/htdocs/okapi/services/apiref/issue.php
+++ b/htdocs/okapi/services/apiref/issue.php
@@ -2,16 +2,13 @@
 
 namespace okapi\services\apiref\issue;
 
-use Exception;
 use ErrorException;
+use okapi\BadRequest;
+use okapi\Cache;
+use okapi\InvalidParam;
 use okapi\Okapi;
 use okapi\OkapiRequest;
-use okapi\BadRequest;
 use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
-use okapi\Cache;
 use okapi\Settings;
 
 class WebService

--- a/htdocs/okapi/services/apiref/method.php
+++ b/htdocs/okapi/services/apiref/method.php
@@ -3,14 +3,14 @@
 namespace okapi\services\apiref\method;
 
 use Exception;
-use okapi\Okapi;
-use okapi\Settings;
-use okapi\OkapiRequest;
-use okapi\ParamMissing;
 use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
+use okapi\Okapi;
 use okapi\OkapiInternalConsumer;
+use okapi\OkapiInternalRequest;
+use okapi\OkapiRequest;
+use okapi\OkapiServiceRunner;
+use okapi\ParamMissing;
+use okapi\Settings;
 
 class WebService
 {

--- a/htdocs/okapi/services/apiref/method_index.php
+++ b/htdocs/okapi/services/apiref/method_index.php
@@ -2,15 +2,12 @@
 
 namespace okapi\services\apiref\method_index;
 
-use Exception;
-use okapi\Okapi;
-use okapi\OkapiRequest;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
 use okapi\Cache;
+use okapi\Okapi;
 use okapi\OkapiInternalConsumer;
 use okapi\OkapiInternalRequest;
+use okapi\OkapiRequest;
+use okapi\OkapiServiceRunner;
 
 
 class WebService

--- a/htdocs/okapi/services/apisrv/installation.php
+++ b/htdocs/okapi/services/apisrv/installation.php
@@ -2,10 +2,9 @@
 
 namespace okapi\services\apisrv\installation;
 
-use Exception;
 use okapi\Okapi;
-use okapi\Settings;
 use okapi\OkapiRequest;
+use okapi\Settings;
 
 class WebService
 {

--- a/htdocs/okapi/services/apisrv/installations.php
+++ b/htdocs/okapi/services/apisrv/installations.php
@@ -2,16 +2,11 @@
 
 namespace okapi\services\apisrv\installations;
 
-use Exception;
 use ErrorException;
-use okapi\Okapi;
-use okapi\Settings;
 use okapi\Cache;
+use okapi\Okapi;
 use okapi\OkapiRequest;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
+use okapi\Settings;
 
 class WebService
 {
@@ -27,8 +22,9 @@ class WebService
         # The list of installations is periodically refreshed by contacting OKAPI
         # repository. This method usually displays the cached version of it.
 
-        $cachekey = 'apisrv/installations';
-        $backupkey = 'apisrv/installations-backup';
+        $VERSION = "2";
+        $cachekey = 'apisrv/installations-v'.$VERSION;
+        $backupkey = 'apisrv/installations-v'.$VERSION.'-backup';
         $results = Cache::get($cachekey);
         if (!$results)
         {
@@ -93,7 +89,7 @@ class WebService
                     'site_name' => $site_name,
                     'okapi_base_url' => $okapi_base_url,
                 );
-                if ($site_url == Settings::get('SITE_URL'))
+                if (in_array($okapi_base_url, Okapi::get_allowed_base_urls()))
                     $i_was_included = true;
             }
 

--- a/htdocs/okapi/services/apisrv/stats.php
+++ b/htdocs/okapi/services/apisrv/stats.php
@@ -2,15 +2,10 @@
 
 namespace okapi\services\apisrv\stats;
 
-use Exception;
-use okapi\Okapi;
-use okapi\Db;
 use okapi\Cache;
+use okapi\Db;
+use okapi\Okapi;
 use okapi\OkapiRequest;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
 use okapi\Settings;
 
 class WebService

--- a/htdocs/okapi/services/attrs/attr_helper.inc.php
+++ b/htdocs/okapi/services/attrs/attr_helper.inc.php
@@ -3,17 +3,9 @@
 namespace okapi\services\attrs;
 
 use Exception;
-use ErrorException;
+use okapi\Cache;
 use okapi\Okapi;
 use okapi\Settings;
-use okapi\Cache;
-use okapi\OkapiRequest;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
-use okapi\OkapiLock;
-use SimpleXMLElement;
 
 
 class AttrHelper

--- a/htdocs/okapi/services/attrs/attribute.php
+++ b/htdocs/okapi/services/attrs/attribute.php
@@ -2,17 +2,12 @@
 
 namespace okapi\services\attrs\attribute;
 
-use Exception;
-use ErrorException;
-use okapi\Okapi;
-use okapi\Settings;
-use okapi\Cache;
-use okapi\OkapiRequest;
-use okapi\ParamMissing;
 use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
+use okapi\Okapi;
 use okapi\OkapiInternalRequest;
-use okapi\services\attrs\AttrHelper;
+use okapi\OkapiRequest;
+use okapi\OkapiServiceRunner;
+use okapi\ParamMissing;
 
 
 class WebService

--- a/htdocs/okapi/services/attrs/attribute_index.php
+++ b/htdocs/okapi/services/attrs/attribute_index.php
@@ -2,17 +2,11 @@
 
 namespace okapi\services\attrs\attribute_index;
 
-use Exception;
-use ErrorException;
 use ArrayObject;
 use okapi\Okapi;
-use okapi\Settings;
-use okapi\Cache;
-use okapi\OkapiRequest;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
 use okapi\OkapiInternalRequest;
+use okapi\OkapiRequest;
+use okapi\OkapiServiceRunner;
 use okapi\services\attrs\AttrHelper;
 
 

--- a/htdocs/okapi/services/attrs/attributes.php
+++ b/htdocs/okapi/services/attrs/attributes.php
@@ -2,18 +2,13 @@
 
 namespace okapi\services\attrs\attributes;
 
-use Exception;
-use ErrorException;
+use okapi\Db;
+use okapi\InvalidParam;
 use okapi\Okapi;
-use okapi\Settings;
-use okapi\Cache;
 use okapi\OkapiRequest;
 use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
 use okapi\services\attrs\AttrHelper;
-use okapi\Db;
+use okapi\Settings;
 
 
 class WebService

--- a/htdocs/okapi/services/caches/formatters/ggz.php
+++ b/htdocs/okapi/services/caches/formatters/ggz.php
@@ -2,22 +2,8 @@
 
 namespace okapi\services\caches\formatters\ggz;
 
-use okapi\Okapi;
-use okapi\Cache;
-use okapi\Settings;
 use okapi\OkapiRequest;
-use okapi\OkapiHttpResponse;
-use okapi\OkapiInternalRequest;
-use okapi\OkapiServiceRunner;
-use okapi\BadRequest;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiAccessToken;
 use okapi\OkapiZIPHttpResponse;
-use okapi\services\caches\search\SearchAssistant;
-
-use \ZipArchive;
-use \Exception;
 
 require_once($GLOBALS['rootpath']."okapi/services/caches/formatters/gpx.php");
 

--- a/htdocs/okapi/services/caches/formatters/gpx.php
+++ b/htdocs/okapi/services/caches/formatters/gpx.php
@@ -2,20 +2,18 @@
 
 namespace okapi\services\caches\formatters\gpx;
 
-use okapi\Okapi;
-use okapi\OkapiRequest;
-use okapi\OkapiHttpResponse;
-use okapi\OkapiInternalRequest;
-use okapi\OkapiServiceRunner;
 use okapi\BadRequest;
-use okapi\ParamMissing;
-use okapi\OkapiAccessToken;
-use okapi\InvalidParam;
-use okapi\services\caches\search\SearchAssistant;
-use okapi\OkapiInternalConsumer;
 use okapi\Db;
-use okapi\Settings;
+use okapi\InvalidParam;
+use okapi\Okapi;
+use okapi\OkapiHttpResponse;
+use okapi\OkapiInternalConsumer;
+use okapi\OkapiInternalRequest;
+use okapi\OkapiRequest;
+use okapi\OkapiServiceRunner;
+use okapi\ParamMissing;
 use okapi\services\attrs\AttrHelper;
+use okapi\Settings;
 
 class WebService
 {

--- a/htdocs/okapi/services/caches/geocache.php
+++ b/htdocs/okapi/services/caches/geocache.php
@@ -2,15 +2,14 @@
 
 namespace okapi\services\caches\geocache;
 
-use okapi\OkapiInternalRequest;
-use okapi\OkapiServiceRunner;
-use okapi\Okapi;
 use okapi\Db;
-use okapi\Settings;
-use okapi\OkapiRequest;
-use okapi\ParamMissing;
 use okapi\InvalidParam;
-use okapi\services\caches\search\SearchAssistant;
+use okapi\Okapi;
+use okapi\OkapiInternalRequest;
+use okapi\OkapiRequest;
+use okapi\OkapiServiceRunner;
+use okapi\ParamMissing;
+use okapi\Settings;
 
 class WebService
 {

--- a/htdocs/okapi/services/caches/geocaches.php
+++ b/htdocs/okapi/services/caches/geocaches.php
@@ -2,20 +2,18 @@
 
 namespace okapi\services\caches\geocaches;
 
-use Exception;
 use ArrayObject;
-use okapi\Okapi;
-use okapi\Db;
-use okapi\Settings;
-use okapi\OkapiRequest;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
+use Exception;
 use okapi\BadRequest;
+use okapi\Db;
+use okapi\InvalidParam;
+use okapi\Okapi;
 use okapi\OkapiInternalRequest;
+use okapi\OkapiRequest;
 use okapi\OkapiServiceRunner;
-use okapi\OkapiAccessToken;
-use okapi\services\caches\search\SearchAssistant;
+use okapi\ParamMissing;
 use okapi\services\attrs\AttrHelper;
+use okapi\Settings;
 
 class WebService
 {
@@ -243,7 +241,13 @@ class WebService
                     case 'type': $entry['type'] = Okapi::cache_type_id2name($row['type']); break;
                     case 'status': $entry['status'] = Okapi::cache_status_id2name($row['status']); break;
                     case 'needs_maintenance': $entry['needs_maintenance'] = $row['needs_maintenance'] > 0; break;
-                    case 'url': $entry['url'] = Settings::get('SITE_URL')."viewcache.php?wp=".$row['wp_oc']; break;
+                    case 'url':
+                        // str_replace is temporary - https://forum.opencaching.pl/viewtopic.php?f=6&t=7089&p=136968#p136968
+                        $entry['url'] = (
+                            str_replace("https://", "http://", Settings::get('SITE_URL')).
+                            "viewcache.php?wp=".$row['wp_oc']
+                        );
+                        break;
                     case 'owner':
                         $owner_ids[$row['wp_oc']] = $row['user_id'];
                         /* continued later */

--- a/htdocs/okapi/services/caches/map/replicate_listener.inc.php
+++ b/htdocs/okapi/services/caches/map/replicate_listener.inc.php
@@ -2,22 +2,11 @@
 
 namespace okapi\services\caches\map;
 
-use Exception;
-use okapi\Okapi;
-use okapi\Settings;
-use okapi\Cache;
 use okapi\Db;
-use okapi\OkapiRequest;
-use okapi\OkapiHttpResponse;
-use okapi\ParamMissing;
 use okapi\InvalidParam;
-use okapi\BadRequest;
-use okapi\DoesNotExist;
-use okapi\OkapiInternalRequest;
 use okapi\OkapiInternalConsumer;
+use okapi\OkapiInternalRequest;
 use okapi\OkapiServiceRunner;
-
-use okapi\services\caches\map\TileTree;
 
 require_once 'tiletree.inc.php';
 

--- a/htdocs/okapi/services/caches/map/tile.php
+++ b/htdocs/okapi/services/caches/map/tile.php
@@ -2,27 +2,19 @@
 
 namespace okapi\services\caches\map\tile;
 
-use Exception;
-use okapi\Okapi;
-use okapi\Settings;
-use okapi\Cache;
-use okapi\FileCache;
-use okapi\Db;
-use okapi\OkapiRequest;
-use okapi\OkapiHttpResponse;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
 use okapi\BadRequest;
-use okapi\DoesNotExist;
-use okapi\OkapiInternalRequest;
-use okapi\OkapiInternalConsumer;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiLock;
-
-use okapi\services\caches\map\TileTree;
-use okapi\services\caches\map\TileRenderer;
-use okapi\services\caches\search\SearchAssistant;
+use okapi\Cache;
+use okapi\Db;
+use okapi\InvalidParam;
 use okapi\OkapiConsumer;
+use okapi\OkapiHttpResponse;
+use okapi\OkapiInternalRequest;
+use okapi\OkapiRequest;
+use okapi\OkapiServiceRunner;
+use okapi\ParamMissing;
+use okapi\services\caches\map\TileRenderer;
+use okapi\services\caches\map\TileTree;
+use okapi\Settings;
 
 require_once('tiletree.inc.php');
 require_once('tilerenderer.inc.php');

--- a/htdocs/okapi/services/caches/map/tilerenderer.inc.php
+++ b/htdocs/okapi/services/caches/map/tilerenderer.inc.php
@@ -3,11 +3,10 @@
 namespace okapi\services\caches\map;
 
 use Exception;
-use okapi\Okapi;
-use okapi\Settings;
 use okapi\Cache;
 use okapi\Db;
-use okapi\FileCache; // WRTODO
+use okapi\FileCache;
+use okapi\Okapi;
 
 
 class TileRenderer

--- a/htdocs/okapi/services/caches/map/tiletree.inc.php
+++ b/htdocs/okapi/services/caches/map/tiletree.inc.php
@@ -4,7 +4,6 @@ namespace okapi\services\caches\map;
 
 use Exception;
 use okapi\Db;
-use okapi\DoesNotExist;
 use okapi\Okapi;
 use okapi\OkapiInternalConsumer;
 use okapi\OkapiInternalRequest;

--- a/htdocs/okapi/services/caches/search/all.php
+++ b/htdocs/okapi/services/caches/search/all.php
@@ -12,8 +12,6 @@ namespace okapi\services\caches\search\all;
 
 use okapi\Okapi;
 use okapi\OkapiRequest;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
 use okapi\services\caches\search\SearchAssistant;
 
 require_once('searching.inc.php');

--- a/htdocs/okapi/services/caches/search/bbox.php
+++ b/htdocs/okapi/services/caches/search/bbox.php
@@ -5,10 +5,10 @@ namespace okapi\services\caches\search\bbox;
 require_once('searching.inc.php');
 
 use okapi\Db;
+use okapi\InvalidParam;
 use okapi\Okapi;
 use okapi\OkapiRequest;
 use okapi\ParamMissing;
-use okapi\InvalidParam;
 use okapi\services\caches\search\SearchAssistant;
 
 class WebService

--- a/htdocs/okapi/services/caches/search/by_urls.php
+++ b/htdocs/okapi/services/caches/search/by_urls.php
@@ -4,12 +4,12 @@ namespace okapi\services\caches\search\by_urls;
 
 require_once('searching.inc.php');
 
+use okapi\Db;
+use okapi\InvalidParam;
 use okapi\Okapi;
-use okapi\Settings;
 use okapi\OkapiRequest;
 use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\Db;
+use okapi\Settings;
 
 class WebService
 {

--- a/htdocs/okapi/services/caches/search/nearest.php
+++ b/htdocs/okapi/services/caches/search/nearest.php
@@ -4,11 +4,11 @@ namespace okapi\services\caches\search\nearest;
 
 require_once('searching.inc.php');
 
-use okapi\Okapi;
 use okapi\Db;
+use okapi\InvalidParam;
+use okapi\Okapi;
 use okapi\OkapiRequest;
 use okapi\ParamMissing;
-use okapi\InvalidParam;
 use okapi\services\caches\search\SearchAssistant;
 
 class WebService

--- a/htdocs/okapi/services/caches/search/searching.inc.php
+++ b/htdocs/okapi/services/caches/search/searching.inc.php
@@ -2,15 +2,15 @@
 
 namespace okapi\services\caches\search;
 
-use okapi\Okapi;
-use okapi\Db;
-use okapi\OkapiInternalRequest;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiRequest;
-use okapi\InvalidParam;
-use okapi\BadRequest;
-use okapi\Settings;
 use Exception;
+use okapi\BadRequest;
+use okapi\Db;
+use okapi\InvalidParam;
+use okapi\Okapi;
+use okapi\OkapiInternalRequest;
+use okapi\OkapiRequest;
+use okapi\OkapiServiceRunner;
+use okapi\Settings;
 
 class SearchAssistant
 {

--- a/htdocs/okapi/services/caches/shortcuts/search_and_retrieve.php
+++ b/htdocs/okapi/services/caches/shortcuts/search_and_retrieve.php
@@ -2,14 +2,14 @@
 
 namespace okapi\services\caches\shortcuts\search_and_retrieve;
 
+use okapi\BadRequest;
+use okapi\InvalidParam;
 use okapi\Okapi;
 use okapi\OkapiHttpResponse;
 use okapi\OkapiInternalRequest;
-use okapi\OkapiServiceRunner;
 use okapi\OkapiRequest;
+use okapi\OkapiServiceRunner;
 use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\BadRequest;
 
 class WebService
 {

--- a/htdocs/okapi/services/logs/entries.php
+++ b/htdocs/okapi/services/logs/entries.php
@@ -2,16 +2,12 @@
 
 namespace okapi\services\logs\entries;
 
-use Exception;
-use okapi\Okapi;
 use okapi\Db;
+use okapi\InvalidParam;
+use okapi\Okapi;
 use okapi\OkapiRequest;
 use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiInternalRequest;
-use okapi\OkapiServiceRunner;
 use okapi\Settings;
-use okapi\services\caches\search\SearchAssistant;
 
 class WebService
 {

--- a/htdocs/okapi/services/logs/entry.php
+++ b/htdocs/okapi/services/logs/entry.php
@@ -2,12 +2,12 @@
 
 namespace okapi\services\logs\entry;
 
-use okapi\OkapiInternalRequest;
-use okapi\OkapiServiceRunner;
-use okapi\Okapi;
-use okapi\OkapiRequest;
-use okapi\ParamMissing;
 use okapi\InvalidParam;
+use okapi\Okapi;
+use okapi\OkapiInternalRequest;
+use okapi\OkapiRequest;
+use okapi\OkapiServiceRunner;
+use okapi\ParamMissing;
 
 class WebService
 {

--- a/htdocs/okapi/services/logs/images/log_images_common.inc.php
+++ b/htdocs/okapi/services/logs/images/log_images_common.inc.php
@@ -7,12 +7,10 @@
 namespace okapi\services\logs\images;
 
 use Exception;
-use okapi\Okapi;
 use okapi\Db;
-use okapi\OkapiRequest;
 use okapi\InvalidParam;
+use okapi\ParamMissing;
 use okapi\Settings;
-use okapi\BadRequest;
 
 
 class LogImagesCommon

--- a/htdocs/okapi/services/logs/logs.php
+++ b/htdocs/okapi/services/logs/logs.php
@@ -2,16 +2,14 @@
 
 namespace okapi\services\logs\logs;
 
-use Exception;
-use okapi\Okapi;
 use okapi\Db;
-use okapi\OkapiRequest;
-use okapi\ParamMissing;
 use okapi\InvalidParam;
+use okapi\Okapi;
 use okapi\OkapiInternalRequest;
+use okapi\OkapiRequest;
 use okapi\OkapiServiceRunner;
+use okapi\ParamMissing;
 use okapi\Settings;
-use okapi\services\caches\search\SearchAssistant;
 
 class WebService
 {

--- a/htdocs/okapi/services/logs/userlogs.php
+++ b/htdocs/okapi/services/logs/userlogs.php
@@ -2,16 +2,14 @@
 
 namespace okapi\services\logs\userlogs;
 
-use Exception;
-use okapi\Okapi;
 use okapi\Db;
-use okapi\OkapiRequest;
-use okapi\ParamMissing;
 use okapi\InvalidParam;
+use okapi\Okapi;
 use okapi\OkapiInternalRequest;
+use okapi\OkapiRequest;
 use okapi\OkapiServiceRunner;
+use okapi\ParamMissing;
 use okapi\Settings;
-use okapi\services\caches\search\SearchAssistant;
 
 class WebService
 {

--- a/htdocs/okapi/services/oauth/access_token.php
+++ b/htdocs/okapi/services/oauth/access_token.php
@@ -6,7 +6,6 @@ use okapi\Okapi;
 use okapi\OkapiHttpResponse;
 use okapi\OkapiRequest;
 use okapi\ParamMissing;
-use okapi\InvalidParam;
 
 class WebService
 {

--- a/htdocs/okapi/services/oauth/authorize.php
+++ b/htdocs/okapi/services/oauth/authorize.php
@@ -2,12 +2,11 @@
 
 namespace okapi\services\oauth\authorize;
 
-use okapi\Okapi;
-use okapi\Settings;
+use okapi\InvalidParam;
 use okapi\OkapiRedirectResponse;
 use okapi\OkapiRequest;
 use okapi\ParamMissing;
-use okapi\InvalidParam;
+use okapi\Settings;
 
 class WebService
 {

--- a/htdocs/okapi/services/oauth/request_token.php
+++ b/htdocs/okapi/services/oauth/request_token.php
@@ -6,7 +6,6 @@ use okapi\Okapi;
 use okapi\OkapiHttpResponse;
 use okapi\OkapiRequest;
 use okapi\ParamMissing;
-use okapi\InvalidParam;
 
 class WebService
 {

--- a/htdocs/okapi/services/replicate/changelog.php
+++ b/htdocs/okapi/services/replicate/changelog.php
@@ -2,17 +2,11 @@
 
 namespace okapi\services\replicate\changelog;
 
-use Exception;
+use okapi\BadRequest;
+use okapi\InvalidParam;
 use okapi\Okapi;
-use okapi\Db;
 use okapi\OkapiRequest;
 use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\BadRequest;
-use okapi\DoesNotExist;
-use okapi\OkapiInternalRequest;
-use okapi\OkapiInternalConsumer;
-use okapi\OkapiServiceRunner;
 use okapi\services\replicate\ReplicateCommon;
 
 class WebService

--- a/htdocs/okapi/services/replicate/fulldump.php
+++ b/htdocs/okapi/services/replicate/fulldump.php
@@ -2,15 +2,11 @@
 
 namespace okapi\services\replicate\fulldump;
 
-use Exception;
-use okapi\Okapi;
-use okapi\Db;
+use okapi\BadRequest;
 use okapi\Cache;
+use okapi\Db;
 use okapi\OkapiHttpResponse;
 use okapi\OkapiRequest;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\BadRequest;
 
 class WebService
 {

--- a/htdocs/okapi/services/replicate/info.php
+++ b/htdocs/okapi/services/replicate/info.php
@@ -2,18 +2,9 @@
 
 namespace okapi\services\replicate\info;
 
-use Exception;
-use okapi\Okapi;
-use okapi\Db;
 use okapi\Cache;
+use okapi\Okapi;
 use okapi\OkapiRequest;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\BadRequest;
-use okapi\DoesNotExist;
-use okapi\OkapiInternalRequest;
-use okapi\OkapiInternalConsumer;
-use okapi\OkapiServiceRunner;
 use okapi\services\replicate\ReplicateCommon;
 
 class WebService

--- a/htdocs/okapi/services/replicate/replicate_common.inc.php
+++ b/htdocs/okapi/services/replicate/replicate_common.inc.php
@@ -3,17 +3,12 @@
 namespace okapi\services\replicate;
 
 use Exception;
-use okapi\Okapi;
-use okapi\Db;
-use okapi\OkapiRequest;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\BadRequest;
-use okapi\DoesNotExist;
-use okapi\OkapiInternalRequest;
-use okapi\OkapiInternalConsumer;
-use okapi\OkapiServiceRunner;
 use okapi\Cache;
+use okapi\Db;
+use okapi\Okapi;
+use okapi\OkapiInternalConsumer;
+use okapi\OkapiInternalRequest;
+use okapi\OkapiServiceRunner;
 use okapi\Settings;
 
 class ReplicateCommon
@@ -208,11 +203,10 @@ class ReplicateCommon
 
                 if (($entry['change_type'] == 'replace') && ($geocache_ignored_fields != null)) {
 
-                    # We were called with a non-null ignored fields. Probably
-                    # this call originated from the database update script
-                    # and new fields have been added to the replicate module.
-                    # We will ignore such new fields - this way no unnecessary
-                    # clog entries will be created.
+                    # We were called with a non-null ignored fields. These
+                    # fields should be ignored when comparing objects for
+                    # changes, so that no unnecessary clog entries will be
+                    # created.
 
                     foreach ($geocache_ignored_fields as $field) {
                         unset($entry['data'][$field]);

--- a/htdocs/okapi/services/users/by_internal_id.php
+++ b/htdocs/okapi/services/users/by_internal_id.php
@@ -2,14 +2,12 @@
 
 namespace okapi\services\users\by_internal_id;
 
-use okapi\Okapi;
-use okapi\OkapiRequest;
-use okapi\ParamMissing;
 use okapi\InvalidParam;
-use okapi\BadRequest;
+use okapi\Okapi;
 use okapi\OkapiInternalRequest;
+use okapi\OkapiRequest;
 use okapi\OkapiServiceRunner;
-use okapi\services\caches\search\SearchAssistant;
+use okapi\ParamMissing;
 
 class WebService
 {

--- a/htdocs/okapi/services/users/by_internal_ids.php
+++ b/htdocs/okapi/services/users/by_internal_ids.php
@@ -2,14 +2,13 @@
 
 namespace okapi\services\users\by_internal_ids;
 
-use okapi\Okapi;
 use okapi\Db;
-use okapi\OkapiInternalRequest;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiRequest;
-use okapi\ParamMissing;
 use okapi\InvalidParam;
-use okapi\services\caches\search\SearchAssistant;
+use okapi\Okapi;
+use okapi\OkapiInternalRequest;
+use okapi\OkapiRequest;
+use okapi\OkapiServiceRunner;
+use okapi\ParamMissing;
 
 class WebService
 {

--- a/htdocs/okapi/services/users/by_username.php
+++ b/htdocs/okapi/services/users/by_username.php
@@ -2,17 +2,12 @@
 
 namespace okapi\services\users\by_username;
 
-use okapi\BadRequest;
-
-use okapi\OkapiInternalRequest;
-
-use okapi\OkapiServiceRunner;
-
-use okapi\Okapi;
-use okapi\OkapiRequest;
-use okapi\ParamMissing;
 use okapi\InvalidParam;
-use okapi\services\caches\search\SearchAssistant;
+use okapi\Okapi;
+use okapi\OkapiInternalRequest;
+use okapi\OkapiRequest;
+use okapi\OkapiServiceRunner;
+use okapi\ParamMissing;
 
 class WebService
 {

--- a/htdocs/okapi/services/users/by_usernames.php
+++ b/htdocs/okapi/services/users/by_usernames.php
@@ -2,14 +2,13 @@
 
 namespace okapi\services\users\by_usernames;
 
-use okapi\Okapi;
 use okapi\Db;
-use okapi\OkapiRequest;
-use okapi\ParamMissing;
 use okapi\InvalidParam;
-use okapi\services\caches\search\SearchAssistant;
-use okapi\OkapiServiceRunner;
+use okapi\Okapi;
 use okapi\OkapiInternalRequest;
+use okapi\OkapiRequest;
+use okapi\OkapiServiceRunner;
+use okapi\ParamMissing;
 use okapi\Settings;
 
 class WebService

--- a/htdocs/okapi/services/users/user.php
+++ b/htdocs/okapi/services/users/user.php
@@ -3,16 +3,11 @@
 namespace okapi\services\users\user;
 
 use okapi\BadRequest;
-
-use okapi\OkapiInternalRequest;
-
-use okapi\OkapiServiceRunner;
-
-use okapi\Okapi;
-use okapi\OkapiRequest;
-use okapi\ParamMissing;
 use okapi\InvalidParam;
-use okapi\services\caches\search\SearchAssistant;
+use okapi\Okapi;
+use okapi\OkapiInternalRequest;
+use okapi\OkapiRequest;
+use okapi\OkapiServiceRunner;
 
 class WebService
 {

--- a/htdocs/okapi/services/users/users.php
+++ b/htdocs/okapi/services/users/users.php
@@ -3,13 +3,12 @@
 namespace okapi\services\users\users;
 
 use Exception;
-use okapi\Okapi;
-use okapi\Settings;
 use okapi\Db;
+use okapi\InvalidParam;
+use okapi\Okapi;
 use okapi\OkapiRequest;
 use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\services\caches\search\SearchAssistant;
+use okapi\Settings;
 
 class WebService
 {
@@ -70,7 +69,9 @@ class WebService
                         }
                         break;
                     case 'internal_id': $entry['internal_id'] = $row['user_id']; break;
-                    case 'date_registered': $entry['date_registered'] = date("Y-m-d", strtotime($row['date_created']));
+                    case 'date_registered':
+                        $entry['date_registered'] = date("Y-m-d", strtotime($row['date_created']));
+                        break;
                     case 'caches_found': /* handled separately */ break;
                     case 'caches_notfound': /* handled separately */ break;
                     case 'caches_hidden': /* handled separately */ break;

--- a/htdocs/okapi/settings.php
+++ b/htdocs/okapi/settings.php
@@ -3,7 +3,6 @@
 namespace okapi;
 
 use Exception;
-use okapi\Locales;
 
 # DO NOT MODIFY THIS FILE. This file should always look like the original here:
 # https://github.com/opencaching/okapi/blob/master/okapi/settings.php

--- a/htdocs/okapi/static/common.css
+++ b/htdocs/okapi/static/common.css
@@ -22,7 +22,7 @@ body.api { background: #f5f1eb; }
 .changelog th { background: #e1d7d8; }
 .changelog td { background: #eee9e9; padding: 8px 16px; }
 
-.apimenu { vertical-align: top; width: 225px; font-size: 15px; padding: 0px 20px 0 32px; }
+.apimenu { vertical-align: top; width: 225px; font-size: 15px; padding: 0 20px 0 32px; }
 .apimenu .revision { float: right; font-size: 11px; color: #888; position: relative; top: -30px; }
 .apimenu a { color: #804937; text-decoration: none; }
 .apimenu a:hover { text-decoration: underline; }

--- a/htdocs/okapi/static/common.js
+++ b/htdocs/okapi/static/common.js
@@ -15,7 +15,7 @@ $(function() {
                 if (issue.comment_count === null) {
                     link = $("<a>Comments</a>");
                 } else {
-                    comments = (issue.comment_count == 1) ? "comment" : "comments";
+                    comments = (issue.comment_count === 1) ? "comment" : "comments";
                     link = $("<a>" + issue.comment_count + " " + comments + "</a>");
                 }
                 link.attr('href', issue.url);
@@ -26,10 +26,11 @@ $(function() {
         });
     });
     $('#switcher').change(function() {
-        var current_base_url = $('#switcher option[current]').attr('value');
-        var new_base_url = $('#switcher option:selected').attr('value');
-        if (current_base_url != new_base_url)
-            window.location.href = window.location.href.replace(current_base_url, new_base_url);
+        // We are purposefully removing schemes from these URLs.
+        var current_base_url = $('#switcher option[current]').attr('value').replace(/^https?:/, "");
+        var new_base_url = $('#switcher option:selected').attr('value').replace(/^https?:/, "");
+        if (current_base_url !== new_base_url)
+            window.location.href = window.location.href.replace(current_base_url, new_base_url).replace("https://", "http://");
     });
     $('#switcher option[current]').attr('selected', true);
 });

--- a/htdocs/okapi/views/apps/authorize.php
+++ b/htdocs/okapi/views/apps/authorize.php
@@ -2,15 +2,13 @@
 
 namespace okapi\views\apps\authorize;
 
-use Exception;
-use okapi\Okapi;
 use okapi\Db;
-use okapi\OkapiHttpResponse;
-use okapi\OkapiHttpRequest;
-use okapi\OkapiRedirectResponse;
-use okapi\Settings;
 use okapi\Locales;
 use okapi\OCSession;
+use okapi\Okapi;
+use okapi\OkapiHttpResponse;
+use okapi\OkapiRedirectResponse;
+use okapi\Settings;
 
 class View
 {
@@ -139,7 +137,7 @@ class View
             where
                 user_id = '".Db::escape_string($OC_user_id)."'
                 and consumer_key = '".Db::escape_string($token['consumer_key'])."'
-        ", 0);
+        ");
 
         if (!$authorized)
         {

--- a/htdocs/okapi/views/apps/authorized.php
+++ b/htdocs/okapi/views/apps/authorized.php
@@ -2,11 +2,9 @@
 
 namespace okapi\views\apps\authorized;
 
-use Exception;
-use okapi\Okapi;
 use okapi\Db;
+use okapi\Okapi;
 use okapi\OkapiHttpResponse;
-use okapi\OkapiHttpRequest;
 use okapi\OkapiRedirectResponse;
 use okapi\Settings;
 

--- a/htdocs/okapi/views/apps/index.php
+++ b/htdocs/okapi/views/apps/index.php
@@ -2,14 +2,12 @@
 
 namespace okapi\views\apps\index;
 
-use Exception;
-use okapi\Okapi;
 use okapi\Db;
+use okapi\OCSession;
+use okapi\Okapi;
 use okapi\OkapiHttpResponse;
-use okapi\OkapiHttpRequest;
 use okapi\OkapiRedirectResponse;
 use okapi\Settings;
-use okapi\OCSession;
 
 class View
 {

--- a/htdocs/okapi/views/apps/revoke_access.php
+++ b/htdocs/okapi/views/apps/revoke_access.php
@@ -2,14 +2,10 @@
 
 namespace okapi\views\apps\revoke_access;
 
-use Exception;
-use okapi\Okapi;
-use okapi\Settings;
 use okapi\Db;
-use okapi\OkapiHttpResponse;
-use okapi\OkapiHttpRequest;
-use okapi\OkapiRedirectResponse;
 use okapi\OCSession;
+use okapi\OkapiRedirectResponse;
+use okapi\Settings;
 
 class View
 {

--- a/htdocs/okapi/views/changelog.php
+++ b/htdocs/okapi/views/changelog.php
@@ -2,11 +2,9 @@
 
 namespace okapi\views\changelog;
 
-use Exception;
 use okapi\Okapi;
-use okapi\Settings;
-use okapi\OkapiRequest;
 use okapi\OkapiHttpResponse;
+use okapi\Settings;
 use okapi\views\menu\OkapiMenu;
 
 class View

--- a/htdocs/okapi/views/changelog.tpl.php
+++ b/htdocs/okapi/views/changelog.tpl.php
@@ -57,7 +57,7 @@
                                         <th>Version</th>
                                         <th>Date</th>
                                         <th>Change</th>
-                                    </th>
+                                    </tr>
                                 <?php foreach($changes as $change) { ?>
                                     <tr id="v<?= $change['version'] ?>">
                                         <td><a href="https://github.com/opencaching/okapi/tree/<?= $change['commit'] ?>"><?= $change['version'] ?></a></td>

--- a/htdocs/okapi/views/changelog_feed.php
+++ b/htdocs/okapi/views/changelog_feed.php
@@ -2,11 +2,8 @@
 
 namespace okapi\views\changelog_feed;
 
-use Exception;
-use okapi\Okapi;
-use okapi\Settings;
-use okapi\OkapiRequest;
 use okapi\OkapiHttpResponse;
+use okapi\Settings;
 use okapi\views\changelog\Changelog;
 
 

--- a/htdocs/okapi/views/changelog_helper.inc.php
+++ b/htdocs/okapi/views/changelog_helper.inc.php
@@ -2,9 +2,10 @@
 
 namespace okapi\views\changelog;
 
+use ErrorException;
 use Exception;
-use okapi\Okapi;
 use okapi\Cache;
+use okapi\Okapi;
 
 
 class Changelog

--- a/htdocs/okapi/views/cron5.php
+++ b/htdocs/okapi/views/cron5.php
@@ -2,18 +2,7 @@
 
 namespace okapi\views\cron5;
 
-use Exception;
 use okapi\Okapi;
-use okapi\Cache;
-use okapi\Db;
-use okapi\OkapiRequest;
-use okapi\OkapiRedirectResponse;
-use okapi\OkapiHttpResponse;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
-use okapi\cronjobs\CronJobController;
 
 /**
  * This is an entry point for system's crontab. System's crontab will be

--- a/htdocs/okapi/views/devel/attrlist.php
+++ b/htdocs/okapi/views/devel/attrlist.php
@@ -2,19 +2,10 @@
 
 namespace okapi\views\devel\attrlist;
 
-use Exception;
-use okapi\Okapi;
-use okapi\Cache;
 use okapi\Db;
-use okapi\OkapiRequest;
-use okapi\OkapiRedirectResponse;
 use okapi\OkapiHttpResponse;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
-use okapi\Settings;
 use okapi\services\attrs\AttrHelper;
+use okapi\Settings;
 
 class View
 {

--- a/htdocs/okapi/views/devel/clogentry.php
+++ b/htdocs/okapi/views/devel/clogentry.php
@@ -2,18 +2,9 @@
 
 namespace okapi\views\devel\clogentry;
 
-use Exception;
-use okapi\Okapi;
-use okapi\Cache;
 use okapi\Db;
-use okapi\OkapiRequest;
-use okapi\OkapiRedirectResponse;
 use okapi\OkapiHttpResponse;
 use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
-use okapi\Settings;
 
 class View
 {

--- a/htdocs/okapi/views/devel/dbstruct.php
+++ b/htdocs/okapi/views/devel/dbstruct.php
@@ -3,19 +3,12 @@
 namespace okapi\views\devel\dbstruct;
 
 use Exception;
-use okapi\Okapi;
-use okapi\Settings;
-use okapi\Cache;
-use okapi\Db;
-use okapi\OkapiRequest;
-use okapi\OkapiRedirectResponse;
-use okapi\OkapiHttpResponse;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
-use okapi\OkapiInternalConsumer;
 use okapi\BadRequest;
+use okapi\OkapiHttpResponse;
+use okapi\OkapiInternalConsumer;
+use okapi\OkapiInternalRequest;
+use okapi\OkapiServiceRunner;
+use okapi\Settings;
 
 class View
 {

--- a/htdocs/okapi/views/devel/sysinfo.php
+++ b/htdocs/okapi/views/devel/sysinfo.php
@@ -2,8 +2,6 @@
 
 namespace okapi\views\devel\sysinfo;
 
-use Exception;
-use okapi\Okapi;
 use okapi\OkapiHttpResponse;
 
 class View

--- a/htdocs/okapi/views/examples.php
+++ b/htdocs/okapi/views/examples.php
@@ -2,15 +2,9 @@
 
 namespace okapi\views\examples;
 
-use Exception;
 use okapi\Okapi;
-use okapi\Settings;
-use okapi\OkapiRequest;
 use okapi\OkapiHttpResponse;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
+use okapi\Settings;
 use okapi\views\menu\OkapiMenu;
 
 class View

--- a/htdocs/okapi/views/http404.php
+++ b/htdocs/okapi/views/http404.php
@@ -2,10 +2,9 @@
 
 namespace okapi\views\http404;
 
-use Exception;
 use okapi\Okapi;
-use okapi\Settings;
 use okapi\OkapiHttpResponse;
+use okapi\Settings;
 use okapi\views\menu\OkapiMenu;
 
 class View

--- a/htdocs/okapi/views/index.php
+++ b/htdocs/okapi/views/index.php
@@ -2,15 +2,8 @@
 
 namespace okapi\views\index;
 
-use Exception;
-use okapi\Okapi;
-use okapi\Settings;
-use okapi\OkapiRequest;
 use okapi\OkapiRedirectResponse;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
+use okapi\Settings;
 
 class View
 {

--- a/htdocs/okapi/views/introduction.php
+++ b/htdocs/okapi/views/introduction.php
@@ -2,17 +2,13 @@
 
 namespace okapi\views\introduction;
 
-use Exception;
 use okapi\Okapi;
-use okapi\Settings;
-use okapi\OkapiRequest;
 use okapi\OkapiHttpResponse;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
-use okapi\views\menu\OkapiMenu;
 use okapi\OkapiInternalConsumer;
+use okapi\OkapiInternalRequest;
+use okapi\OkapiServiceRunner;
+use okapi\Settings;
+use okapi\views\menu\OkapiMenu;
 
 class View
 {

--- a/htdocs/okapi/views/menu.inc.php
+++ b/htdocs/okapi/views/menu.inc.php
@@ -2,11 +2,10 @@
 
 namespace okapi\views\menu;
 
-use Exception;
 use okapi\Okapi;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
 use okapi\OkapiInternalConsumer;
+use okapi\OkapiInternalRequest;
+use okapi\OkapiServiceRunner;
 use okapi\Settings;
 
 require_once($GLOBALS['rootpath'].'okapi/service_runner.php');

--- a/htdocs/okapi/views/method_call.php
+++ b/htdocs/okapi/views/method_call.php
@@ -2,17 +2,10 @@
 
 namespace okapi\views\method_call;
 
-use Exception;
-use okapi\Okapi;
-use okapi\Settings;
-use okapi\OkapiHttpRequest;
-use okapi\OkapiHttpResponse;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
 use okapi\BadRequest;
+use okapi\OkapiHttpRequest;
 use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
-use okapi\views\menu\OkapiMenu;
+use okapi\Settings;
 
 class View
 {

--- a/htdocs/okapi/views/method_doc.php
+++ b/htdocs/okapi/views/method_doc.php
@@ -2,17 +2,13 @@
 
 namespace okapi\views\method_doc;
 
-use Exception;
-use okapi\Okapi;
-use okapi\Settings;
-use okapi\OkapiRequest;
-use okapi\OkapiHttpResponse;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
 use okapi\BadRequest;
 use okapi\Http404;
-use okapi\OkapiServiceRunner;
+use okapi\Okapi;
+use okapi\OkapiHttpResponse;
 use okapi\OkapiInternalRequest;
+use okapi\OkapiServiceRunner;
+use okapi\Settings;
 use okapi\views\menu\OkapiMenu;
 
 class View

--- a/htdocs/okapi/views/signup.php
+++ b/htdocs/okapi/views/signup.php
@@ -2,17 +2,10 @@
 
 namespace okapi\views\signup;
 
-use Exception;
 use okapi\Okapi;
-use okapi\Settings;
-use okapi\OkapiRequest;
 use okapi\OkapiHttpResponse;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
+use okapi\Settings;
 use okapi\views\menu\OkapiMenu;
-use okapi\OkapiHttpRequest;
 
 class View
 {

--- a/htdocs/okapi/views/tilestress.php
+++ b/htdocs/okapi/views/tilestress.php
@@ -3,22 +3,12 @@
 namespace okapi\views\tilestress;
 
 use Exception;
-
-use okapi\Okapi;
-use okapi\Cache;
 use okapi\Db;
-use okapi\OkapiRequest;
-use okapi\OkapiRedirectResponse;
-use okapi\OkapiHttpResponse;
-use okapi\ParamMissing;
-use okapi\InvalidParam;
-use okapi\OkapiServiceRunner;
-use okapi\OkapiInternalRequest;
-use okapi\OkapiInternalConsumer;
-use okapi\OkapiInternalAccessToken;
-use okapi\Settings;
-use okapi\OkapiLock;
 use okapi\OkapiExceptionHandler;
+use okapi\OkapiInternalAccessToken;
+use okapi\OkapiInternalConsumer;
+use okapi\OkapiInternalRequest;
+use okapi\OkapiServiceRunner;
 
 require_once($GLOBALS['rootpath']."okapi/service_runner.php");
 


### PR DESCRIPTION
Hi!

Recently we introduced HTTPS on OCPL too, and a couple of minor bugs were reported for HTTPS support in OKAPI. I can see that some things don't work on OCDE's OKAPI as they should too, for example OKAPI identifies itself as "DEVELSITE".

Upgrading to this version should help, but it would be best if you tested it with your HTTPS settings first.