### PR TITLE
Show log password field for attended logs (Bug #1191)

### DIFF
--- a/htdocs/templates2/ocstyle/log_cache.tpl
+++ b/htdocs/templates2/ocstyle/log_cache.tpl
@@ -73,7 +73,7 @@ function logtype_changed()
         datecomment.innerHTML = "";
 
     {if $use_log_pw}
-        if (logtype == 1)
+        if (logtype == 1 || logtype == 7)
             document.getElementById("cachelisting-logpw").style.display = "block";
         else
             document.getElementById("cachelisting-logpw").style.display = "none";


### PR DESCRIPTION
### 1. Why is this change necessary?
On the log page, when selecting a "attended" log to log a Event cache whit password the password field didn't show up.

### 2. What does this change do, exactly?
Show the password field for both "attended" and "found" logs.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://redmine.opencaching.de/issues/1191

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
