### PR TITLE
provide other-language hint if none available in selected language

### DIFF
--- a/htdocs/viewcache.php
+++ b/htdocs/viewcache.php
@@ -199,6 +199,29 @@ if ($rCache['status'] == 5) {
     }
 }
 
+// try to provide other-language hints if none is available for selected language
+if (trim($rCache['hint']) == '') {
+    $rs = sql(
+        "SELECT
+            `hint`,
+            IFNULL(`stt`.`text`, `native_name`) AS `language`
+         FROM `cache_desc`
+         JOIN `languages`
+            ON `languages`.`short`=`cache_desc`.`language`
+         LEFT JOIN `sys_trans_text` `stt`
+            ON `stt`.`trans_id`=`languages`.`trans_id`
+            AND `stt`.`lang`='&2'
+         WHERE `cache_desc`.`cache_id`='&1'
+         AND TRIM(`hint`) != ''",
+        $cacheid,
+        $opt['template']['locale']
+    );
+    while ($r = sql_fetch_assoc($rs)) {
+        $rCache['hint'] .= '[' . $r['language'] . '] ' . $r['hint'] . '<br />';
+    }
+    sql_free_result($rs);
+}
+
 // format waylength
 if ($rCache['waylength'] < 5) {
     if (round($rCache['waylength'], 2) != round($rCache['waylength'], 1)) {


### PR DESCRIPTION
### 1. Why is this change necessary?

Es gibt einige hundert aktive Caches auf Opencaching.de, die Beschreibungen in mehreren Sprachen haben, wo aber der verschlüsselte Hinweis nicht bei allen Sprachen vorhanden ist:

select wp_oc from caches WHERE status=1 and (select count(*) from cache_desc where cache_desc.cache_id=caches.cache_id and trim(hint)<>'') > 0 and (select count(*) from cache_desc where cache_desc.cache_id=caches.cache_id and trim(hint)<>'') < (select count(*) from cache_desc where cache_desc.cache_id=caches.cache_id)

Wenn man z.B. Deutsch gewählt hat und der Hint nur auf Englisch vorhanden ist, wird man das in der Regel nicht mitbekommen. Die Cachesuche wird dadurch erschwert, ungünstigstenfalls findet man den Cache gar nicht.

Hier kann das Einblenden der anderssprachigen Hints helfen.

### 2. What does this change do, exactly?

Wenn in der gewählten Sprache kein Hint vorhanden ist, aber in einer oder mehreren anderen Sprachen, dann werden die anderssprachigen Hints angezeigt.

### 3. Describe each step to reproduce the issue or behaviour.

Siehe z.B. die Hints bei OC1612, OC3434 und OC10E56.

### 4. Please link to the relevant issues (if any).

https://redmine.opencaching.de/issues/1071

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
