### PR TITLE
hide coordinate historiy of quiz and safari caches; updates #958

### DIFF
--- a/htdocs/lib2/logic/cache.class.php
+++ b/htdocs/lib2/logic/cache.class.php
@@ -456,14 +456,26 @@ class cache
             return [];
         }
 
-        $rsCoords = sql(
-            "SELECT `date_created` `date`, `latitude`, `longitude`
-             FROM `cache_coordinates`
-             WHERE `cache_id`='&1'
-             ORDER BY `date_created` DESC",
+        $is_quiz_or_safari = sql_value(
+            "SELECT `type`=7 OR `type`=8 OR `attrib_id` IS NOT NULL
+             FROM `caches`
+             LEFT JOIN `caches_attributes` `ca` ON `ca`.`cache_id`=`caches`.`cache_id` AND `attrib_id`=61
+             WHERE `caches`.`cache_id`='&1'",
+            0,
             $cacheId
         );
-        $coords = sql_fetch_assoc_table($rsCoords);
+        if ($is_quiz_or_safari) {
+            $coords = [];
+        } else {
+            $rsCoords = sql(
+                "SELECT `date_created` `date`, `latitude`, `longitude`
+                 FROM `cache_coordinates`
+                 WHERE `cache_id`='&1'
+                 ORDER BY `date_created` DESC",
+                $cacheId
+            );
+            $coords = sql_fetch_assoc_table($rsCoords);
+        }
 
         if ($coords) {
             $lastcoorddate = $coords[count($coords)-1]['date'];


### PR DESCRIPTION
### 1. Why is this change necessary?

Weil damit unnütze / irritierende Informationen ausgeblendet werden.

### 2. What does this change do, exactly?

Blendet die Koordinatenhistorie von Rätsel- und Safaricaches aus.

Die Koordinatenhistorie erscheint vor/zwischen/nach den Logs eines Caches, wenn der Owner nach einem Log die Koodinaten geändert hat. Sie dient dazu, die verschiedenen Versteckorte eines Caches nachvollziehen zu können. So sieht man z.B. wo man einen Cache früher gesucht hat.

Bei Rätsel- und Safaricaches sind die Koordinaten jedoch beliebig, sie haben keinen Bezug  zum Versteck bzw. zum Fundort. Daher sind Altkoordinaten dort überflüssig und eher irritierend.

### 3. Describe each step to reproduce the issue or behaviour.

* Einen Cache loggen und danach dessen Koordinaten ändern.
* Den Cachetyp nacheinander auf Rätsel, Mathe/Physik, Virtual/Safari und auf einen anderen Typ ändern und die Koordinatenhistorie bei den Logs beobachten.

### 4. Please link to the relevant issues (if any).

https://redmine.opencaching.de/issues/958

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
