### PR TITLE
fix max image upload size for OKAPI

### DIFF
--- a/htdocs/okapi_settings.php
+++ b/htdocs/okapi_settings.php
@@ -46,7 +46,7 @@ function get_okapi_settings()
         'VAR_DIR'          => $opt['okapi']['var_dir'],
         'IMAGES_DIR'       => rtrim($opt['logic']['pictures']['dir'], '/'),
         'IMAGES_URL'       => rtrim($opt['logic']['pictures']['url'], '/') . '/',
-        'IMAGE_MAX_UPLOAD_SIZE' => 2 * $opt['logic']['pictures']['maxsize'],
+        'IMAGE_MAX_UPLOAD_SIZE' => $opt['logic']['pictures']['maxsize'],
         'IMAGE_MAX_PIXEL_COUNT' => 786432, # 1024 x 768; TODO: move PICTURE_MAX_LONG_SIDE to settings
         'SITE_LOGO'        => $opt['page']['absolute_url'] . 'resource2/' . $opt['template']['default']['style'] . '/images/oclogo/oc_logo_alpha3.png',
         'OC_NODE_ID'       => $opt['logic']['node']['id'],


### PR DESCRIPTION
### 1. Why is this change necessary?

bugfix for dectecting too large log image uploads by OKAPI

### 2. What does this change do, exactly?

correct OKAPI setting IMAGE_MAX_UPLOAD_SIZE

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
