### PR TITLE
fix object type 8/9 assignments

### DIFF
--- a/htdocs/lib2/logic/const.inc.php
+++ b/htdocs/lib2/logic/const.inc.php
@@ -36,6 +36,7 @@ define('OBJECT_TRAVELER', 5);
 define('OBJECT_PICTURE', 6);
 define('OBJECT_REMOVEDOBJECT', 7);
 define('OBJECT_WAYPOINT', 8);
+define('OBJECT_CACHELIST', 9);
 
 // coordinate types
 define('COORDINATE_WAYPOINT', 1);

--- a/sql/static-data/object_types.sql
+++ b/sql/static-data/object_types.sql
@@ -8,4 +8,5 @@ INSERT INTO `object_types` (`id`, `name`) VALUES ('4', 'user');
 INSERT INTO `object_types` (`id`, `name`) VALUES ('5', 'Traveler');
 INSERT INTO `object_types` (`id`, `name`) VALUES ('6', 'Picture');
 INSERT INTO `object_types` (`id`, `name`) VALUES ('7', 'Removed Object');
-INSERT INTO `object_types` (`id`, `name`) VALUES ('8', 'cache list');
+INSERT INTO `object_types` (`id`, `name`) VALUES ('8', 'waypoint');
+INSERT INTO `object_types` (`id`, `name`) VALUES ('9', 'cache list');


### PR DESCRIPTION
Object type 8 has been erroneously assigned to both additional waypoints and cachelists. Fortunately, the cache list OT has not been used yet, so this can be easily resolved.