### PR TITLE
fix url scheme of cache pic gallery overlay images; updates #1107

### DIFF
--- a/htdocs/viewcache.php
+++ b/htdocs/viewcache.php
@@ -294,7 +294,6 @@ $rs = sql(
             `uuid`,
             `url`,
             `title`,
-            `thumb_url`,
             `spoiler`,
             `display`
      FROM `pictures`
@@ -304,8 +303,13 @@ $rs = sql(
      ORDER BY `seq`",
     $cacheid
 );
-$tpl->assign_rs('pictures', $rs);
+$cachepics = [];
+while ($r = sql_fetch_assoc($rs)) {
+    $r['url'] = use_current_protocol($r['url']);
+    $cachepics[] = $r;
+}
 sql_free_result($rs);
+$tpl->assign('pictures', $cachepics);
 
 $tpl->assign('pictures_per_row', $opt['logic']['pictures']['listing_thumbs_per_row']);
 // REDISGN TODO:


### PR DESCRIPTION
### 1. Why is this change necessary?

Bugfix. Bei angehängten Bildern in Cachebeschreibungen, die noch auf http://www.opencaching.de hochgeladen worden waren, wird beim Klick auf die Thumbnails die http-Bild-URL geöffnet. Sollte auf https://www.opencaching.de aber eine https-URL sein.

### 2. What does this change do, exactly?

pictures.url auf das ULR-Schema des aktiven Requests umbiegen.

Damit das auf www.opencaching.de tatsächlich funktioniert, muss auch der Bug #1107 behoben werden (lokales Konfigurationsproblem?).

### 3. Describe each step to reproduce the issue or behaviour.

* https://www.opencaching.de/viewcache.php?wp=OCE793
* auf das Bild von der Bunkertür klicken
* rechte Maustaste -> Bildadresse kopieren: sie lautet http://www.opencaching.de/images/uploads/1F0D4580-CEA2-11E1-A758-00163E0AF0A3.jpg statt https://...

### 4. Please link to the relevant issues (if any).

vgl. https://redmine.opencaching.de/issues/1107

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
