### PR TITLE
fix recommendation calculations

### DIFF
--- a/htdocs/lib2/logic/user.class.php
+++ b/htdocs/lib2/logic/user.class.php
@@ -1591,7 +1591,7 @@ class user
         global $opt;
 
         // get number of possible rates
-        return (int) floor($this->getStatFound() * $opt['logic']['rating']['percentageOfFounds'] / 100);
+        return floor($this->getStatFound() * $opt['logic']['rating']['percentageOfFounds'] / 100);
     }
 
     public function allowRatings()
@@ -1605,7 +1605,7 @@ class user
         global $opt;
         $rating = $opt['logic']['rating'];
 
-        return (int) ($rating['percentageOfFounds'] - ($this->getStatFound() % $rating['percentageOfFounds']));
+        return ceil($rating['percentageOfFounds'] - ($this->getStatFound() % $rating['percentageOfFounds']));
     }
 
     public function showStatFounds()

--- a/htdocs/lib2/logic/user.class.php
+++ b/htdocs/lib2/logic/user.class.php
@@ -1605,7 +1605,7 @@ class user
         global $opt;
         $rating = $opt['logic']['rating'];
 
-        return ceil($rating['percentageOfFounds'] - ($this->getStatFound() % $rating['percentageOfFounds']));
+        return round($rating['percentageOfFounds'] - ($this->getStatFound() % $rating['percentageOfFounds']));
     }
 
     public function showStatFounds()

--- a/htdocs/viewprofile.php
+++ b/htdocs/viewprofile.php
@@ -370,7 +370,7 @@ $tpl->assign('maintenance', $record['maintenance'] <= 0 ? '0' : $record['mainten
 $tpl->assign('hidden', $record['hidden'] <= 0 ? '0' : $record['hidden']);
 $tpl->assign('active', $active);
 $tpl->assign('recommended', sql_value("SELECT COUNT(*) FROM `cache_rating` WHERE `user_id`='&1'", 0, $userid));
-$tpl->assign('maxrecommended', (int) floor($record['found'] * $opt['logic']['rating']['percentageOfFounds'] / 100));
+$tpl->assign('maxrecommended', floor($record['found'] * $opt['logic']['rating']['percentageOfFounds'] / 100));
 $tpl->assign('show_statistics', $show_statistics);
 $tpl->assign('show_oconly81', $show_oconly81);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Redundant code / Bugfix

The first calculation already does a floor() and thus eliminates floating point precision issues; (int) is obsolete.

In the second calculation, (int) will round down, but the logic here requires to round up. (Actually, floating point issues can occur here only if `$rating['percentageOfFounds']` is not an integer. Currently it is 10).

Note that the original bug - Redmine #1036 - was only related to [this code](https://github.com/OpencachingDeutschland/oc-server3/commit/5c61210aa90c89fb8b5dd8f20c8775d226befda4), which was discarded with #552.  There was no problem with the code in `user` class.

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
