### PR TITLE
exclude unpublished caches from 'active caches' link in myhome

### DIFF
--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -254,6 +254,7 @@ if ($queryid != 0) {
     // get the search options parameters and store them in the queries table (to view "the next page")
     $options['f_userowner'] = isset($_REQUEST['f_userowner']) ? $_REQUEST['f_userowner'] : 0; // Ocprop
     $options['f_userfound'] = isset($_REQUEST['f_userfound']) ? $_REQUEST['f_userfound'] : 0; // Ocprop
+    $options['f_unpublished'] = isset($_REQUEST['f_unpublished']) ? $_REQUEST['f_unpublished'] : 0;
     $options['f_disabled'] = isset($_REQUEST['f_disabled']) ? $_REQUEST['f_disabled'] : 0;
     $options['f_inactive'] = isset($_REQUEST['f_inactive']) ? $_REQUEST['f_inactive'] : 1; // Ocprop
     // f_inactive formerly was used for both, archived and disabled caches.
@@ -1126,6 +1127,12 @@ if ($options['showresult'] == 1) {
                      WHERE
                         `cache_logs`.`user_id`='" . sql_escape($login->userid) . "'
                         AND `cache_logs`.`type` IN (1, 7))";
+        }
+        if (!isset($options['f_unpublished'])) {
+            $options['f_unpublished'] = '0';
+        }
+        if ($options['f_unpublished'] != 0) {
+            $sql_where[] = '`caches`.`status`<>5';
         }
         if (!isset($options['f_inactive'])) {
             $options['f_inactive'] = '0';

--- a/htdocs/templates2/ocstyle/myhome.tpl
+++ b/htdocs/templates2/ocstyle/myhome.tpl
@@ -141,7 +141,7 @@ function myHomeLoad()
             <img src="resource2/{$opt.template.style}/images/cacheicon/22x20-traditional.png" width="22" height="20"  style="margin-right: 10px;" />&nbsp;
             {t 1=$hidden}Geocaches hidden: %1{/t} &nbsp;
             {* Ocprop: (find|us|own)erid=([0-9]+) *}
-            {if $caches|@count > 0}<span class="content-title-link">[<a href="search.php?showresult=1&amp;expert=0&amp;output=HTML&amp;sort=bycreated&amp;ownerid={$login.userid}&amp;searchbyowner=&amp;f_inactive=0&calledbysearch=0">{t}Show details{/t}</a>{if $active < $hidden}]&nbsp; [<a href="search.php?showresult=1&amp;expert=0&amp;output=HTML&amp;sort=bycreated&amp;ownerid={$login.userid}&amp;searchbyowner=&amp;f_inactive=1&calledbysearch=0">... {t}only active caches{/t}</a>]{/if}</span>{/if}
+            {if $caches|@count > 0}<span class="content-title-link">[<a href="search.php?showresult=1&amp;expert=0&amp;output=HTML&amp;sort=bycreated&amp;ownerid={$login.userid}&amp;searchbyowner=&amp;f_inactive=0&calledbysearch=0">{t}Show details{/t}</a>{if $active < $hidden}]&nbsp; [<a href="search.php?showresult=1&amp;expert=0&amp;output=HTML&amp;sort=bycreated&amp;ownerid={$login.userid}&amp;searchbyowner=&amp;f_inactive=1&f_unpublished=1&calledbysearch=0">... {t}only active caches{/t}</a>]{/if}</span>{/if}
         </p>
     </div>
 


### PR DESCRIPTION
### 1. Why is this change necessary?
because there is a bug

### 2. What does this change do, exactly?
exclude unpublished caches from the user's "... only active caches" list

### 3. Describe each step to reproduce the issue or behaviour.
* open myhome.php
* if there are no unpublished caches, create a new cache by newcache.php and return to myhome.php
* click on "... only active caches"

### 4. Please link to the relevant issues (if any).
https://redmine.opencaching.de/issues/1079

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
