### PR TITLE
changed OC http site links to https

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -41,7 +41,7 @@ If you are using this source code to establish a geocache listing service
 or some sort of service which can be compared with it, you agree to 
 publish your geocaching data via XML Interface and/or OKAPI the same way
 and under the same (or less restrictive) conditions as opencaching.de does;
-see http://www.opencaching.de/doc/xml and http://www.opencaching.de/okapi.
+see https://www.opencaching.de/doc/xml and https://www.opencaching.de/okapi.
 
 
 A different license may apply to third party components being used.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Opencaching.de Code Repository
 ==============================
 
-[Opencaching.de](http://www.opencaching.de) is a major Geocaching website in Germany.
+[Opencaching.de](https://www.opencaching.de) is a major Geocaching website in Germany.
 This repository contains the website's code, including all third-party libraries
 needed to run it. It is one of two major
 [Opencaching code forks](http://wiki.opencaching.de/index.php/Datei:Codegenerationen.png); 
@@ -30,7 +30,7 @@ This repo contains three branches:
 The *next* branch is now and then resetted to development state and rebuilt from there,
 so do not derive any working-branches from it. Use development instead.
 
-Major OC.de site updates are version-tagged. See the [changelog](http://www.opencaching.de/articles.php?page=changelog&locale=EN)
+Major OC.de site updates are version-tagged. See the [changelog](https://www.opencaching.de/articles.php?page=changelog&locale=EN)
 for a detailed list.
 
 Translation [![Crowdin](https://d322cqt584bo4o.cloudfront.net/opencaching/localized.svg)](https://crowdin.com/project/opencaching)

--- a/htdocs/config2/nodetext/1.txt
+++ b/htdocs/config2/nodetext/1.txt
@@ -1,9 +1,9 @@
 site_title Opencaching.de
-site_url http://www.opencaching.de
+site_url https://www.opencaching.de
 site_contact http://opencaching.wikispaces.com/Kontakt
 faq_login http://cms.opencaching.de/index.php?id=login
 faq_npa http://cms.opencaching.de/index.php?id=140
-faq_htmltag http://www.opencaching.de/articles.php?page=htmltags
+faq_htmltag https://www.opencaching.de/articles.php?page=htmltags
 terms_of_service articles.php?page=impressum#tos
 faq_cacheinfo articles.php?page=cacheinfo
 terms_privacy articles.php?page=dsb

--- a/htdocs/config2/settings-dist.inc.php
+++ b/htdocs/config2/settings-dist.inc.php
@@ -184,10 +184,10 @@ $opt['debug'] = DEBUG_DEVELOPER;
 /* other template options
  *
  */
-$opt['page']['origin_url'] = 'http://www.opencaching.de/';  // production installation for this OC site
+$opt['page']['origin_url'] = 'https://www.opencaching.de/';  // production installation for this OC site
 $opt['page']['develsystem'] = false;
-$opt['page']['teampic_url'] = 'http://www.opencaching.de/images/team/';
-$opt['page']['teammember_url'] = 'http://www.opencaching.de/';
+$opt['page']['teampic_url'] = 'https://www.opencaching.de/images/team/';
+$opt['page']['teammember_url'] = 'https://www.opencaching.de/';
 
 /*
  * configure infos on 404.php
@@ -217,19 +217,19 @@ $opt['page']['404']['www.opencaching.de'] = [
 
     'newcaches' => [
         'show' => true,
-        'url' => 'http://www.opencaching.de',
+        'url' => 'https://www.opencaching.de',
         'urlname' => '',  // optional: show other name than the url-domain
     ],
 ];
 
 /* Well known node id's - required for synchronization
  *  1 Opencaching Deutschland (www.opencaching.de)
- *  2 Opencaching Polen (www.opencaching.pl)
+ *  2 Opencaching Polen (opencaching.pl)
  *  3 Opencaching Tschechien (www.opencaching.cz)
  *  4 Local Development
  *  5 Opencaching Entwicklung Deutschland (devel.opencaching.de)
  *  6 Opencaching Schweden (www.opencaching.se)
- *  7 Opencaching Großbritannien (www.opencache.uk)
+ *  7 Opencaching Großbritannien (opencache.uk)
  *  8 Opencaching Norwegen (www.opencaching.no)
  *  9 Opencaching Lettland (?)
  * 10 Opencaching USA (www.opencaching.us)

--- a/htdocs/config2/settings-sample.inc.php
+++ b/htdocs/config2/settings-sample.inc.php
@@ -109,7 +109,7 @@ $opt['template']['default']['locale'] = 'DE'; // can be overwritten by $opt['dom
  * Must be overwritten in BOTH lib1 and lib2 settings.inc.php,
  * and BEFORE calling set_absolute_urls!
  */
-//$opt['domain']['www.opencaching.de']['url'] = 'http://www.opencaching.de/';
+//$opt['domain']['www.opencaching.de']['url'] = 'https://www.opencaching.de/';
 //$opt['domain']['www.opencaching.de']['shortlink_domain'] = 'opencaching.de';
 //$opt['domain']['www.opencaching.de']['sitename'] = 'Opencaching.de';
 //$opt['domain']['www.opencaching.de']['locale'] = 'DE';
@@ -126,7 +126,7 @@ $opt['template']['default']['locale'] = 'DE'; // can be overwritten by $opt['dom
 //$opt['domain']['www.opencaching.de']['https']['is_default'] = false;
 //$opt['domain']['www.opencaching.de']['https']['force_login'] = true;
 
-//$opt['domain']['www.opencaching.pl']['url'] = 'http://www.opencaching.pl/';
+//$opt['domain']['www.opencaching.pl']['url'] = 'https://opencaching.pl/';
 //$opt['domain']['www.opencaching.pl']['sitename'] = 'Opencaching.PL';
 //$opt['domain']['www.opencaching.pl']['locale'] = 'PL';
 //$opt['domain']['www.opencaching.pl']['fallback_locale'] = 'EN';
@@ -140,7 +140,7 @@ $opt['template']['default']['locale'] = 'DE'; // can be overwritten by $opt['dom
 // Supply the site's primary URL and the shortlink domain here.
 // Can be overriden by domain settings.
 // Set shortlink domain to false if not available.
-set_absolute_urls($opt, 'http://www.opencaching.de/', 'opencaching.de', 2);
+set_absolute_urls($opt, 'https://www.opencaching.de/', 'opencaching.de', 2);
 
 /* The OC site's ID; see settings-dist.inc.php for known IDs.
  */
@@ -244,6 +244,6 @@ function post_config()
             config_domain_www_opencachingspain_es();
             break;
         default:
-            $tpl->redirect('http://www.opencaching.de/index.php');
+            $tpl->redirect('https://www.opencaching.de/index.php');
     }
 }

--- a/htdocs/doc/xml/xml11.htm
+++ b/htdocs/doc/xml/xml11.htm
@@ -17,7 +17,7 @@
             <a href="../../okapi/">Opencaching-API</a> (OKAPI) zur Verfügung.
         </p>
         <p>
-            <span style="color:red">Die abgerufenen Daten sind urheberrechtlich geschützt und dürfen nur unter den Bedingungen der <a href="http://www.opencaching.de/articles.php?page=impressum#datalicense">Opencaching.de-Datenlizenz</a> weitergegeben und genutzt werden.</span>
+            <span style="color:red">Die abgerufenen Daten sind urheberrechtlich geschützt und dürfen nur unter den Bedingungen der <a href="https://www.opencaching.de/articles.php?page=impressum#datalicense">Opencaching.de-Datenlizenz</a> weitergegeben und genutzt werden.</span>
         </p>
 
         <p>
@@ -28,7 +28,7 @@
             This documentation is currently available in German only. If you need english text,
             please contact us at <a href="mailto:kontakt@opencaching.de">kontakt@opencaching.de</a>
             and tell us about the application you are going to develop; then we may translate it.<br />
-            <span style="color:red">The downloaded data is copyrighted and must only be used under the terms of <a href="http://www.opencaching.de/articles.php?page=impressum&locale=EN#datalicense">Opencaching.de data license</a>.</span></em>
+            <span style="color:red">The downloaded data is copyrighted and must only be used under the terms of <a href="https://www.opencaching.de/articles.php?page=impressum&locale=EN#datalicense">Opencaching.de data license</a>.</span></em>
         </p>
 
         <h2>Version 1.1</h2>
@@ -41,7 +41,7 @@
         </ul>
         <p>Seit dem 7. April 2013 gibt es folgende Ergänzung:</p>
         <ul>
-            <li>Wenn beim Auruf der zusätzliche Parameter "&amp;license=1" angegeben ist, wird bei Cachebeschreibungen, Logs und Bildern ein zusätzliches Feld &lt;license&gt;...&lt;/license&gt; mitgeliefert, das einen Copyright-Disclaimer gemäß <a href="http://www.opencaching.de/articles.php?page=impressum#datalicense">Datenlizenz</a> enthält. Dieser ist bei der Darstellung der Daten mit anzuzeigen und bei Weitergabe mitzuliefern. Wenn der license-Parameter <em>nicht</em> angegeben ist, wird der Disclaimer automatisch an alle Cachebeschreibungen angehängt. <br />
+            <li>Wenn beim Auruf der zusätzliche Parameter "&amp;license=1" angegeben ist, wird bei Cachebeschreibungen, Logs und Bildern ein zusätzliches Feld &lt;license&gt;...&lt;/license&gt; mitgeliefert, das einen Copyright-Disclaimer gemäß <a href="https://www.opencaching.de/articles.php?page=impressum#datalicense">Datenlizenz</a> enthält. Dieser ist bei der Darstellung der Daten mit anzuzeigen und bei Weitergabe mitzuliefern. Wenn der license-Parameter <em>nicht</em> angegeben ist, wird der Disclaimer automatisch an alle Cachebeschreibungen angehängt. <br />
             Mit dem zusätzlichen Parameter "language" kann die Sprache des Disclaimers gewählt werden,
             z.&nbsp;B. "&amp;language=de" für Deutsch. Ist "language" nicht angegeben, wird der Text
             nach Möglichkeit in der Sprache der Cachebeschreibung bzw. des Logeintrags erzeugt,
@@ -113,24 +113,24 @@
             eine neue id für den Datensatz erzeugt und die uuid beibhalten.</p>
         <h3>Attributliste</h3>
         <p>&lt;attrlist&gt;<br />
-            &nbsp; &lt;attr id="1" icon_large="http://www.opencaching.de/images/attributes/night.gif"<br />
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; icon_no="http://www.opencaching.de/images/attributes/night-no.gif"<br />
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; icon_undef="http://www.opencaching.de/images/attributes/night-undef.gif"&gt;<br />
+            &nbsp; &lt;attr id="1" icon_large="https://www.opencaching.de/images/attributes/night.gif"<br />
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; icon_no="https://www.opencaching.de/images/attributes/night-no.gif"<br />
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; icon_undef="https://www.opencaching.de/images/attributes/night-undef.gif"&gt;<br />
             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &lt;![CDATA[Nachtcache]]&gt;<br />
             &nbsp; &lt;/attr&gt;<br />
-            &nbsp; &lt;attr id="6" icon_large="http://www.opencaching.de/images/attributes/oconly.gif"<br />
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; icon_no="http://www.opencaching.de/images/attributes/oconly-no.gif"<br />
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; icon_undef="http://www.opencaching.de/images/attributes/oconly-undef.gif"&gt;<br />
+            &nbsp; &lt;attr id="6" icon_large="https://www.opencaching.de/images/attributes/oconly.gif"<br />
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; icon_no="https://www.opencaching.de/images/attributes/oconly-no.gif"<br />
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; icon_undef="https://www.opencaching.de/images/attributes/oconly-undef.gif"&gt;<br />
             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &lt;![CDATA[Nur bei Opencaching]]&gt;<br />
             &nbsp; &lt;/attr&gt;<br />
-            &nbsp; &lt;attr id="7" icon_large="http://www.opencaching.de/images/attributes/wwwlink.gif"<br />
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; icon_no="http://www.opencaching.de/images/attributes/wwwlink-no.gif"<br />
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; icon_undef="http://www.opencaching.de/images/attributes/wwwlink-undef.gif"&gt;<br />
+            &nbsp; &lt;attr id="7" icon_large="https://www.opencaching.de/images/attributes/wwwlink.gif"<br />
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; icon_no="https://www.opencaching.de/images/attributes/wwwlink-no.gif"<br />
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; icon_undef="https://www.opencaching.de/images/attributes/wwwlink-undef.gif"&gt;<br />
             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &lt;![CDATA[Nur Hyperlink]]&gt;<br />
             &nbsp; &lt;/attr&gt;<br />
-            &nbsp; &lt;attr id="8" icon_large="http://www.opencaching.de/images/attributes/letterbox.gif"<br />
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; icon_no="http://www.opencaching.de/images/attributes/letterbox-no.gif"<br />
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; icon_undef="http://www.opencaching.de/images/attributes/letterbox-undef.gif"&gt;<br />
+            &nbsp; &lt;attr id="8" icon_large="https://www.opencaching.de/images/attributes/letterbox.gif"<br />
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; icon_no="https://www.opencaching.de/images/attributes/letterbox-no.gif"<br />
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; icon_undef="https://www.opencaching.de/images/attributes/letterbox-undef.gif"&gt;<br />
             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &lt;![CDATA[Letterbox (benötigt Stempel)]]&gt;<br />
             &nbsp; &lt;/attr&gt;<br />
             &lt;/attrlist&gt;<br />
@@ -231,7 +231,7 @@
             &lt;picture&gt;<br />
             &nbsp; &lt;id id="4619"&gt;558990D1-4DE2-50AF-B53A-135E87704D70&lt;/id&gt;<br />
             &nbsp;
-            &lt;url&gt;http://www.opencaching.de/images/uploads/558990D1-4DE2-50AF-B53A-135E87704D70.jpg&lt;/url&gt;<br />
+            &lt;url&gt;https://www.opencaching.de/images/uploads/558990D1-4DE2-50AF-B53A-135E87704D70.jpg&lt;/url&gt;<br />
             &nbsp; &lt;title&gt;&lt;![CDATA[Schlurfende Gestalten]]&gt;&lt;/title&gt;<br />
             &nbsp; &lt;desc html="0"&gt;&lt;/desc&gt;<br />
             &nbsp; &lt;object id="73240" type="1" typename=
@@ -300,20 +300,20 @@
         <p>Paramter uuid ... wie cacheid, ausser dass statt der cacheid die UUID des Caches verwendet wird.</p>
         <h3>Beispiele</h3>
         <p>1. Alle Daten inkrementell abrufen<br/>
-            <a>http://www.opencaching.de/xml/ocxml15.php?modifiedsince=&lt;date&gt;&amp;user=1&amp;cache=1&amp;cachedesc=1&amp;cachelog=1&amp;picture=1&amp;removedobject=1</a></p>
+            <a>https://www.opencaching.de/xml/ocxml15.php?modifiedsince=&lt;date&gt;&amp;user=1&amp;cache=1&amp;cachedesc=1&amp;cachelog=1&amp;picture=1&amp;removedobject=1</a></p>
         <p>2. Alle Daten von Deutschland inkrementell abrufen<br/>
-            <A>http://www.opencaching.de/xml/ocxml15.php?modifiedsince=&lt;date&gt;&amp;cache=1&amp;cachedesc=1&amp;cachelog=1&amp;picture=1&amp;removedobject=0&amp;country=DE&amp;picturefromcachelog=1</a></p>
+            <A>https://www.opencaching.de/xml/ocxml15.php?modifiedsince=&lt;date&gt;&amp;cache=1&amp;cachedesc=1&amp;cachelog=1&amp;picture=1&amp;removedobject=0&amp;country=DE&amp;picturefromcachelog=1</a></p>
         <p>3. Alle Caches ohne Logs von Deutschland inkrementell abrufen<br/>
-            <a>http://www.opencaching.de/xml/ocxml15.php?modifiedsince=&lt;date&gt;&amp;cache=1&amp;cachedesc=1&amp;picture=1&amp;removedobject=0&amp;country=DE</a></p>
+            <a>https://www.opencaching.de/xml/ocxml15.php?modifiedsince=&lt;date&gt;&amp;cache=1&amp;cachedesc=1&amp;picture=1&amp;removedobject=0&amp;country=DE</a></p>
         <p>4. Alle Daten im Umkreis von 15 km abrufen<br/>
-            <a>http://www.opencaching.de/xml/ocxml15.php?modifiedsince=&lt;date&gt;&amp;cache=1&amp;cachedesc=1&amp;cachelog=1&amp;picture=1&amp;removedobject=0&amp;lat=48&amp;lon=9&amp;distance=15&amp;picturefromcachelog=1</a></p>
+            <a>https://www.opencaching.de/xml/ocxml15.php?modifiedsince=&lt;date&gt;&amp;cache=1&amp;cachedesc=1&amp;cachelog=1&amp;picture=1&amp;removedobject=0&amp;lat=48&amp;lon=9&amp;distance=15&amp;picturefromcachelog=1</a></p>
         <p>5. Alle Bilder abrufen<br/>
-            <a>http://www.opencaching.de/xml/ocxml15.php?modifiedsince=&lt;date&gt;&amp;picture=1</a></p>
+            <a>https://www.opencaching.de/xml/ocxml15.php?modifiedsince=&lt;date&gt;&amp;picture=1</a></p>
         <p>6. Alle Bilder von Caches abrufen die in Deutschland versteckt sind<br/>
-            <a>http://www.opencaching.de/xml/ocxml2.php?modifiedsince=&lt;date&gt;&amp;picture=1&amp;country=DE</a></p>
+            <a>https://www.opencaching.de/xml/ocxml2.php?modifiedsince=&lt;date&gt;&amp;picture=1&amp;country=DE</a></p>
         <p>7. Alle Bilder von Caches und deren Logs abrufen die in Deutschland versteckt
             sind<br/>
-            <a>http://www.opencaching.de/xml/ocxml15.php?modifiedsince=&lt;date&gt;&amp;picture=1&amp;country=DE</a>&amp;picturefromcachelog=1</p>
+            <a>https://www.opencaching.de/xml/ocxml15.php?modifiedsince=&lt;date&gt;&amp;picture=1&amp;country=DE</a>&amp;picturefromcachelog=1</p>
         <p>Mit ocxml11.php kann stattdessen die Interface-Version 1.1 verwendet werden.</p>
         <p>Diese Anfragen werden mit einem kurzen XML-Stream beantwortet, der die
             XML-Session-Id zurückgibt. Mit dieser Id können dann die Daten abgerufen
@@ -329,9 +329,9 @@
             Summe der Datensätze ist in diesem Beispiel 1205 - es werden also 3 Aufrufe
             benötigt (500, 500, 205 Datensätze).</p>
         <p>Die Daten können dann mit folgender Anfrage abgerufen werden:<br/>
-            <a>http://www.opencaching.de/xml/ocxml15.php?sessionid=12345&amp;file=1</a><br/>
-            <a>http://www.opencaching.de/xml/ocxml15.php?sessionid=12345&amp;file=2</a><br/>
-            <a>http://www.opencaching.de/xml/ocxml15.php?sessionid=12345&amp;file=3</a></p>
+            <a>https://www.opencaching.de/xml/ocxml15.php?sessionid=12345&amp;file=1</a><br/>
+            <a>https://www.opencaching.de/xml/ocxml15.php?sessionid=12345&amp;file=2</a><br/>
+            <a>https://www.opencaching.de/xml/ocxml15.php?sessionid=12345&amp;file=3</a></p>
         <p>Die Sessionid ist eine Stunde lang gültig, wobei sich dieser Zeitraum mit jedem
             einzelnen Dateiabruf verlängert &ndash; zwischen den Einzelabrufen darf also
             maximal eine Stunde vergehen. Dauert es länger, müsste eine neue sessionid
@@ -340,14 +340,14 @@
         <p>Um alle Ergebnisse in einer Datei abzurufen muss bei dem Aufruf der Paramter
             session auf 0 gesetzt werden.</p>
         <p>Beispeil:<br/>
-            <a>http://www.opencaching.de/xml/ocxml15.php?modifiedsince=&lt;date&gt;&amp;user=1&amp;cache=1&amp;cachedesc=1&amp;cachelog=1&amp;picture=1&amp;removedobject=1&amp;session=0</a></p>
+            <a>https://www.opencaching.de/xml/ocxml15.php?modifiedsince=&lt;date&gt;&amp;user=1&amp;cache=1&amp;cachedesc=1&amp;cachelog=1&amp;picture=1&amp;removedobject=1&amp;session=0</a></p>
         <h3>Dateikomprimierung einstellen</h3>
         <p>Dei Dateikomprimierung kann mit dem Paramter zip eingestellt weren. Mögliche
             Werte sind 0, zip, bzip2, gzip. Null bedeutet hier keine Kompression. Wird
             keine Kompression angegeben, wird zip verwendet.</p>
         <p>Beispeil:<br/>
-            <a>http://www.opencaching.de/xml/ocxml15.php?modifiedsince=&lt;date&gt;&amp;user=1&amp;cache=1&amp;cachedesc=1&amp;cachelog=1&amp;picture=1&amp;removedobject=1&amp;session=0&amp;zip=bzip2</a><br/>
-            <a>http://www.opencaching.de/xml/ocxml15.php?sessionid=12345&amp;file=1&amp;zip=gzip</a></p>
+            <a>https://www.opencaching.de/xml/ocxml15.php?modifiedsince=&lt;date&gt;&amp;user=1&amp;cache=1&amp;cachedesc=1&amp;cachelog=1&amp;picture=1&amp;removedobject=1&amp;session=0&amp;zip=bzip2</a><br/>
+            <a>https://www.opencaching.de/xml/ocxml15.php?sessionid=12345&amp;file=1&amp;zip=gzip</a></p>
             <h3>XML-Optionen</h3>
             <p>Die folgenden XML-Optionen müssen bei jedem Aufruf übergeben
             werden.</p>
@@ -361,8 +361,8 @@
             charset ... (Default) iso-8859-1 / utf-8<br />
             attrlist ... (Default) 0 = keine Attributliste &uuml;bertragen / 1 = Attributliste &uuml;bertragen</p>
             <h4><a>Beispiele</a></h4>
-            <p>http://www.opencaching.de/xml/ocxml15.php?modifiedsince=20060320000000&amp;user=1&amp;cache=1&amp;cachelog=1&amp;cachedesc=1&amp;picture=1&amp;removedobject=1&amp;session=1&amp;charset=utf-8&amp;cdata=1&amp;xmldecl=0&amp;ocxmltag=0&amp;doctype=0<br/>
-            http://www.opencaching.de/xml/ocxml15.php?sessionid=4711&amp;file=1&amp;charset=utf-8&amp;cdata=1&amp;xmldecl=0&amp;ocxmltag=0&amp;doctype=0</p>
+            <p>https://www.opencaching.de/xml/ocxml15.php?modifiedsince=20060320000000&amp;user=1&amp;cache=1&amp;cachelog=1&amp;cachedesc=1&amp;picture=1&amp;removedobject=1&amp;session=1&amp;charset=utf-8&amp;cdata=1&amp;xmldecl=0&amp;ocxmltag=0&amp;doctype=0<br/>
+            https://www.opencaching.de/xml/ocxml15.php?sessionid=4711&amp;file=1&amp;charset=utf-8&amp;cdata=1&amp;xmldecl=0&amp;ocxmltag=0&amp;doctype=0</p>
         <h3>Sonstige Anmerkungen</h3>
         <ul>
             <li>
@@ -388,7 +388,7 @@
         <h3>Ressourcen</h3>
         <ul>
             <li>Das XML-Dokument enthält folgende DTD (Document Type Definition):
-            http://www.opencaching.de/xml/ocxmlXX.dtd mit XX = Versionummer, z.B. ocxml12.dtd für Version 1.2.</li>
+            https://www.opencaching.de/xml/ocxmlXX.dtd mit XX = Versionummer, z.B. ocxml12.dtd für Version 1.2.</li>
             <li>Der Quellcode ist hier erhältlich: <a href="https://github.com/OpencachingDeutschland/oc-server3/tree/stable/htdocs/xml">
                     https://github.com/OpencachingDeutschland/oc-server3/tree/stable/htdocs/xml</a></li>
             <li>Eine Referenzimplementierung kann hier heruntergeladen werden:
@@ -400,8 +400,8 @@
             <li>Der Quellcode steht unter der GNU Gerneral Public License Version 2 und später, siehe <a href="https://github.com/OpencachingDeutschland/oc-server3/tree/stable/doc/license.txt">https://github.com/OpencachingDeutschland/oc-server3/tree/stable/doc/license.txt</a>.</li>
             <li>
                 Für Daten, die über das XML-Interface abgerufen werden, gelten die
-                Nutzungsbedingungen von Opencaching.de: <a href="http://www.opencaching.de/articles.php?page=impressum#tos">
-                    http://www.opencaching.de/articles.php?page=impressum#tos</a></li></ul>
+                Nutzungsbedingungen von Opencaching.de: <a href="https://www.opencaching.de/articles.php?page=impressum#tos">
+                    https://www.opencaching.de/articles.php?page=impressum#tos</a></li></ul>
         <p>&nbsp;</p>
         </span>
     </body>

--- a/htdocs/lang/de/ocstyle/main.tpl.php
+++ b/htdocs/lang/de/ocstyle/main.tpl.php
@@ -253,12 +253,12 @@ foreach ($opt['template']['locales'] as $k => $lang) {
                     <p class="sidebar-maintitle">{t}Country sites{/t}</p>
                     <div style="text-align: center;" class="nodeflags">
                         <a href="http://www.opencaching.cz" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-cz.png" width="100" height="22" /></a><br />
-                        <a href="http://www.opencaching.de" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-de.png" width="100" height="22" /></a><br />
-                        <a href="http://www.opencachingspain.es" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-es.png" width="100" height="22" /></a><br />
-                        <a href="http://www.opencaching.fr" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-fr.png" width="100" height="22" /></a><br />
-                        <a href="http://www.opencaching.it" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-it.png" width="100" height="22" /></a><br />
+                        <a href="https://www.opencaching.de" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-de.png" width="100" height="22" /></a><br />
+                        <a href="https://www.opencachingspain.es" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-es.png" width="100" height="22" /></a><br />
+                        <a href="https://www.opencaching.fr" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-fr.png" width="100" height="22" /></a><br />
+                        <a href="https://www.opencaching.it" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-it.png" width="100" height="22" /></a><br />
                         <a href="http://www.opencaching.nl" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-nl.png" width="100" height="22" /></a><br />
-                        <a href="http://www.opencaching.pl" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-pl.png" width="100" height="22" /></a><br />
+                        <a href="https://opencaching.pl" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-pl.png" width="100" height="22" /></a><br />
                         <a href="http://www.opencaching.ro" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-ro.png" width="100" height="22" /></a><br />
                         <a href="https://opencache.uk" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-org-uk.png" width="100" height="22" /></a><br />
                         <a href="http://www.opencaching.us" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-us.png" width="100" height="22" /></a>

--- a/htdocs/lib/settings-dist.inc.php
+++ b/htdocs/lib/settings-dist.inc.php
@@ -54,7 +54,7 @@ $develWarning = '';
  * than one locale on one server with multiple default-locales.
  * Must be overwritten in BOTH lib1 and lib2 settings.inc.php!!
  */
-//$opt['domain']['www.opencaching.de']['url'] = 'http://www.opencaching.de/';
+//$opt['domain']['www.opencaching.de']['url'] = 'https://www.opencaching.de/';
 //$opt['domain']['www.opencaching.de']['shortlink_domain'] = 'opencaching.de';
 //$opt['domain']['www.opencaching.de']['sitename'] = 'Opencaching.de';
 //$opt['domain']['www.opencaching.de']['locale'] = 'DE';
@@ -71,7 +71,7 @@ $develWarning = '';
 //$opt['domain']['www.opencaching.de']['https']['is_default'] = false;
 //$opt['domain']['www.opencaching.de']['https']['force_login'] = true;
 
-//$opt['domain']['www.opencaching.pl']['url'] = 'http://www.opencaching.pl/';
+//$opt['domain']['www.opencaching.pl']['url'] = 'https://opencaching.pl/';
 //$opt['domain']['www.opencaching.pl']['sitename'] = 'Opencaching.PL';
 //$opt['domain']['www.opencaching.pl']['locale'] = 'PL';
 //$opt['domain']['www.opencaching.pl']['fallback_locale'] = 'EN';
@@ -85,7 +85,7 @@ $develWarning = '';
 // Supply the site's primary URL and the shortlink domain here.
 // Can be overriden by domain settings.
 // Set shortlink domain to false if not available.
-set_absolute_urls($opt, 'http://www.opencaching.de/', 'opencaching.de', 1);
+set_absolute_urls($opt, 'https://www.opencaching.de/', 'opencaching.de', 1);
 
 // 'From' EMail address for admin error messages and log removals
 if (!isset($emailaddr)) {

--- a/htdocs/resource2/misc/mapsource/opencachingde.wlx
+++ b/htdocs/resource2/misc/mapsource/opencachingde.wlx
@@ -36,7 +36,7 @@
         <supportedLanguage>TRK</supportedLanguage>
     </supportedLanguages>
     <url>
-        <token xsi:type="Literal_t" content="http://www.opencaching.de/search.php?client=mapsource&amp;searchto=searchbydistance&amp;f_userowner=1&amp;f_userfound=1&amp;f_ignored=1&amp;showresult=1&amp;expert=0&amp;output=HTML&amp;sort=bydistance&amp;f_inactive=1&amp;distance=25&amp;unit=km" />
+        <token xsi:type="Literal_t" content="https://www.opencaching.de/search.php?client=mapsource&amp;searchto=searchbydistance&amp;f_userowner=1&amp;f_userfound=1&amp;f_ignored=1&amp;showresult=1&amp;expert=0&amp;output=HTML&amp;sort=bydistance&amp;f_inactive=1&amp;distance=25&amp;unit=km" />
         <token xsi:type="Literal_t" content="&amp;latNS="/>
         <token xsi:type="Value_t" format="LAT_ORIENTATION"/>
         <token xsi:type="Literal_t" content="&amp;lonEW="/>

--- a/htdocs/resource2/misc/mozilla/OpencachingDE.src
+++ b/htdocs/resource2/misc/mozilla/OpencachingDE.src
@@ -5,12 +5,12 @@
    name="Opencaching.de"
    description="Opencaching-Suche"
    method="GET"
-   action="http://www.opencaching.de/searchplugin.php"
+   action="https://www.opencaching.de/searchplugin.php"
    update=""
    updateCheckDays=0
    queryEncoding="ISO-8859-1"
    queryCharset="ISO-8859-1"
-   searchForm="http://www.opencaching.de/search.php"
+   searchForm="https://www.opencaching.de/search.php"
 >
 
 <input name="userinput" user>
@@ -27,8 +27,8 @@
     resultItemEnd="<!--n-->"
 >
 <browser
- update="http://www.opencaching.de/resource2/misc/mozilla/OpencachingDE.src"
- updateicon="http://www.opencaching.de/resource2/misc/mozilla/OpencachingDE.png"
+ update="https://www.opencaching.de/resource2/misc/mozilla/OpencachingDE.src"
+ updateicon="https://www.opencaching.de/resource2/misc/mozilla/OpencachingDE.png"
  updatecheckdays="30"
 >
 </search>

--- a/htdocs/templates2/ocstyle/articles/DE/changelog.tpl
+++ b/htdocs/templates2/ocstyle/articles/DE/changelog.tpl
@@ -295,7 +295,7 @@
             <li>HTML-Filterfunktionen für Logs und Cachebeschreibungen verbessert
                 (<a href="http://redmine.opencaching.de/issues/79">#79</a>),
                 eine Liste der jetzt verwendbaren HTML-Elemente ist
-                <a href="http://www.opencaching.de/articles.php?page=htmltags">hier</a>
+                <a href="https://www.opencaching.de/articles.php?page=htmltags">hier</a>
                 zu finden.
             </li>
             <li>
@@ -775,7 +775,7 @@
         <p id="v3.0.1"><strong>OC 3.0 Version 1</strong> &ndash; 8. August 2012</p>
         <p>Neu:</p>
         <ul>
-            <li>Kurzadressen für Direktzugriff auf Cachelistings, z.B. <a href="http://www.opencaching.de/OCD93B">http://opencaching.de/OCD93B</a></li>
+            <li>Kurzadressen für Direktzugriff auf Cachelistings, z.B. <a href="https://www.opencaching.de/OCD93B">http://opencaching.de/OCD93B</a></li>
             <li>Anzeige &bdquo;Du hast dieses Event besucht&ldquo; in Karten-Popup-Fenstern
             <li>englische Übersetzung der Seiten <a href="./articles.php?page=geocaching">Über Geocaching</a>, <a href="./articles.php?page=cacheinfo">Cachebeschreibung</a>, <a href="./articles.php?page=impressum">Impressum &amp; Nutzungsbedingungen</a>, <a href="./articles.php?page=dsb">Datenschutzbelehrung</a>, <a href="./articles.php?page=donations">Spenden</a>, <a href="./articles.php?page=contact">Kontakt</a> und <a href="./articles.php?page=team">Teamliste</a> (umschalten auf englischsprachige Seite oben mit <img src="images/flag/EN.png" />)
             <li>Versionsgeschichte</li>

--- a/htdocs/templates2/ocstyle/articles/DE/impressum.tpl
+++ b/htdocs/templates2/ocstyle/articles/DE/impressum.tpl
@@ -347,7 +347,7 @@
         Die Datenschutzbelehrung kann auf folgender Seite abgerufen werden:
     </p>
     <p>
-        <a href="articles.php?page=dsb">http://www.opencaching.de/articles.php?page=dsb</a>
+        <a href="articles.php?page=dsb">https://www.opencaching.de/articles.php?page=dsb</a>
     </p>
     <br />
 </div>

--- a/htdocs/templates2/ocstyle/articles/DE/team.tpl
+++ b/htdocs/templates2/ocstyle/articles/DE/team.tpl
@@ -11,7 +11,7 @@
         Hier m&ouml;chten wir euch unser Team vorstellen, das hinter den Kulissen von Opencaching.de unerm&uuml;dlich
         für euch werkelt.
         Wir freuen uns &uuml;ber eure Anregungen, Vorschl&auml;ge und Kritik. Auf der
-        <a href="http://www.opencaching.de/articles.php?page=contact">Kontakt-Seite</a>
+        <a href="https://www.opencaching.de/articles.php?page=contact">Kontakt-Seite</a>
         habt ihr M&ouml;glichkeiten, euch n&auml;her über Opencaching zu informieren oder mit uns in Kontakt zu treten.
         Natürlich k&ouml;nt ihr unsere
         Teammitglieder auch direkt &uuml;ber eines der Benutzerprofile anschreiben.

--- a/htdocs/templates2/ocstyle/articles/EN/changelog.tpl
+++ b/htdocs/templates2/ocstyle/articles/EN/changelog.tpl
@@ -179,7 +179,7 @@
     <li>Improved HTML filters for logs and cache descriptions
     (<a href="http://redmine.opencaching.de/issues/79">#79</a>),
     a list of allowed HTML elements can be found
-    <a href="http://www.opencaching.de/articles.php?page=htmltags&locale=EN">here</a>.
+    <a href="https://www.opencaching.de/articles.php?page=htmltags&locale=EN">here</a>.
     </li>
     <li>
     Popups of the HTML-editor are not cropped any more when using large fonts.
@@ -648,7 +648,7 @@
      <p id="v3.0.1"><strong>OC 3.0 Release 1</strong> &ndash; 8 August 2012</p>
    <p>New:</p>
      <ul>
-       <li>URL shortener for direct cache listing access, e.g. <a href="http://www.opencaching.de/OCD93B">http://www.opencaching.de/OCD93B</a></li>
+       <li>URL shortener for direct cache listing access, e.g. <a href="https://www.opencaching.de/OCD93B">https://www.opencaching.de/OCD93B</a></li>
        <li>englisch translation of <a href="./articles.php?page=geocaching">About Geocaching</a>, <a href="./articles.php?page=cacheinfo">Cache descriptions</a>, <a href="./articles.php?page=impressum">Legal information</a>, <a href="./articles.php?page=dsb">Privacy statement</a>, <a href="./articles.php?page=donations">Donations</a>, <a href="./articles.php?page=contact">Contact</a> and <a href="./articles.php?page=team">Team members' list</a> pages; team list, legal information and donations pages have been updated</li>
        <li>display of "You have attended this event" in map popups</li>
        <li>changelog</li>

--- a/htdocs/templates2/ocstyle/articles/EN/impressum.tpl
+++ b/htdocs/templates2/ocstyle/articles/EN/impressum.tpl
@@ -301,7 +301,7 @@
 <div class="content-txtbox-noshade" style="padding-right: 25px;">
     <p>
         Our data privacy disclaimer and policy is available at
-        <a href="articles.php?page=dsb">http://www.opencaching.de/articles.php?page=dsb</a>.
+        <a href="articles.php?page=dsb">https://www.opencaching.de/articles.php?page=dsb</a>.
     </p>
 
     <br />

--- a/htdocs/templates2/ocstyle/articles/EN/team.tpl
+++ b/htdocs/templates2/ocstyle/articles/EN/team.tpl
@@ -8,7 +8,7 @@
 
 <p>We would like to introduce our team of volunteers, which is restlessly working behind the scenery for you, the users of opencaching.de, opencaching.it, opencachingspain.es and opencaching.fr.</p>
 
-<p>We appreciate your suggetions and comments. On the <a href="http://www.opencaching.de/articles.php?page=contact">contact page</a>, you will find information on how to contact us. Of course, you may also send Emails directly to the team members by their Opencaching.de user profiles.</p>
+<p>We appreciate your suggetions and comments. On the <a href="https://www.opencaching.de/articles.php?page=contact">contact page</a>, you will find information on how to contact us. Of course, you may also send Emails directly to the team members by their Opencaching.de user profiles.</p>
 
 <p>At this occasion, we would also like to thank all Opencaching users and unnamed aides and supporters, who contributed to Opencaching's success by their suggestions and commitment.</p>
 

--- a/htdocs/templates2/ocstyle/sys_main.tpl
+++ b/htdocs/templates2/ocstyle/sys_main.tpl
@@ -230,12 +230,12 @@
                 <p class="sidebar-maintitle">{t}Country sites{/t}</p>
                 <div style="text-align: center;" class="nodeflags">
                     <a href="http://www.opencaching.cz" target="_blank"><img src="resource2/{$opt.template.style}/images/nodes/oc-cz.png" width="100" height="22" /></a><br />
-                    <a href="http://www.opencaching.de" target="_blank"><img src="resource2/{$opt.template.style}/images/nodes/oc-de.png" width="100" height="22" /></a><br />
-                    <a href="http://www.opencachingspain.es" target="_blank"><img src="resource2/{$opt.template.style}/images/nodes/oc-es.png" width="100" height="22" /></a><br />
-                    <a href="http://www.opencaching.fr" target="_blank"><img src="resource2/{$opt.template.style}/images/nodes/oc-fr.png" width="100" height="22" /></a><br />
-                    <a href="http://www.opencaching.it" target="_blank"><img src="resource2/{$opt.template.style}/images/nodes/oc-it.png" width="100" height="22" /></a><br />
+                    <a href="https://www.opencaching.de" target="_blank"><img src="resource2/{$opt.template.style}/images/nodes/oc-de.png" width="100" height="22" /></a><br />
+                    <a href="https://www.opencachingspain.es" target="_blank"><img src="resource2/{$opt.template.style}/images/nodes/oc-es.png" width="100" height="22" /></a><br />
+                    <a href="https://www.opencaching.fr" target="_blank"><img src="resource2/{$opt.template.style}/images/nodes/oc-fr.png" width="100" height="22" /></a><br />
+                    <a href="https://www.opencaching.it" target="_blank"><img src="resource2/{$opt.template.style}/images/nodes/oc-it.png" width="100" height="22" /></a><br />
                     <a href="http://www.opencaching.nl" target="_blank"><img src="resource2/{$opt.template.style}/images/nodes/oc-nl.png" width="100" height="22" /></a><br />
-                    <a href="http://www.opencaching.pl" target="_blank"><img src="resource2/{$opt.template.style}/images/nodes/oc-pl.png" width="100" height="22" /></a><br />
+                    <a href="https://opencaching.pl" target="_blank"><img src="resource2/{$opt.template.style}/images/nodes/oc-pl.png" width="100" height="22" /></a><br />
                     <a href="http://www.opencaching.ro" target="_blank"><img src="resource2/{$opt.template.style}/images/nodes/oc-ro.png" width="100" height="22" /></a><br />
                     <a href="https://opencache.uk" target="_blank"><img src="resource2/{$opt.template.style}/images/nodes/oc-org-uk.png" width="100" height="22" /></a><br />
                     <a href="http://www.opencaching.us" target="_blank"><img src="resource2/{$opt.template.style}/images/nodes/oc-us.png" width="100" height="22" /></a>

--- a/htdocs/util/google-earth/opencaching.kml
+++ b/htdocs/util/google-earth/opencaching.kml
@@ -11,7 +11,7 @@
   <NetworkLink>
     <name>Opencaching</name>
     <Url>
-      <href>http://www.opencaching.de/util2/google-earth/caches.php</href>
+      <href>https://www.opencaching.de/util2/google-earth/caches.php</href>
       <viewRefreshTime>1</viewRefreshTime>
       <viewRefreshMode>onStop</viewRefreshMode>
     </Url>

--- a/htdocs/util2/google-earth/opencaching-en.kml
+++ b/htdocs/util2/google-earth/opencaching-en.kml
@@ -11,7 +11,7 @@
   <NetworkLink>
     <name>Opencaching</name>
     <Url>
-      <href>http://www.opencaching.de/util2/google-earth/caches-en.php</href>
+      <href>https://www.opencaching.de/util2/google-earth/caches-en.php</href>
       <viewRefreshTime>1</viewRefreshTime>
       <viewRefreshMode>onStop</viewRefreshMode>
     </Url>

--- a/htdocs/util2/google-earth/opencaching.kml
+++ b/htdocs/util2/google-earth/opencaching.kml
@@ -11,7 +11,7 @@
   <NetworkLink>
     <name>Opencaching</name>
     <Url>
-      <href>http://www.opencaching.de/util2/google-earth/caches.php</href>
+      <href>https://www.opencaching.de/util2/google-earth/caches.php</href>
       <viewRefreshTime>1</viewRefreshTime>
       <viewRefreshMode>onStop</viewRefreshMode>
     </Url>

--- a/htdocs/xml/ocxml11.php
+++ b/htdocs/xml/ocxml11.php
@@ -483,7 +483,7 @@ function outputXmlFile($sessionid, $filenr, $bXmlDecl, $bOcXmlTag, $bDocType, $z
     if ($bDocType == '1') {
         fwrite(
             $f,
-            '<!DOCTYPE oc11xml PUBLIC "-//Opencaching Network//DTD OCXml V 1.' . ($ocXmlVersion % 10) . '//EN" "http://www.opencaching.de/xml/ocxml' . $ocXmlVersion . '.dtd">' . "\n"
+            '<!DOCTYPE oc11xml PUBLIC "-//Opencaching Network//DTD OCXml V 1.' . ($ocXmlVersion % 10) . '//EN" "https://www.opencaching.de/xml/ocxml' . $ocXmlVersion . '.dtd">' . "\n"
         );
     }
     if ($bOcXmlTag == '1') {

--- a/local/ocxml11client/index.php
+++ b/local/ocxml11client/index.php
@@ -16,7 +16,7 @@
  * Nicht für Produktivsystem!
  *
  * Die Dokuemntation beachten:
- * http://www.opencaching.de/doc/xml/xml11.htm
+ * https://www.opencaching.de/doc/xml/xml11.htm
  *
  * TODO:
  * - removed_objects ... Abhängigkeiten prüfen
@@ -1048,7 +1048,7 @@ function ImportPictureArray($r)
 {
     /*
         [ID][__DATA] => DCFDE050-B42F-A76A-E9C7-BCCCC8812A23
-        [URL][__DATA] => http://www.opencaching.de/images/uploads/DCFDE050-B42F-A76A-E9C7-BCCCC8812A23.jpg
+        [URL][__DATA] => https://www.opencaching.de/images/uploads/DCFDE050-B42F-A76A-E9C7-BCCCC8812A23.jpg
         [TITLE][__DATA] => Cache
         [OBJECT][__ATTR][TYPE] => 2
         [OBJECT][__DATA] => 42264069-CDD6-5997-104A-AEDA9CEF4E18

--- a/local/ocxml11client/settings-dist.php
+++ b/local/ocxml11client/settings-dist.php
@@ -40,7 +40,7 @@ $opt['distance'] = 150;
 // sonstige Einstellungen
 $opt['tmpdir'] = 'tmp/';
 $opt['archivdir'] = 'data-files/';
-$opt['url'] = 'http://www.opencaching.de/xml/ocxml11.php?modifiedsince={modifiedsince}&user={user}&cache={cache}&cachedesc={cachedesc}&cachelog={cachelog}&picture={picture}&picturefromcachelog={picturefromcachelog}&removedobject={removedobject}&session={session}&zip={zip}&charset=utf-8';
+$opt['url'] = 'https://www.opencaching.de/xml/ocxml11.php?modifiedsince={modifiedsince}&user={user}&cache={cache}&cachedesc={cachedesc}&cachelog={cachelog}&picture={picture}&picturefromcachelog={picturefromcachelog}&removedobject={removedobject}&session={session}&zip={zip}&charset=utf-8';
 $opt['urlappend_country'] = '&country={country}';
 $opt['urlappend_coords'] = '&lon={lon}&lat={lat}&distance={distance}';
-$opt['url_getsession'] = 'http://www.opencaching.de/xml/ocxml11.php?sessionid={sessionid}&file={file}&zip={zip}&charset=utf-8';
+$opt['url_getsession'] = 'https://www.opencaching.de/xml/ocxml11.php?sessionid={sessionid}&file={file}&zip={zip}&charset=utf-8';

--- a/sql/static-data/nodes.sql
+++ b/sql/static-data/nodes.sql
@@ -2,7 +2,7 @@
 SET NAMES 'utf8';
 TRUNCATE TABLE `nodes`;
 INSERT INTO `nodes` (`id`, `name`, `url`, `waypoint_prefix`) VALUES ('1', 'Opencaching Germany', 'www.opencaching.de', 'OC');
-INSERT INTO `nodes` (`id`, `name`, `url`, `waypoint_prefix`) VALUES ('2', 'Opencaching Poland', 'www.opencaching.pl', 'OP');
+INSERT INTO `nodes` (`id`, `name`, `url`, `waypoint_prefix`) VALUES ('2', 'Opencaching Poland', 'opencaching.pl', 'OP');
 INSERT INTO `nodes` (`id`, `name`, `url`, `waypoint_prefix`) VALUES ('3', 'Opencaching Czech', 'www.opencaching.cz', 'OZ');
 INSERT INTO `nodes` (`id`, `name`, `url`, `waypoint_prefix`) VALUES ('4', 'Local Development', '', 'AA');
 INSERT INTO `nodes` (`id`, `name`, `url`, `waypoint_prefix`) VALUES ('6', 'Opencaching Sweden', 'www.opencaching.se', 'OS');

--- a/sql/static-data/sys_trans_text_it.sql
+++ b/sql/static-data/sys_trans_text_it.sql
@@ -968,7 +968,7 @@ INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUE
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1428', 'IT', 'Già pubblicata', '2010-09-10 23:40:08');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1429', 'IT', 'Pubblicata su', '2010-09-13 22:10:04');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1430', 'IT', 'Non ancora pubblicata.', '2010-09-13 22:10:04');
-INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1431', 'IT', 'Ho letto e accetto le <a href=\"articles.php?page=impressum#tos\" target=\"_blank\">condizioni d\'uso di Opencaching.de</a> e la <a href=\"http://www.opencaching.de/articles.php?page=impressum#datalicense\">Lecenza dati Opencaching.de</a>.', '2010-09-10 23:39:25');
+INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1431', 'IT', 'Ho letto e accetto le <a href=\"articles.php?page=impressum#tos\" target=\"_blank\">condizioni d\'uso di Opencaching.de</a> e la <a href=\"articles.php?page=impressum#datalicense\">Lecenza dati Opencaching.de</a>.', '2010-09-10 23:39:25');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1432', 'IT', 'Informazione: il tuo log è stato cancellato dal proprietario della cache.', '2010-09-10 23:39:09');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1433', 'IT', 'Seleziona città', '2010-10-27 18:49:19');
 INSERT INTO `sys_trans_text` (`trans_id`, `lang`, `text`, `last_modified`) VALUES ('1434', 'IT', 'Totale di %1 città corrispondenti', '2010-09-10 23:38:52');


### PR DESCRIPTION
### 1. Why is this change necessary?

lots of outdated http URLs in code and docs

### 2. What does this change do, exactly?

* http://www.opencaching.de -> https://www.opencaching.de
* http://www.opencaching.it -> https://www.opencaching.it
* http://www.opencaching.fr -> https://www.opencaching.fr
* http://www.opencachingspain.es -> https://www.opencachingspain.es
* http://www.opencaching.pl -> https://opencaching.pl
* www.opencaching.pl -> opencaching.pl
* www.opencache.uk -> opencache.uk

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
