### PR TITLE
fixed lib1 PHP error display settings

### DIFF
--- a/dev-ops/local.team-opencaching.de/templates/config2-settings.inc.tpl.php
+++ b/dev-ops/local.team-opencaching.de/templates/config2-settings.inc.tpl.php
@@ -8,9 +8,6 @@ $dev_basepath = '/var/www/html/';
 $dev_codepath = '*';
 $dev_baseurl = '__FRONTEND_URL__';
 
-error_reporting(E_ALL);
-ini_set('display_errors', 'on');
-
 // enable HTTPS
 if (defined('HTTPS_ENABLED')) {
     $opt['page']['https']['mode'] = HTTPS_ENABLED;

--- a/dev-ops/local.team-opencaching.de/templates/lib-settings.inc.tpl.php
+++ b/dev-ops/local.team-opencaching.de/templates/lib-settings.inc.tpl.php
@@ -8,8 +8,7 @@ $dev_basepath = '/var/www/html/';
 $dev_codepath = '';
 $dev_baseurl = '__FRONTEND_URL__';
 
-error_reporting(E_ALL);
-ini_set('display_errors', 'on');
+$debug_page = true;
 
 // setting cookie values
 $opt['session']['path'] = '/';

--- a/htdocs/lib/clicompatbase.inc.php
+++ b/htdocs/lib/clicompatbase.inc.php
@@ -53,6 +53,15 @@ foreach ($opt['page']['banned_user_agents'] as $ua) {
 date_default_timezone_set($timezone);
 register_errorhandlers();
 
+if (isset($debug_page) && $debug_page)
+{
+    ini_set('display_errors', true);
+    ini_set('error_reporting', E_ALL);
+} else {
+    ini_set('display_errors', false);
+    ini_set('error_reporting', E_ALL & ~E_NOTICE);
+}
+
 $dblink_slave = false;
 $db_error = 0;
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Added missing PHP error settings to lib1; removed redundant settings from devel system templates - this is controlled via the debug setting.

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
