### PR TITLE
don't display only-whitespace short cache descriptions

### DIFF
--- a/htdocs/templates2/ocstyle/viewcache.tpl
+++ b/htdocs/templates2/ocstyle/viewcache.tpl
@@ -160,7 +160,7 @@
 
         <div class="content2-container-2col-left" id="cache_name_block">
             <span class="content-title-noshade-size5">{$cache.name|escape}</span>
-            {if $cache.shortdesc!=''}
+            {if $cache.shortdesc|trim != ''}
                 <!-- <br /> --><p class="content-title-noshade-size1">&nbsp;{$cache.shortdesc|escape}</p>
             {/if}
 


### PR DESCRIPTION
### 1. Why is this change necessary?

it improves display of cache listings / makes display consistent

### 2. What does this change do, exactly?

Do not display cache descriptions that only contain whitespaces.

### 3. Describe each step to reproduce the issue or behaviour.

https://www.opencaching.de/viewcache.php?wp=OCC9BF => empty line below cache name

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
