### PR TITLE
always validate uploaded images (if imagick is installed); updates #1009

### DIFF
--- a/htdocs/lib2/logic/picture.class.php
+++ b/htdocs/lib2/logic/picture.class.php
@@ -852,6 +852,7 @@ class picture
                 if ($image) {
                     $image->clear();
                 }
+                return false;
             }
         }
 

--- a/htdocs/picture.php
+++ b/htdocs/picture.php
@@ -135,6 +135,12 @@ if ($action == 'add') { // Ocprop
             $fname = pathinfo($_FILES['file']['name'], PATHINFO_FILENAME);
             $ext = pathinfo($_FILES['file']['name'], PATHINFO_EXTENSION);
 
+            // SECURITY NOTE (see redmine #1009):
+            //
+            // Calling rotate() or rotate_and_shrink() does not only resolve
+            // image rotations, but also checks for a valid image format.
+            // rotate() requires imagick to do that.
+
             // try saving file if smaller unchg_size and browser native format
             if (in_array(mb_strtolower($ext), ['gif', 'png', 'jpg', 'jpeg'])
                 && ($_FILES['file']['size'] <= $opt['logic']['pictures']['unchg_size'])

--- a/sql/static-data/sys_trans_text_de.sql
+++ b/sql/static-data/sys_trans_text_de.sql
@@ -63,7 +63,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('79', 'DE', 'Isländisch', '2010-08-28 11:48:06');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('80', 'DE', 'Startseite', '2010-08-28 11:48:06');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('82', 'DE', 'Auf dieser Website findest du Geocaches aus der ganzen Welt, mit Schwerpunkt Deutschland, \&Ouml;sterreich, Schweiz, Italien und Spanien. Au\&szlig;erdem gibt es das <a href=\"http://wiki.opencaching.de\">Opencaching-Wiki</a> mit Anleitungen und Informationen rund um Opencaching und Geocaching, und ein <a href=\"http://forum.opencaching.de\">Diskussionsforum</a>.', '2010-08-28 11:48:06');
-INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('83', 'DE', 'Bei der Dateiübertragung ist ein Fehler aufgetreten.', '2010-08-28 11:48:06');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('83', 'DE', 'Beim Hochladen der Datei ist ein Fehler aufgetreten.', '2010-08-28 11:48:06');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('84', 'DE', 'Die Datei war zu groß. Es sind maximal %1 KB erlaubt.', '2010-08-28 11:48:06');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('85', 'DE', 'Kein Bild angegeben.', '2010-08-28 11:48:06');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('86', 'DE', 'gleiche Cacheart', '2010-09-04 21:39:08');


### PR DESCRIPTION
Es gab zwei Fälle, in denen ein hochgeladenes Bild nicht validiert wurde:
* Wenn die Datei unter der Größenschwelle lag, ab der das Bild verkleinert wird.
* Wenn Imagick nicht installiert war.

Ersteres ist hiermit behoben. Imagic ist auf www.opencaching.de vorhanden.