### PR TITLE
fixed re-editing plaintext; #updates #998

### DIFF
--- a/htdocs/editdesc.php
+++ b/htdocs/editdesc.php
@@ -144,7 +144,7 @@ if ($error == false) {
                         $desc = iconv("ISO-8859-1", "UTF-8", $desc);
                     }
 
-                    $desc = processEditorInput($oldDescMode, $descMode, $desc);
+                    $desc = processEditorInput($oldDescMode, $descMode, $desc, $representDesc);
 
                     if (isset($_POST['submitform'])) {  // Ocprop
                         // prüfen, ob sprache nicht schon vorhanden
@@ -221,15 +221,16 @@ if ($error == false) {
                     $oldDescMode = ($desc_html == 0 ? 0 : ($desc_htmledit ? 3 : 2));
 
                     if ($oldDescMode == 0) {
-                        $desc = processEditorInput($oldDescMode, $descMode, $desc_record['desc']);
+                        $desc = processEditorInput($oldDescMode, $descMode, $desc_record['desc'], $representDesc);
                     } else {
                         $desc = $desc_record['desc'];
+                        $representDesc = $desc;
                     }
                 }
 
                 //here we only set up the template variables
 
-                tpl_set_var('desc', htmlspecialchars($desc, ENT_COMPAT, 'UTF-8'), true);
+                tpl_set_var('desc', htmlspecialchars($representDesc, ENT_COMPAT, 'UTF-8'), true);
                 tpl_set_var('descMode', $descMode);
                 tpl_set_var('htmlnotice', $descMode == 2 ? $htmlnotice : '');
 

--- a/htdocs/editlog.php
+++ b/htdocs/editlog.php
@@ -225,7 +225,7 @@ if ($error == false) {
                     $log_text = iconv("ISO-8859-1", "UTF-8", $log_text);
                 }
 
-                $log_text = processEditorInput($oldDescMode, $descMode, $log_text);
+                $log_text = processEditorInput($oldDescMode, $descMode, $log_text, $represent_text);
 
                 //validate date
                 $date_ok = false;
@@ -442,9 +442,9 @@ if ($error == false) {
                 tpl_set_var('date_message', !$date_ok ? $date_message : '');
 
                 if ($descMode != 1) {
-                    tpl_set_var('logtext', htmlspecialchars($log_text, ENT_COMPAT, 'UTF-8'), true);
+                    tpl_set_var('logtext', htmlspecialchars($represent_text, ENT_COMPAT, 'UTF-8'), true);
                 } else {
-                    tpl_set_var('logtext', $log_text);
+                    tpl_set_var('logtext', $represent_text);
                 }
 
                 // Text / normal HTML / HTML editor

--- a/htdocs/lib2/edithelper.inc.php
+++ b/htdocs/lib2/edithelper.inc.php
@@ -27,7 +27,7 @@ require_once __DIR__ . '/smiley.inc.php';
  * @param $text
  * @return mixed|string
  */
-function processEditorInput($oldDescMode, $descMode, $text)
+function processEditorInput($oldDescMode, $descMode, $text, &$representText)
 {
     global $opt, $smiley;
 
@@ -37,20 +37,24 @@ function processEditorInput($oldDescMode, $descMode, $text)
             $text = nl2br(htmlspecialchars($text));
             // .. and smilies
             $text = str_replace($smiley['text'], $smiley['spaced_image'], $text);
+            $representText = $text;
         } else {
             // save HTML input => verify / tidy / filter;
             // also implemented in okapi/services/logs/submit.php
             $purifier = new OcHTMLPurifier($opt);
             $text = $purifier->purify($text);
+            $representText = $text;
         }
     } else {
         if ($oldDescMode == 1) {
-            // save plain text input => convert to HTML;
+            // keep plain text for re-presenting to the user
+            $representText = $text;
+            // convert to HTML for storing to database
             // also implemented in okapi/services/logs/submit.php
             $text = nl2br(htmlspecialchars($text, ENT_COMPAT, 'UTF-8'));
         } else {
             // mode switch from HTML editor to plain text, or decode HTML-encoded plain text
-            $text = html2plaintext($text, $oldDescMode = 0, 0);
+            $representText = html2plaintext($text, $oldDescMode = 0, 0);
         }
     }
 

--- a/htdocs/log.php
+++ b/htdocs/log.php
@@ -203,7 +203,7 @@ if ($cacheId != 0) {
     $tpl->add_header_javascript(editorJsPath());
 
     // check and prepare log text
-    $logText = processEditorInput($oldDescMode, $descMode, $logText);
+    $logText = processEditorInput($oldDescMode, $descMode, $logText, $representLogText);
 
     // validate date
     if (is_numeric($logDateMonth)
@@ -368,7 +368,7 @@ if ($cacheId != 0) {
     $tpl->assign('listing_outdated', $listingOutdated);
     $tpl->assign('condition_history', $cache->getConditionHistory());
     // log text
-    $tpl->assign('logtext', $logText);
+    $tpl->assign('logtext', $representLogText);
     // text, <html> or editor
     $tpl->assign('descMode', $descMode);
     // logtypes

--- a/htdocs/newcache.php
+++ b/htdocs/newcache.php
@@ -147,12 +147,13 @@ if ($error == false) {
 
         //desc
         if (isset($_POST['desc'])) {
-            $desc = trim(processEditorInput($oldDescMode, $descMode, $_POST['desc']));
+            $desc = trim(processEditorInput($oldDescMode, $descMode, $_POST['desc'], $representDesc));
         } else {
             $desc = '';
+            $representDesc = '';
         }
 
-        tpl_set_var('desc', htmlspecialchars($desc, ENT_COMPAT, 'UTF-8'));
+        tpl_set_var('desc', htmlspecialchars($representDesc, ENT_COMPAT, 'UTF-8'));
 
         $headers = tpl_get_var('htmlheaders') . "\n";
         if ($descMode == 3) {

--- a/htdocs/newdesc.php
+++ b/htdocs/newdesc.php
@@ -82,7 +82,7 @@ if ($error == false) {
                 }
 
                 // Filter Input
-                $desc = processEditorInput($oldDescMode, $descMode, $desc);
+                $desc = processEditorInput($oldDescMode, $descMode, $desc, $representDesc);
 
                 $desc_lang_exists = false;
 
@@ -218,7 +218,7 @@ if ($error == false) {
                 tpl_set_var('show_all_langs', $show_all_langs);
                 tpl_set_var('show_all_langs_submit', ($show_all_langs == 0) ? $show_all_langs_submit : '');
                 tpl_set_var('short_desc', htmlspecialchars($short_desc, ENT_COMPAT, 'UTF-8'));
-                tpl_set_var('desc', htmlspecialchars($desc, ENT_COMPAT, 'UTF-8'));
+                tpl_set_var('desc', htmlspecialchars($representDesc, ENT_COMPAT, 'UTF-8'));
                 tpl_set_var('hints', htmlspecialchars($hints, ENT_COMPAT, 'UTF-8'));
 
                 // Text / normal HTML / HTML editor


### PR DESCRIPTION
Das Problem hier war, dass in der Funktion processEditorInput() ein bestimmter Fall nicht vorgesehen war:

1. Editor steht auf "Text".
2. Das Formular wird abgesendet und danach erneut angezeigt.

In diesem Fall bleibt der Editor-Modus unverändert, und das interpretierte die Funktion so, dass das Formular nicht erneut angezeigt wird, sondern der Text nun in der Datenbank landet. Also wurde der Text nach HTML konviertiert, dem Datenbank-Textformat, und das dann dem Benutzer als Plaintext präsentiert.

Ob das Formular neu erscheinen wird oder der Text in der Datenbank landet, steht zum Zeitpunkt des Funktionsaufrufs noch nicht fest. Daher besteht der Fix darin, jeweils zwei Texte zurückzuliefern, einer für die Datenbank und einer fürs Wiedereinsentzen in das Editor-Formular (re-presenting to the user). Anschließend wird der jeweils passende davon verwendet.

Das Ganze betrifft das Erstellen und editieren von Cachebeschreibungen und Logs. Beim Benutzerprofiltext gibt es keine Plaintext-Option.

Es waren 24 verschiedene Fälle zu testen, sechs php-Module mal die vier Fälle in der Funktion processEditorInput(). Hoffe, dass ich nichts übersehen habe; die Änderungen sind aber recht simpel.