### PR TITLE
OCC-25: Enable deletion of users without caches etc.

### DIFF
--- a/htdocs/lib2/logic/user.class.php
+++ b/htdocs/lib2/logic/user.class.php
@@ -1487,12 +1487,7 @@ class user
             return false;
         }
 
-        return
-            sql_value("SELECT COUNT(*) FROM `caches` WHERE `user_id`='&1'", 0, $this->nUserId)
-            + sql_value("SELECT COUNT(*) FROM `cache_logs` WHERE `user_id`='&1'", 0, $this->nUserId)
-            + sql_value("SELECT COUNT(*) FROM `cache_logs_archived` WHERE `user_id`='&1'", 0, $this->nUserId)
-            + sql_value("SELECT COUNT(*) FROM `cache_reports` WHERE `userid`='&1'", 0, $this->nUserId)
-            == 0;
+        return true;
     }
 
     public function delete()


### PR DESCRIPTION
Currently it is not possible to delete users without caches, cache_logs etc.
This pr fixes it