### PR TITLE
enable Safari search button on  map for logged-off users; updates #1127

### DIFF
--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -426,7 +426,8 @@ if ($queryid != 0) {
     } elseif (isset($_REQUEST['searchall'])) {
         if (!$login->logged_in() &&
             !(isset($_REQUEST['country']) && $_REQUEST['country'] != '') &&
-            !(isset($_REQUEST['language']) && $_REQUEST['language'] != '')
+            !(isset($_REQUEST['language']) && $_REQUEST['language'] != '') &&
+            !(isset($_REQUEST['cache_attribs']) && $_REQUEST['cache_attribs'] == 61)  // map Safari button
         ) {
             // This operation is very expensive and therefore available only
             // for logged-in users.


### PR DESCRIPTION
### 1. Why is this change necessary?

Safari Cache button on map produces error messages if user is not logged in.

### 2. What does this change do, exactly?

Allow searching for alle Safari caches for logged-off users.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

https://redmine.opencaching.de/issues/1127

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
