### PR TITLE
added short cache description to fulltext desc search; updates #986

### DIFF
--- a/bin/dbsv-update.php
+++ b/bin/dbsv-update.php
@@ -1164,6 +1164,17 @@ function dbv_159()
     }
 }
 
+function dbv_160()
+{
+    // initiate refresh of cache desc fulltext search index, see redmine #986
+    sql(
+      "UPDATE `search_index_times`
+       SET `last_refresh`='2000-01-01 00:00:00'
+       WHERE `object_type`='&1'",
+      OBJECT_CACHEDESC
+    );
+}
+
 // When adding new mutations, take care that they behave well if run multiple
 // times. This improves robustness of database versioning.
 //

--- a/bin/dbsv-update.php
+++ b/bin/dbsv-update.php
@@ -1168,10 +1168,10 @@ function dbv_160()
 {
     // initiate refresh of cache desc fulltext search index, see redmine #986
     sql(
-      "UPDATE `search_index_times`
-       SET `last_refresh`='2000-01-01 00:00:00'
-       WHERE `object_type`='&1'",
-      OBJECT_CACHEDESC
+        "UPDATE `search_index_times`
+         SET `last_refresh`='2000-01-01 00:00:00'
+         WHERE `object_type`='&1'",
+        OBJECT_CACHEDESC
     );
 }
 

--- a/htdocs/lib2/search/ftsearch.inc.php
+++ b/htdocs/lib2/search/ftsearch.inc.php
@@ -325,7 +325,7 @@ function ftsearch_text2sort($str)
 function ftsearch_refresh()
 {
     ftsearch_refresh_all_caches();
-    ftsearch_refresh_all_cache_desc();
+    ftsearch_refresh_all_cache_descs();
     ftsearch_refresh_all_pictures();
     ftsearch_refresh_all_cache_logs();
 }
@@ -368,7 +368,7 @@ function ftsearch_refresh_cache($cache_id)
 }
 
 
-function ftsearch_refresh_all_cache_desc()
+function ftsearch_refresh_all_cache_descs()
 {
     $rs = sql(
         'SELECT `cache_desc`.`id`
@@ -406,7 +406,7 @@ function ftsearch_refresh_cache_desc($id)
         "
         SELECT
           `cache_id`,
-          `desc`,
+          CONCAT(`desc`, ' ', `short_desc`) AS `desc`,
           `last_modified`
         FROM `cache_desc`
         WHERE `id`='&1'",


### PR DESCRIPTION
Nach dem Deployment muss einmal `htdocs/util2/cron/fill_search_index.php` durchlaufen, um den Beschreibungs-Suchindex neu aufzubauen. Auf meiner Entwickler-VM hat das gut eine Stunde gedauert.

fill_search_index.php läuft nachts als Cronjob, also vielleicht lässt man's am besten in der nächsten Nacht erledigen.
