### PR TITLE
Always set GPX attribute 'Park and grab' for Drive-In caches

### DIFF
--- a/htdocs/lib2/search/search.gpx.inc.php
+++ b/htdocs/lib2/search/search.gpx.inc.php
@@ -434,13 +434,17 @@ function search_output()
 
         // attributes
         $rsAttributes = sql_slave(
-            '
+            "
             SELECT `gc_id`, `gc_inc`, `gc_name`
             FROM `caches_attributes`
             INNER JOIN `cache_attrib`
                 ON `cache_attrib`.`id`=`caches_attributes`.`attrib_id`
-            WHERE `caches_attributes`.`cache_id`=&1
-            AND `gc_id` > 0',
+            WHERE `caches_attributes`.`cache_id`='&1'
+            AND `gc_id` > 0
+            UNION
+            SELECT `gc_id`, `gc_inc`, `gc_name`
+            FROM `cache_attrib`
+            WHERE `id` IN ('" . implode("','", array_map(sql_escape, $addAttributes)) . "')",
             $r['cacheid']
         );
         $gc_ids = [];


### PR DESCRIPTION
### 1. Why is this change necessary?

information can be lost when exporting Drive-In caches to GPX

### 2. What does this change do, exactly?

see title

### 3. Describe each step to reproduce the issue or behaviour.

download a drive-in cache as GPX which has no "near by car" attribute

### 4. Please link to the relevant issues (if any).

https://redmine.opencaching.de/issues/1136

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
