### PR TITLE
reset download option in listing to 'download as ...' after download

### DIFF
--- a/htdocs/templates2/ocstyle/viewcache.tpl
+++ b/htdocs/templates2/ocstyle/viewcache.tpl
@@ -285,7 +285,7 @@
         <tr>
             <td colspan="2"><p>
                 <img src="resource2/{$opt.template.style}/images/viewcache/print-18.png" class="icon16" alt="" />
-                <select class="exportlist" onchange="location.href=this.options[this.selectedIndex].value+'&nocrypt='+bNoCrypt">
+                <select class="exportlist" onchange="location.href=this.options[this.selectedIndex].value+'&nocrypt='+bNoCrypt" onfocus="this.selectedIndex=0">
                     <option value="#">{t}Print{/t} …</option>
                     <option value="viewcache.php?cacheid={$cache.cacheid}&{if $desclang}desclang={$desclang}&{/if}print=y&log=N">{t}without logs{/t}</option>
                     <option value="viewcache.php?cacheid={$cache.cacheid}&{if $desclang}desclang={$desclang}&{/if}print=y&log=5">{t}with 5 logs{/t}</option>
@@ -293,7 +293,7 @@
                     <option value="viewcache.php?cacheid={$cache.cacheid}&{if $desclang}desclang={$desclang}&{/if}print=y&log=A">{t}with all logs{/t}</option>
                 </select>&nbsp;
                 <img src="resource2/{$opt.template.style}/images/viewcache/16x16-save.png" class="icon16" alt="" />
-                <select class="exportlist" onchange="location.href=this.options[this.selectedIndex].value">
+                <select class="exportlist" onchange="location.href=this.options[this.selectedIndex].value" onfocus="this.selectedIndex=0">
                     <option value="#">{t}Download as...{/t}</option>
                     <option value="search.php?searchto=searchbycacheid&showresult=1&f_inactive=0&f_ignored=0&startat=0&cacheid={$cache.cacheid}&output=gpx">GPX</option>
                     <option value="search.php?searchto=searchbycacheid&showresult=1&f_inactive=0&f_ignored=0&startat=0&cacheid={$cache.cacheid}&output=loc">LOC</option>


### PR DESCRIPTION
### 1. Why is this change necessary?

Bugfix

### 2. What does this change do, exactly?

Reset the download selection box in cache listing to "Download as ..." after each download.

### 3. Describe each step to reproduce the issue or behaviour.

see https://redmine.opencaching.de/issues/1129

### 4. Please link to the relevant issues (if any).

https://redmine.opencaching.de/issues/1129

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
