### PR TITLE
show log date year in own caches log pic gallery; updates #39

### DIFF
--- a/htdocs/templates2/ocstyle/myhome.tpl
+++ b/htdocs/templates2/ocstyle/myhome.tpl
@@ -125,7 +125,7 @@ function myHomeLoad()
     </p>
 
     {if $allpics == 'owncaches'}
-        {include file="res_logpictures.tpl" logdate=true loguser=true maxlines=$maxlines fullyear=false}
+        {include file="res_logpictures.tpl" logdate=true loguser=true maxlines=$maxlines shortyear=true}
     {else}
         {include file="res_logpictures.tpl" logdate=true loguser=false maxlines=$maxlines fullyear=true}
     {/if}


### PR DESCRIPTION
### 1. Why is this change necessary?

Date was missing in own caches logpic gallery (#535)

### 2. What does this change do, exactly?

Add 2-digit date to log picture subtitles

### 3. Describe each step to reproduce the issue or behaviour.

myhome.php?allpics=owncaches

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
