### PR TITLE
fixed what3words map coord search, PR to stable

### DIFF
--- a/htdocs/map2.php
+++ b/htdocs/map2.php
@@ -460,9 +460,9 @@ function output_namesearch($sName, $nLat, $nLon, $nResultId)
         if ($result) {
             $json = json_decode($result, true);
             if ($json['words'] !== null && $json['geometry'] !== null && count($json['geometry']) === 2) {
-                echo '<coord name="' . xmlentities(implode('.', $json['words'])) .
-                    '" latitude="' . xmlentities($json['lat']) .
-                    '" longitude="' . xmlentities($json['lng']) . '" />' . "\n";
+                echo '<coord name="' . xmlentities($json['words']) .
+                    '" latitude="' . xmlentities($json['geometry']['lat']) .
+                    '" longitude="' . xmlentities($json['geometry']['lng']) . '" />' . "\n";
             }
         }
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

bugfix

### 2. What does this change do, exactly?

repair what3words v2 API usage in map.php

### 3. Describe each step to reproduce the issue or behaviour.

e.g. search for "egal.kennzeichnen.bilderbuch" on the map

### 4. Please link to the relevant issues (if any).

https://redmine.opencaching.de/issues/1130

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
