### PR TITLE
update okapi - ignore bad exif data

### DIFF
--- a/htdocs/okapi/meta.php
+++ b/htdocs/okapi/meta.php
@@ -1,4 +1,4 @@
 <?php return array (
-  'version_number' => 1684,
-  'git_revision' => '8b1f529bf3f46aaad59ca83f0f95b37c20e71fa0',
+  'version_number' => 1686,
+  'git_revision' => 'f899783a15b8b8721da9792c94314a2b462f05e7',
 );


### PR DESCRIPTION
Fix for this problem:


OKAPI caught the following exception while executing API method request.
This is an error in OUR code and should be fixed. Please contact the
developer of the module that threw this error. Thanks!

ERROR MESSAGE
ErrorException:
exif_read_data(Z
): Illegal IFD size

--- Stack trace ---
#0 [internal function]: okapi\core\OkapiErrorHandler::handle(2, 'exif_read_data(...', '/var/www/openca...', 275, Array)
#1 /var/www/opencaching.de/www/code/htdocs/vendor/opencaching/okapi/okapi/services/logs/images/add/WebService.php(275): exif_read_data('data://image/jp...')
#2 /var/www/opencaching.de/www/code/htdocs/vendor/opencaching/okapi/okapi/services/logs/images/add/WebService.php(164): okapi\services\logs\images\add\WebService::postprocess_image('/9j/4QA0RXhpZgA...', Resource id #86, 2, 934, 703)
#3 /var/www/opencaching.de/www/code/htdocs/vendor/opencaching/okapi/okapi/services/logs/images/add/WebService.php(405): okapi\services\logs\images\add\WebService::_call(Object(okapi\core\Request\OkapiHttpRequest))
#4 [internal function]: okapi\services\logs\images\add\WebService::call(Object(okapi\core\Request\OkapiHttpRequest))
#5 /var/www/opencaching.de/www/code/htdocs/vendor/opencaching/okapi/okapi/core/OkapiServiceRunner.php(139): call_user_func(Array, Object(okapi\core\Request\OkapiHttpRequest))
#6 /var/www/opencaching.de/www/code/htdocs/vendor/opencaching/okapi/okapi/views/method_call/View.php(19): okapi\core\OkapiServiceRunner::call('services/logs/i...', Object(okapi\core\Request\OkapiHttpRequest))
#7 [internal function]: okapi\views\method_call\View::call('services/logs/i...')
#8 /var/www/opencaching.de/www/code/htdocs/vendor/opencaching/okapi/okapi/OkapiScriptEntryPointController.php(51): call_user_func_array(Array, Array)
#9 /var/www/opencaching.de/www/code/htdocs/vendor/opencaching/okapi/okapi/index.php(50): okapi\OkapiScriptEntryPointController::dispatch_request('/okapi/services...')
#10 /var/www/opencaching.de/www/code/htdocs/okapi/index.php(7): require_once('/var/www/openca...')
#11 {main}

--- OKAPI method called ---
/okapi/services/logs/images/add

--- OKAPI version ---
1684 (8b1f529bf3f46aaad59ca83f0f95b37c20e71fa0)

--- Request headers ---
Accept-Charset: utf-8,iso-8859-1;q=0.8,utf-16;q=0.8,*;q=0.7
Accept-Language: en-US,*;q=0.9
X-Requested-With: XMLHttpRequest
User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:9.0.1) Gecko/20100101 Firefox/9.0.1
Content-Type: application/x-www-form-urlencoded
Content-Length: 1020720
Host: www.opencaching.de
Connection: Keep-Alive
Accept-Encoding: gzip
.
