### PR TITLE
review e19a185e - avoid hard-coded url scheme

### DIFF
--- a/htdocs/lib2/OcSmarty.class.php
+++ b/htdocs/lib2/OcSmarty.class.php
@@ -187,6 +187,7 @@ class OcSmarty extends Smarty
         $optn['page']['absolute_urlpath'] = parse_url($opt['page']['absolute_url'], PHP_URL_PATH);
         $optn['page']['absolute_http_url'] = $opt['page']['absolute_http_url'];
         $optn['page']['default_absolute_url'] = $opt['page']['default_absolute_url'];
+        $optn['page']['slashed_protocol'] = $opt['page']['protocol'] . '://';
         $optn['page']['login_url'] = ($opt['page']['https']['force_login'] ? $opt['page']['absolute_https_url'] : '') . 'login.php';
         $optn['page']['target'] = $this->target;
         $optn['page']['showdonations'] = $opt['page']['showdonations'];

--- a/htdocs/templates2/ocstyle/res_logpicture.tpl
+++ b/htdocs/templates2/ocstyle/res_logpicture.tpl
@@ -2,8 +2,8 @@
     <table width="100%" height="100%"><tr>
         <td style="text-align:center; padding:0" align="center" valign="middle">
             <div style="max-width:{$itemwidth}px; overflow:hidden">
-                <a id="pl{$picture.pic_uuid}" href="{$picture.pic_url|replace:'http://':'https://'}">
-                    <img src="thumbs.php?type=1&uuid={$picture.pic_uuid}" class="img-{if @$nopicshadow}no{/if}shadow-loggallery" onclick="enlarge(this);" longdesc="{$picture.pic_url|replace:'http://':'https://'}" onload="document.getElementById('pl{$picture.pic_uuid}').removeAttribute('href'); this.alt='{$picture.title|replace:"'":"´"|replace:'"':'´´'}'" title="{$picture.title|replace:"'":"´"|replace:'"':'´´'}" /> {* ' in title would cause enlargit and IE errors, even if escaped *}
+                <a id="pl{$picture.pic_uuid}" href="{$picture.pic_url|replace:'http://':$opt.page.slashed_protocol}">
+                    <img src="thumbs.php?type=1&uuid={$picture.pic_uuid}" class="img-{if @$nopicshadow}no{/if}shadow-loggallery" onclick="enlarge(this);" longdesc="{$picture.pic_url|replace:'http://':$opt.page.slashed_protocol}" onload="document.getElementById('pl{$picture.pic_uuid}').removeAttribute('href'); this.alt='{$picture.title|replace:"'":"´"|replace:'"':'´´'}'" title="{$picture.title|replace:"'":"´"|replace:'"':'´´'}" /> {* ' in title would cause enlargit and IE errors, even if escaped *}
                 </a>
                 {if $logdate || $loguser}
                     <div style="line-height:1.2em; max-height:2.4em; margin-top:5px">


### PR DESCRIPTION
### 1. Why is this change necessary?

Der OC-Code verwendet bislang durchgehend kein hart-codiertes URL-Schema (http / https) sondern hält das flexibel. Wird zwar seit Kurzem auf www.opencaching.de nicht mehr genutzt, kann aber in anderen Umgebungen noch nützlich sein (z.B. Entwicklersystem, Wiederverwendung des freien OCDE-Codes für andere Websites).

### 2. What does this change do, exactly?

URL für lokale Bildinks durch das Protokoll der aktuellen Abfrage ersetzen statt hart durch "https".

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
