### PR TITLE
proposal: drop the doctrine down migrations

### DIFF
--- a/htdocs/app/Migrations/Version20160607213541.php
+++ b/htdocs/app/Migrations/Version20160607213541.php
@@ -27,8 +27,5 @@ class Version20160607213541 extends AbstractMigration
      */
     public function down(Schema $schema)
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
-
-        $this->addSql('DROP TABLE field_note');
     }
 }

--- a/htdocs/app/Migrations/Version20170221215409.php
+++ b/htdocs/app/Migrations/Version20170221215409.php
@@ -26,9 +26,5 @@ class Version20170221215409 extends AbstractMigration
      */
     public function down(Schema $schema)
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
-
-        $this->addSql('ALTER TABLE `user` DROP `admin_password`');
-        $this->addSql('ALTER TABLE `user` DROP `roles`');
     }
 }

--- a/htdocs/app/Migrations/Version20170510222222.php
+++ b/htdocs/app/Migrations/Version20170510222222.php
@@ -25,8 +25,5 @@ class Version20170510222222 extends AbstractMigration
      */
     public function down(Schema $schema)
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
-
-        $this->addSql('DROP TABLE field_note');
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

When going back to an old OC code version for testing, these down migrations will delete the developer's test data. This probably is not desired. As no drawbacks arise from temporary keeping those tables / fields - until returning to the current code - I propose to discard the down-migrations.

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
