### PR TITLE
restored utf-8 mark of dbsv-update.php, was deleted by 0f4c547 rebase

### DIFF
--- a/bin/dbsv-update.php
+++ b/bin/dbsv-update.php
@@ -1,6 +1,9 @@
 <?php
 /***************************************************************************
  * for license information see LICENSE.md
+ *
+ * UTF-8 trigger: äöü
+ * (avoids auto-detecting this file as ISO-8859-1-encoded by some editors)
  ***************************************************************************/
 
 /*


### PR DESCRIPTION
### 1. Why is this change necessary?

Prevent detection of dbsv-update.php as iso-8859-1 (and thus destroying v127 and v165) by some editors. v165 contains unusual combinations of non-ASCII-chars which can mislead automatic charset detection.

this was (accidentally?) deleted when rebasing my commit 0f4c5479

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
