### PR TITLE
Fix OKAPI SITE_URL setting; updates #1056

### DIFF
--- a/htdocs/okapi_settings.php
+++ b/htdocs/okapi_settings.php
@@ -39,7 +39,7 @@ function get_okapi_settings()
         'DB_CHARSET'       => $opt['charset']['mysql'],
         'SITELANG'         => strtolower($opt['template']['default']['locale']),
         'TIMEZONE'         => $opt['php']['timezone'],
-        'SITE_URL'         => $opt['page']['absolute_url'],
+        'SITE_URL'         => $opt['page']['default_primary_url'],
         'REGISTRATION_URL' => $opt['page']['https']['mode'] != HTTPS_DISABLED
                                   ? 'https://' . $opt['page']['domain'] . '/register.php'
                                   : $opt['page']['absolute_url'] . 'register.php',


### PR DESCRIPTION
### 1. Why is this change necessary?

OKAPI requirement, see https://redmine.opencaching.de/issues/1056.

### 2. What does this change do, exactly?

Set OKAPI SITE_URL to the primary URL of the site, i.e. https://www.opecaching.de/. No matter if called via "http" or "https", and no matter if called via www.opencaching.de or www.opencaching.it etc.

Needs `$opt['page']['https']['is_default'] = true` to return the https url.

### 3. Describe each step to reproduce the issue or behaviour.

http://www.opencaching.de/okapi/services/apisrv/installation returns http URL instead of https.

### 4. Please link to the relevant issues (if any).

https://redmine.opencaching.de/issues/1056

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
