### PR TITLE
allow admins to reopen cache reports

### DIFF
--- a/htdocs/templates2/ocstyle/adminreports.tpl
+++ b/htdocs/templates2/ocstyle/adminreports.tpl
@@ -160,9 +160,10 @@ function editcomment(edit)
       </div>
 
         <p style="line-height: 1.6em; margin-bottom:24px">
-        {if !$ownreport}
+        {if !$ownreport || $reopenable}
             <input type="submit" name="assign" value="{t}Assign to me{/t}" class="formbutton" onclick="submitbutton('assign')" />
-        {else}
+        {/if}
+        {if $ownreport}
             &nbsp;<input type="submit" name="contact" value="{t}Contact owner{/t}" class="formbutton" onclick="submitbutton('contact')" />&nbsp;&nbsp;<input type="submit" name="contact_reporter" value="{t}Contact reporter{/t}" class="formbutton" onclick="submitbutton('contact_reporter')" />{if $inprogress}&nbsp;&nbsp;<input type="submit" name="done" value="{t}Mark as finished{/t}" class="formbutton" onclick="submitbutton('done')" />{/if}
             </p>
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Es verhindert Probleme durch Fehlbedienungen.

### 2. What does this change do, exactly?

Wenn man als Admin eine Cachemeldung übernommen und auf "als erledigt markiern" geklickt hat, erhält man 10 Minuten lang die Möglichkeit, die Cachemeldung wieder zu öffnen.

### 3. Describe each step to reproduce the issue or behaviour.

* Unter adminreports.php eine neue Meldung öffnen
* auf "mir zuordnen" klicken
* auf "als erledigt markieren" klicken

Bislang ist die Meldung damit endgültig geschlossen. Mit dieser Änderung erscheint 10 Minuten lang wieder der Button "mir zuordnen", um die Meldung erneut zu übernehmen.

### 4. Please link to the relevant issues (if any).

https://redmine.opencaching.de/issues/1003

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
