### PR TITLE
do not produce '<p><p>logtext</p></p>'; updates #1139

### DIFF
--- a/htdocs/lib2/logic/cache.class.php
+++ b/htdocs/lib2/logic/cache.class.php
@@ -577,6 +577,7 @@ class cache
                     `cache_logs`.`needs_maintenance` AS `needs_maintenance`,
                     `cache_logs`.`listing_outdated` AS `listing_outdated`,
                     `cache_logs`.`text` AS `text`,
+                    `cache_logs`.`text` REGEXP '^<p[ >].*</p>$' AS `paragraphed_text`,  /* see redmine #1139 */
                     `cache_logs`.`text_html` AS `texthtml`,
                     `cache_logs`.`picture`,
                     " . $delfields . ",

--- a/htdocs/templates2/ocstyle/res_logentry_logitem.tpl
+++ b/htdocs/templates2/ocstyle/res_logentry_logitem.tpl
@@ -74,11 +74,15 @@
     {/if}
 
     <div class="viewcache_log-content" style="margin-top: 15px;">
+        {strip}
+        {if !$logItem.paragraphed_text}<p>{/if}
         {if $logItem.texthtml}
-            <p>{$logItem.text}</p>
+            {$logItem.text}
         {else}
-            <p>{$logItem.text|smiley|hyperlink}</p>
+            {$logItem.text|smiley|hyperlink}
         {/if}
+        {if !$logItem.paragraphed_text}</p>{/if}
+        {/strip}
 
         {foreach from=$logItem.pictures item=pictureItem name=pictures}
             {if $smarty.foreach.pictures.first}


### PR DESCRIPTION
### 1. Why is this change necessary?

bad HTML when displaying log entries

### 2. What does this change do, exactly?

do not encodes log texts in `<p>...</p>` which already are enclosed in `<p>...</p>`

### 3. Describe each step to reproduce the issue or behaviour.

* Log a cache.
* Look at the HTML code of the log => there are double `<p><p>...</p></p>`.

### 4. Please link to the relevant issues (if any).

https://redmine.opencaching.de/issues/1139

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
