### PR TITLE
validate entered hide date for geocaches; updates #898

### DIFF
--- a/htdocs/lang/de/ocstyle/editcache.inc.php
+++ b/htdocs/lang/de/ocstyle/editcache.inc.php
@@ -24,6 +24,8 @@ $all_countries_submit = '<input type="submit" name="show_all_countries_submit" i
 $error_general = "<tr><td class='error' colspan='2'><b>" . t('Some errors occurred, please check the marked fields.') . "</b></td></tr>";
 $name_message = '&nbsp;<span class="errormsg">' . t('Cachename is invalid') . '</span>';
 $date_message = '<span class="errormsg">' . t('date is invalid') . '</span>';
+$hide_after_publish_message = '<span class="errormsg">' . t('The cache must be hidden before publish.') . '</span>';
+$event_before_publish_message = '<span class="errormsg">' . t('The event must happen after publish.') . '</span>';
 $coords_message = '<span class="errormsg">' . t('The used coordinates are invalid.') . '</span>';
 $time_not_ok_message = '<span class="errormsg">' . t('The entered time is invalid.') . '</span>';
 $way_length_not_ok_message = '<span class="errormsg">' . t('The distance you have entered is invalid. Format aa.aaa') . '</span>';

--- a/htdocs/lang/de/ocstyle/newcache.inc.php
+++ b/htdocs/lang/de/ocstyle/newcache.inc.php
@@ -30,6 +30,8 @@
     $time_not_ok_message = '<span class="errormsg">' . t('The entered time is invalid.') . '</span>';
     $way_length_not_ok_message = '<span class="errormsg">' . t('The entered distance is invalid, Format: aa.aaa') . '</span>';
     $date_not_ok_message = '<span class="errormsg">' . t('Invalid date, format:DD-MM-JJJJ') . '</span>';
+    $hide_after_publish_message = '<span class="errormsg">' . t('The cache must be hidden before publish.') . '</span>';
+    $event_before_publish_message = '<span class="errormsg">' . t('The event must happen after publish.') . '</span>';
     $name_not_ok_message = '&nbsp;<span class="errormsg">' . t('Cachename is invalid') . '</span>';
     $tos_not_ok_message = '<br/><span class="errormsg">' . t('The cache can only be adopted if you agree our terms of use.') . '</span>';
     $type_not_ok_message = '&nbsp;<span class="errormsg">' . t('No cache-type is chosen.') . '</span>';

--- a/htdocs/newcache.php
+++ b/htdocs/newcache.php
@@ -770,7 +770,6 @@ if ($error == false) {
                 $error = true;
             }
 
-
             //check hidden_since
             $hidden_date_not_ok = true;
             if (is_numeric($hidden_day) && is_numeric($hidden_month) && is_numeric($hidden_year)) {
@@ -779,6 +778,23 @@ if ($error == false) {
             if ($hidden_date_not_ok) {
                 tpl_set_var('hidden_since_message', $date_not_ok_message);
                 $error = true;
+            } else if ($publish != 'notnow') {
+                $hidden_date = mktime(0, 0, 0, $hidden_month, $hidden_day, $hidden_year);
+                if ($publish == 'later') {
+                    // Activation hour can be ignored here. This simplifies checking event dates.
+                    $publish_date = mktime(0, 0, 0, $activate_month, $activate_day, $activate_year);
+                } else {
+                    $publish_date = time();
+                }
+                if ($sel_type == 6 && $hidden_date < $publish_date) {
+                    tpl_set_var('hidden_since_message', $event_before_publish_message);
+                    $hidden_date_not_ok = true;
+                    $error = true;
+                } elseif ($sel_type != 6 && $hidden_date > $publish_date) {
+                    tpl_set_var('hidden_since_message', $hide_after_publish_message);
+                    $hidden_date_not_ok = true;
+                    $error = true;
+                }
             }
 
             //check GC waypoint

--- a/sql/static-data/sys_trans.sql
+++ b/sql/static-data/sys_trans.sql
@@ -1953,3 +1953,5 @@ INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2656', 'as firs
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2657', 'after "%1"', '2017-08-20 19:30:00');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2658', 'as last picture', '2017-08-20 19:30:00');
 INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2659', 'Recommendation', '2017-08-20 19:30:00');
+INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2660', 'The cache must be hidden before publish.', '2017-08-20 19:30:00');
+INSERT INTO `sys_trans` (`id`, `text`, `last_modified`) VALUES ('2661', 'The event must happen after publish.', '2017-08-20 19:30:00');

--- a/sql/static-data/sys_trans_text_de.sql
+++ b/sql/static-data/sys_trans_text_de.sql
@@ -1951,3 +1951,5 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2657', 'DE', 'nach &bdquo;%1&ldquo;', '2017-08-20 19:30:00');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2658', 'DE', 'als letztes Bild', '2017-08-20 19:30:00');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2659', 'DE', 'Empfehlung', '2017-08-20 19:30:00');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2660', 'DE', 'Der Cache muss vor Veröffentlichung versteckt werden.', '2017-08-20 19:30:00');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('2661', 'DE', 'Das Event muss nach der Cacheveröffentlichung stattfinden.', '2017-08-20 19:30:00');


### PR DESCRIPTION
### 1. Why is this change necessary?
Because it prevents the user from entering invalid data.

### 2. What does this change do, exactly?
Compare the entered "hide date" for a geocache to the publish date and show an error message if
* the entered date of an event is before publish, or
* the entered date of another type of cache is after publish.

### 3. Describe each step to reproduce the issue or behaviour.
Create or edit a geocache listing and enter an invalid "hide date" (see above).

### 4. Please link to the relevant issues (if any).
https://redmine.opencaching.de/issues/898

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code

As always, this change is carefully tested and self-reviewed.

### 6. Notes
Numeric constants are used for cache state and type. This is consistent with the other editcache.php and newcache.php code. In lib2 there are named constants available which are created from the static data tables. It's probably not feasible to add this to the old 'lib' code, which needs to be refactored to a new library anyway.