### PR TITLE
fix original coords display, part 3

### DIFF
--- a/htdocs/lib2/logic/cache.class.php
+++ b/htdocs/lib2/logic/cache.class.php
@@ -515,7 +515,7 @@ class cache
                     `date_created` - INTERVAL 4 SECOND AS `adjusted_date_created`,
                      /*
                         The first cache_coordinates entry is created immediately after
-                        creating inserting cache into caches table. This usually takes
+                        inserting the cache into caches table. This usually takes
                         a few milliseconds. We apply a 4 seconds 'safety margin' for
                         detecting the original coords. In the extremly unlikely case that
                         it took more than 4 seconds AND the owner did a coordinate change
@@ -605,6 +605,7 @@ class cache
             $coordpos = 0;
             $current_coord = new coordinate($coords[0]['latitude'], $coords[0]['longitude']);
         }
+        $displayed_coord_changes = 0;
 
         while ($rLog = sql_fetch_assoc($rsLogs)) {
             $pictures = [];
@@ -655,6 +656,7 @@ class cache
                                 $rLog['movedbykm'] = round($distance);
                             }
                             $rLog['cache_moved'] = true;
+                            ++$displayed_coord_changes;
                         }
                     } else {
                         // This is the original coord of the cache.
@@ -672,7 +674,7 @@ class cache
         // not added to a a real log entry because there are logs older than the
         // OC cache listing (cmp. https://redmine.opencaching.de/issues/1102):
 
-        if ($coord_changes && $coordpos < count($coords) && count($logs) > 0) {
+        if ($displayed_coord_changes > 0 && $coordpos < count($coords) && count($logs) > 0) {
             $coord = new coordinate($coords[$coordpos]['latitude'], $coords[$coordpos]['longitude']);
             $logs[] = [
                 'newcoord' => $coord->getDecimalMinutes($protect_old_coords),


### PR DESCRIPTION
### 1. Why is this change necessary?

minor bug introduced by #595: original coords are displayed in some special cases where it's not necessary

### 2. What does this change do, exactly?

hide original coordinates if no _visible_ coordinate changes occured, like changing coords and then immediately reverting to original coords


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
