### PR TITLE
documentet rating calculation bug

### DIFF
--- a/htdocs/config2/settings-dist-common.inc.php
+++ b/htdocs/config2/settings-dist-common.inc.php
@@ -87,7 +87,9 @@ $opt['logic']['waypoint_pool']['valid_chars'] = '0123456789ABCDEF';
 // fill_gaps = false: continue with the last waypoint
 $opt['logic']['waypoint_pool']['fill_gaps'] = false;
 
-/* geocache recommendation settings
+/*
+ * percentage of geocache ratings which can be given per found-log;
+ * must be in integer number; see user::foundsUntilNextRating()
  */
 $opt['logic']['rating']['percentageOfFounds'] = 10;
 

--- a/htdocs/lib2/logic/user.class.php
+++ b/htdocs/lib2/logic/user.class.php
@@ -1605,6 +1605,11 @@ class user
         global $opt;
         $rating = $opt['logic']['rating'];
 
+        /*
+         * The following calculation only works for integer values of
+         * $rating['percentageOfFounds']. For non-integers, the (int) would produce
+         * wrong results, because the result must be rounded UP, while (int) rounds DOWN.
+         */
         return (int) ($rating['percentageOfFounds'] - ($this->getStatFound() % $rating['percentageOfFounds']));
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

fragile code

### 2. What does this change do, exactly?

Document the restrictions on `$opt['logic']['rating']['percentageOfFounds']` setting after the bugfix #628 was rejected.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
