### PR TITLE
map scrolling without ctrl key; remove OCM leftover; updates #1124

### DIFF
--- a/htdocs/templates2/ocstyle/map2.tpl
+++ b/htdocs/templates2/ocstyle/map2.tpl
@@ -343,7 +343,7 @@ function mapLoad()
     if (bFullscreen && msInitSiderbarDisplay == "block")
     toggle_sidebar(false);
 
-    var maptypes = ['OSM', 'OCM',
+    var maptypes = ['OSM',
                     google.maps.MapTypeId.ROADMAP, google.maps.MapTypeId.SATELLITE,
                     google.maps.MapTypeId.HYBRID, google.maps.MapTypeId.TERRAIN ];
   var initType = google.maps.MapTypeId.ROADMAP;
@@ -355,7 +355,8 @@ function mapLoad()
         zoom: mnInitZoom,
         center: new google.maps.LatLng(mnInitLat, mnInitLon),
         mapTypeId: initType,
-        backgroundColor: "#d0dccc",
+        backgroundColor: '#d0dccc',
+        gestureHandling: 'greedy',
 
         mapTypeControl: true,
         mapTypeControlOptions: { mapTypeIds: maptypes, position: google.maps.ControlPosition.TOP_RIGHT },
@@ -387,7 +388,7 @@ function mapLoad()
     {/if}
     {literal}
 
-    setMapType("OSM", "OpenStreetMap", "http://tile.openstreetmap.org/", 18);
+    setMapType("OSM", "OpenStreetMap", "https://tile.openstreetmap.org/", 18);
 
     moInfoWindow = new google.maps.InfoWindow();
     moWpInfoWindow = new google.maps.InfoWindow();
@@ -506,9 +507,9 @@ function updateCopyrights()
     {
         {/literal}
         if (newMapType == "OCM")
-            copyrightDiv.innerHTML = '{t escape=js}Map data &copy; <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> and <a href="http://www.thunderforest.com/opencyclemap/" target="_blank">OpenCycleMap</a> contributors{/t}';
+            copyrightDiv.innerHTML = '{t escape=js}Map data &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> and <a href="http://www.thunderforest.com/opencyclemap/" target="_blank">OpenCycleMap</a> contributors{/t}';
         else
-            copyrightDiv.innerHTML = '{t escape=js}Map data &copy; <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors{/t}';
+            copyrightDiv.innerHTML = '{t escape=js}Map data &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors{/t}';
         {literal}
         if (mapIcon != null) {
             mapIcon.style.display = "none";


### PR DESCRIPTION
### 1. Why is this change necessary?

* usability of [small map](http://www.opencaching.de/map2.php?mode=normalscreen) is impaired since Google Maps requires Ctrl key for zooming
* OSM tiles are loaded via http, therefore www.opencaching.de/map2.php (in OSM mode) appears as "unsafe" in the browser
* OCM leftover in the map types list

### 2. What does this change do, exactly?

* disable the Ctrl key for map zooming
* change OSM URLs from http to https
* remove OCM from map types list

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
