### PR TITLE
added cross reference comment to CacheLocation cronjob

### DIFF
--- a/htdocs/util2/cron/modules/cache_location.class.php
+++ b/htdocs/util2/cron/modules/cache_location.class.php
@@ -9,6 +9,14 @@
  *
  ***************************************************************************/
 
+// This file is also included in bin/dbsv-update.php! If you change anything
+// here, take care that the DB mutation 161 still works, i.e. it should at
+// least not crash. If keeping it downward compatible is expensive, you may
+// simply decide to remove the "CacheLocation" inclusion and call from the
+// DB mutation 161; the only negative effect might be that on some lately
+// updated developer or test machine caches.last_modified=NOW() is set
+// for some eastern european caches.
+
 checkJob(new CacheLocation());
 
 class CacheLocation


### PR DESCRIPTION
### 1. Why is this change necessary?

Database mutation 161 may be accidentially broken by changes in cache_location.class.php.

### 2. What does this change do, exactly?

Add a comment to cache_location.class.php to prevent that.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
