### PR TITLE
Fix newcaches.php filter and paging

### DIFF
--- a/htdocs/newcaches.php
+++ b/htdocs/newcaches.php
@@ -93,7 +93,7 @@ if (!$tpl->is_cached()) {
     $tpl->assign('newCaches', $newCaches);
 
     $startAt = isset($_REQUEST['startat']) ? $_REQUEST['startat'] + 0 : 0;
-    $cacheype_par = ($cacheType ? " & cachetype = $cacheType" : '');
+    $cacheype_par = ($cacheType ? "&cachetype=$cacheType" : '');
 
     $countQuery = $connection->createQueryBuilder()
         ->select('COUNT(*)')

--- a/htdocs/newcaches.php
+++ b/htdocs/newcaches.php
@@ -121,7 +121,7 @@ if (!$tpl->is_cached()) {
 
         $pager = new pager('newcaches.php?country=' . $country . '&startat={offset}' . $cacheype_par);
     }
-    $pager->make_from_offset($startAt, $count, 100);
+    $pager->make_from_offset($startAt, $count, $perpage);
 
     $tpl->assign('defaultcountry', $opt['template']['default']['country']);
     $tpl->assign('countryCode', $country);

--- a/htdocs/newcaches.php
+++ b/htdocs/newcaches.php
@@ -80,10 +80,11 @@ if (!$tpl->is_cached()) {
         $newCachesQuery->setParameter('country', $country);
     }
 
-    if ($cacheType && !$bEvents) {
+    if ($cacheType) {
         $newCachesQuery->andWhere('`caches`.`type` = :cacheType');
         $newCachesQuery->setParameter(':cacheType', $cacheType);
-    } elseif ($bEvents) {
+    }
+    if ($bEvents) {
         $newCachesQuery->andWhere('`date_hidden` >= curdate()');
     }
 
@@ -101,10 +102,11 @@ if (!$tpl->is_cached()) {
         ->setParameter(':statusId', 1);
 
     if ($country === '') {
-        if ($cacheType && !$bEvents) {
+        if ($cacheType) {
             $countQuery->andWhere('`caches`.`type` = :cacheType');
             $countQuery->setParameter(':cacheType', $cacheType);
-        } elseif ($bEvents) {
+        }
+        if ($bEvents) {
             $countQuery->andWhere('`date_hidden` >= curdate()');
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Under [https://www.opencaching.de/newcaches.php?cachetype=6](https://www.opencaching.de/newcaches.php?cachetype=6) (linked on the home page) only event caches should be listed. Instead, also caches of other types who are published today are listed. This fixes it by filtering also for cache type.

The paging does not properly forward the filters to the next page.

Also the page size was specified in tow places instead of one.

### 2. What does this change do, exactly?

Filtering also for cache type also if we search for events.

### 3. Describe each step to reproduce the issue or behaviour.

1. Publish a non event cache with publication date of today
2. Open [https://www.opencaching.de/newcaches.php?cachetype=6](https://www.opencaching.de/newcaches.php?cachetype=6)
3. The new cache is shown (with a event symbol)

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
