### PR TITLE
fixed deleted logs display in admin cache-history

### DIFF
--- a/htdocs/lib2/logic/cache.class.php
+++ b/htdocs/lib2/logic/cache.class.php
@@ -950,7 +950,7 @@ class cache
             sql_value("SELECT `username` FROM `user` WHERE `user_id`='&1'", "", $rCache['user_id'])
         );
 
-        $tpl->assign('deleted_logs', $this->getLogsArray($this->getCacheId(), 0, 1000, true));
+        $tpl->assign('deleted_logs', $this->getLogsArray(0, 1000, true));
 
         // status changes
         $rs = sql(


### PR DESCRIPTION
### 1. Why is this change necessary?

see https://forum.opencaching.de/index.php?topic=4908.msg61321


### 2. What does this change do, exactly?

fix the retrievel of deleted logs for admin history display

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
