### PR TITLE
change background color of transparent picture attachments

### DIFF
--- a/bin/dbsv-update.php
+++ b/bin/dbsv-update.php
@@ -1175,6 +1175,18 @@ function dbv_160()
     );
 }
 
+function dbv_161()
+{
+    // Discard thumbnails of images that may contain transparency,
+    // because background color has been changed from black to white.
+    sql(
+        "UPDATE `pictures`
+         SET `thumb_last_generated`='0000-00-00 00:00:00', thumb_url=''
+         WHERE `url` RLIKE '\.(png|gif)$'"
+    );
+}
+
+
 // When adding new mutations, take care that they behave well if run multiple
 // times. This improves robustness of database versioning.
 //

--- a/htdocs/templates2/ocstyle/res_logentry_logitem.tpl
+++ b/htdocs/templates2/ocstyle/res_logentry_logitem.tpl
@@ -86,7 +86,7 @@
             {/if}
 
             {* the position of the following image is the anchor for enlargit activity: *}
-            <a name="piclink" href="{$pictureItem.url}" onclick="enlarge(document.getElementById('pic{$pictureItem.id}'))" style="cursor:pointer">{$pictureItem.title|escape}<img id="pic{$pictureItem.id}" class="enlargegroup{$logItem.id}" src="resource2/ocstyle/images/misc/empty.png" longdesc="{$pictureItem.url}" title="{$pictureItem.title|replace:"'":"´"|replace:'"':'´´'}" alt="{$pictureItem.title|replace:"'":"´"|replace:'"':'´´'}" /></a> {* ' in title would cause enlargit and IE errors, even if escaped *}
+            <a name="piclink" href="{$pictureItem.url}" onclick="enlarge(document.getElementById('pic{$pictureItem.id}'))" style="cursor:pointer">{$pictureItem.title|escape}<img id="pic{$pictureItem.id}" class="enlargegroup{$logItem.id}" src="resource2/ocstyle/images/misc/empty.png" longdesc="{$pictureItem.url}" title="{$pictureItem.title|replace:"'":"´"|replace:'"':'´´'}" alt="{$pictureItem.title|replace:"'":"´"|replace:'"':'´´'}" style="background-color:#fff"/></a> {* ' in title would cause enlargit and IE errors, even if escaped *}
             {if $pictureItem.spoiler}
                 ({t}Spoiler{/t})
             {/if}

--- a/htdocs/templates2/ocstyle/res_logpicture.tpl
+++ b/htdocs/templates2/ocstyle/res_logpicture.tpl
@@ -3,7 +3,7 @@
         <td style="text-align:center; padding:0" align="center" valign="middle">
             <div style="max-width:{$itemwidth}px; overflow:hidden">
                 <a id="pl{$picture.pic_uuid}" href="{$picture.pic_url|replace:'http://':'https://'}">
-                    <img src="thumbs.php?type=1&uuid={$picture.pic_uuid}" class="img-{if @$nopicshadow}no{/if}shadow-loggallery" onclick="enlarge(this);" longdesc="{$picture.pic_url|replace:'http://':'https://'}" onload="document.getElementById('pl{$picture.pic_uuid}').removeAttribute('href'); this.alt='{$picture.title|replace:"'":"´"|replace:'"':'´´'}'" title="{$picture.title|replace:"'":"´"|replace:'"':'´´'}" /> {* ' in title would cause enlargit and IE errors, even if escaped *}
+                    <img src="thumbs.php?type=1&uuid={$picture.pic_uuid}" class="img-{if @$nopicshadow}no{/if}shadow-loggallery" onclick="enlarge(this);" longdesc="{$picture.pic_url|replace:'http://':'https://'}" onload="document.getElementById('pl{$picture.pic_uuid}').removeAttribute('href'); this.alt='{$picture.title|replace:"'":"´"|replace:'"':'´´'}'" title="{$picture.title|replace:"'":"´"|replace:'"':'´´'}" style="background-color:#fff" /> {* ' in title would cause enlargit and IE errors, even if escaped *}
                 </a>
                 {if $logdate || $loguser}
                     <div style="line-height:1.2em; max-height:2.4em; margin-top:5px">

--- a/htdocs/templates2/ocstyle/viewcache.tpl
+++ b/htdocs/templates2/ocstyle/viewcache.tpl
@@ -467,7 +467,7 @@ function showalllists()
             <div class="viewcache-pictureblock" {if $piccount++ % $pictures_per_row == 0}style="clear:both"{/if}>
                 <div class="img-shadow">
                     <!-- a href="{$pictureItem.url|escape}" target="_blank" -->
-                        <img class="enlargegroup_cachepics" src="thumbs.php?type=2&uuid={$pictureItem.uuid|urlencode}" longdesc="{$pictureItem.url|escape}" alt="{$pictureItem.title|escape}" border="0" align="bottom" onclick="enlarge(this)" />
+                        <img class="enlargegroup_cachepics" src="thumbs.php?type=2&uuid={$pictureItem.uuid|urlencode}" longdesc="{$pictureItem.url|escape}" alt="{$pictureItem.title|escape}" border="0" align="bottom" onclick="enlarge(this)" style="background-color:#fff" />
                     <!-- /a -->
                 </div>
                 <span class="title">{$pictureItem.title|escape}</span>

--- a/htdocs/thumbs.php
+++ b/htdocs/thumbs.php
@@ -201,6 +201,8 @@ if ($r) {
 
         // Create and save thumb
         $thumbimage = imagecreatetruecolor($thumbwidth, $thumbheight);
+        $white = imagecolorallocate($thumbimage, 255, 255, 255);
+        imagefill($thumbimage, 0, 0, $white);
         imagecopyresampled($thumbimage, $im, 0, 0, 0, 0, $thumbwidth, $thumbheight, $imwidth, $imheight);
 
         // Create directory


### PR DESCRIPTION
### 1. Why is this change necessary?

Bilder mit transparentem Hintergrund sind in aller Regel für die Darstellung auf einem hellen Hintergrund gemacht. Lädt man sie als Anhang zu einem Cache oder Log auf Opencaching.de hoch, werden sie aber auf schwarzem Hintergrund dargestellt. Dadurch wird meist wenig zu erkennen sein; man erwartet eine andere Darstellung.

### 2. What does this change do, exactly?

Setzt einen weißen Hintergrund für die Darstellung von Thumbnails und vergrößerten Bildern. (Bislang war gar kein Hintergrund gesetzt, der Default der PHP- bzw. enlargit-Funktionen war dann schwarz).

### 3. Describe each step to reproduce the issue or behaviour.

Ein Bild mit transparentem Hintergrund an einen Cache oder ein Log anhängen, z.B. die links über den OC-Header geblendete Logo-Grafik.

### 4. Please link to the relevant issues (if any).

https://redmine.opencaching.de/issues/338

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code

(Kein phpDoc für die Datenbank-Updatefunktion, weil die niemals explizit aufgerufen wird sondern nur modulinten automatisch.)