### PR TITLE
added missing error message when entering invalid profile coords

### DIFF
--- a/htdocs/src/OcLegacy/SmartyPlugins/function.coordinput.php
+++ b/htdocs/src/OcLegacy/SmartyPlugins/function.coordinput.php
@@ -63,6 +63,10 @@ function smarty_function_coordinput($params, &$smarty)
             'UTF-8'
         ) . '" size="5" maxlength="6" /> \'';
 
+    if (isset($params['laterror']) && $params['laterror'] == true) {
+        $returnValue .= ' &nbsp; <span class="errormsg">' . gettext('Invalid coordinate') . '</span>';
+    }
+
     $returnValue .= '<br />';
 
     $returnValue .= '<select name="' . htmlspecialchars($prefix, ENT_QUOTES, 'UTF-8') . 'EW">';
@@ -97,6 +101,10 @@ function smarty_function_coordinput($params, &$smarty)
             ENT_QUOTES,
             'UTF-8'
         ) . '" size="5" maxlength="6" /> \'';
+
+    if (isset($params['lonerror']) && $params['lonerror'] == true) {
+        $returnValue .= ' &nbsp; <span class="errormsg">' . gettext('Invalid coordinate') . '</span>';
+    }
 
     return $returnValue;
 }

--- a/htdocs/templates2/ocstyle/myprofile.tpl
+++ b/htdocs/templates2/ocstyle/myprofile.tpl
@@ -92,7 +92,7 @@
                 <td valign=top>{t}Home coordinates:{/t}</td>
                 <td>
                     {if $edit==true}
-                        {coordinput prefix="coord" lat=$coordsDecimal.lat lon=$coordsDecimal.lon}
+                        {coordinput prefix="coord" lat=$coordsDecimal.lat laterror=$latitudeError lon=$coordsDecimal.lon lonerror=$longitudeError}
                     {else}
                         {$coords.lat|escape} {$coords.lon|escape}
                     {/if}


### PR DESCRIPTION
### 1. Why is this change necessary?

Bugfix

### 2. What does this change do, exactly?

Zeigt im Benutzerprofil eine Fehlermeldung an, wenn man ungültige Koordinaten eingibt.

### 3. Describe each step to reproduce the issue or behaviour.

myprofile.php => Profildaten ändern => 99° Breite und/oder 200° Länge eingeben => speichern

### 4. Please link to the relevant issues (if any).

https://redmine.opencaching.de/issues/982

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
