### PR TITLE
hide irrelevant cache and log modification dates; updates #1109

### DIFF
--- a/htdocs/lib2/logic/cache.class.php
+++ b/htdocs/lib2/logic/cache.class.php
@@ -531,13 +531,14 @@ class cache
         }
 
         $rsLogs = sql(
-            'SELECT `cache_logs`.`user_id` AS `userid`,
+            "SELECT `cache_logs`.`user_id` AS `userid`,
                     `cache_logs`.`id` AS `id`,
                     `cache_logs`.`uuid` AS `uuid`,
                     `cache_logs`.`date` AS `date`,
                     `cache_logs`.`order_date` AS `order_date`,
                     `cache_logs`.`entry_last_modified`,
-                    DATEDIFF(`cache_logs`.`entry_last_modified`, `cache_logs`.`date_created`) >= 1 AS `late_modified`,
+                    (`cache_logs`.`node` != 1 OR `cache_logs`.`entry_last_modified` != '2017-02-14 22:49:20')  /* see redmine #1109 */
+                    AND DATEDIFF(`cache_logs`.`entry_last_modified`, `cache_logs`.`date_created`) >= 1 AS `late_modified`,
                     substr(`cache_logs`.`date`,12) AS `time`,  /* 00:00:01 = 00:00 logged, 00:00:00 = no time */
                     `cache_logs`.`type` AS `type`,
                     `cache_logs`.`oc_team_comment` AS `oc_team_comment`,
@@ -546,7 +547,7 @@ class cache
                     `cache_logs`.`text` AS `text`,
                     `cache_logs`.`text_html` AS `texthtml`,
                     `cache_logs`.`picture`,
-                    ' . $delfields . ",
+                    " . $delfields . ",
                     `user`.`username` AS `username`,
                     IF(ISNULL(`cache_rating`.`cache_id`), 0, `cache_logs`.`type` IN (1,7)) AS `recommended`
              FROM $table AS `cache_logs`

--- a/htdocs/templates2/ocstyle/viewcache.tpl
+++ b/htdocs/templates2/ocstyle/viewcache.tpl
@@ -233,7 +233,10 @@
             {if $cache.searchtime>0 || $cache.waylength>0}<br />{/if}
             <img src="resource2/{$opt.template.style}/images/viewcache/date.png" class="icon16" alt="" title="" align="middle" />&nbsp;{if $cache.type==6}{t}Event date:{/t}{else}{t}Hidden on:{/t}{/if} {$cache.datehidden|date_format:$opt.format.datelong}<br />
             <img src="resource2/{$opt.template.style}/images/viewcache/date.png" class="icon16" alt="" title="" align="middle" />&nbsp;{if $cache.is_publishdate==0}{t}Listed since:{/t}{else}{t}Published on:{/t}{/if} {$cache.datecreated|date_format:$opt.format.datelong}<br />
-            <img src="resource2/{$opt.template.style}/images/viewcache/date.png" class="icon16" alt="" title="" align="middle" />&nbsp;{t}Last update:{/t} {$cache.lastmodified|date_format:$opt.format.datelong}<br />  {* Ocprop: <br />\s*Wegpunkt: (OC[A-Z0-9]+)\s*<br /> -- Waypoint: <b>(OC[A-Z0-9]+)<\/b><br \/> *}
+            {if $cache.show_last_modified}
+                <img src="resource2/{$opt.template.style}/images/viewcache/date.png" class="icon16" alt="" title="" align="middle" />&nbsp;{t}Last update:{/t} {$cache.lastmodified|date_format:$opt.format.datelong}<br />
+            {/if}
+            {* Ocprop: <br />\s*Wegpunkt: (OC[A-Z0-9]+)\s*<br /> -- Waypoint: <b>(OC[A-Z0-9]+)<\/b><br \/> *}
             <!-- Ocprop: <br /> Wegpunkt: <b>{$cache.wpoc}</b><br /> -->
             <img src="resource2/{$opt.template.style}/images/viewcache/arrow_in.png" class="icon16" alt="" title="" align="middle" />&nbsp;{t}Listing{/t}{t}#colonspace#{/t}: {if $shortlink_url !== false}{$shortlink_url}{/if}<b>{$cache.wpoc}</b><br />
             {if $cache.wpgc!=''}<img src="resource2/{$opt.template.style}/images/viewcache/link.png" class="icon16" alt="" title="" align="middle" />

--- a/htdocs/viewcache.php
+++ b/htdocs/viewcache.php
@@ -101,7 +101,8 @@ if ($login->userid != 0) {
 $rs = sql(
     "SELECT `caches`.`cache_id` AS `cacheid`,
             `caches`.`listing_last_modified` AS `lastmodified`,
-            `caches`.`user_id` AS `userid`,
+            `caches`.`node` != 1 OR`caches`.`listing_last_modified` != '2017-02-14 22:54:22' AS `show_last_modified`,
+            `caches`.`user_id` AS `userid`,      /* see redmine #1109 */
             `caches`.`status` AS `status`,
             `caches`.`latitude` AS `latitude`,
             `caches`.`longitude` AS `longitude`,


### PR DESCRIPTION
### 1. Why is this change necessary?

Misleading modification dates are displayed for some hundred caches and some thousand logs at Opencaching.de.

### 2. What does this change do, exactly?

Hide modification dates of caches and logs which were touched by a manual database operation on 14 February 2017. After this change, those dates will be
* completely hidden on www.opencaching.de
* geocache dates still be visible via OKAPI (but we may add a flag field to indicate dates that should be discarded)
* geocache and log dates still visible via XML interface (neglectable)

### 3. Describe each step to reproduce the issue or behaviour.

See e.g. modification dates of
* caches: [OC4093](https://www.opencaching.de/viewcache.php?cacheid=119592),  [OC75A1](https://www.opencaching.de/viewcache.php?cacheid=133182), [OC3FD7](https://www.opencaching.de/viewcache.php?cacheid=119404)
* logs: [ID 108705 and 108708](https://www.opencaching.de/viewcache.php?cacheid=112001&log=A#log108708)

### 4. Please link to the relevant issues (if any).

https://redmine.opencaching.de/issues/1109

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
