### PR TITLE
fixed logpic gallery for own caches (33637efa)

### DIFF
--- a/htdocs/myhome.php
+++ b/htdocs/myhome.php
@@ -140,7 +140,7 @@ if ($allpics === '1') {
 if ($allpics == 'ownlogs' || $allpics == 'owncaches') {
     $gallery =  ($allpics == 'ownlogs' ? LogPics::FOR_OWNLOGS_GALLERY : LogPics::FOR_OWNCACHES_GALLERY);
     $all_pictures = LogPics::get($gallery);
-    LogPics::setPaging($gallery, 0, 0, "myhome.php?allpics=1");
+    LogPics::setPaging($gallery, 0, 0, "myhome.php?allpics=" . $allpics);
 } else {
     $all_pictures = LogPics::get(LogPics::FOR_OWNLOGS_GALLERY);
     $tpl->assign('pictures', $all_pictures);


### PR DESCRIPTION
### 1. Why is this change necessary?

Bug in new feature introduced by PR #535

### 2. What does this change do, exactly?

Fix paging in own-caches log picture gallery

### 3. Describe each step to reproduce the issue or behaviour.

see redmine 39, last comment

### 4. Please link to the relevant issues (if any).

https://redmine.opencaching.de/issues/39

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
