### PR TITLE
Fix translations and encoding on testserver

### DIFF
--- a/dev-ops/local.team-opencaching.de/templates/config2-settings.inc.tpl.php
+++ b/dev-ops/local.team-opencaching.de/templates/config2-settings.inc.tpl.php
@@ -14,8 +14,8 @@ if (defined('HTTPS_ENABLED')) {
 }
 
 $opt['debug'] = true;
-$opt['httpd']['user'] = 'vagrant';
-$opt['httpd']['group'] = 'vagrant';
+$opt['httpd']['user'] = 'application';
+$opt['httpd']['group'] = 'application';
 
 // show blog and forum news on index.php
 $debug_startpage_news = false;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
             - opencaching
 
     mariadb:
-        image: mariadb:10.1
+        build: ./docker/mariadb
         container_name: opencaching-mariadb
         working_dir: /application
         volumes:

--- a/docker/httpd/Dockerfile
+++ b/docker/httpd/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update -y \
     default-mysql-client \
     nano \
     curl \
-    yarn
+    yarn \
+    gettext
 
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt-get install -y nodejs
 

--- a/docker/mariadb/Dockerfile
+++ b/docker/mariadb/Dockerfile
@@ -1,0 +1,3 @@
+FROM mariadb:10.1
+
+COPY mariadb.cnf /etc/mysql/conf.d/mariadb.cnf

--- a/docker/mariadb/mariadb.cnf
+++ b/docker/mariadb/mariadb.cnf
@@ -1,0 +1,13 @@
+# MariaDB-specific config file.
+# Read by /etc/mysql/my.cnf
+
+[client]
+default-character-set=utf8mb4
+
+[mysql]
+default-character-set=utf8mb4
+
+[mysqld]
+collation-server = utf8mb4_unicode_520_ci
+init-connect='SET NAMES utf8mb4'
+character-set-server = utf8mb4


### PR DESCRIPTION
### 1. Why is this change necessary?

Translations on the testserver (http://docker.team-opencaching.de) work only partialy and when creating a new GeoCache, the attributes are not selectable.

⚠️ The changes in this PR did make it work on my machine - more tests on other machines are needed. ⚠️

### 2. What does this change do, exactly?

* Install gettext
* Configure the correct user for docker "application" instead of "vagrant"
* Set the default character-set for the connection to MariaDB to "utf8mb4"

### 3. Describe each step to reproduce the issue or behaviour.

1. Install the testserver (from scratch?)
2. Open http://docker.team-opencaching.de
3. Try to switch the language -> It won't work
4. Try to switch the country -> The list is empty on most pages and incomplete on some.
5. Try to create a new GeoCache and select a Attribute -> it wont work

### 4. Please link to the relevant issues (if any).

https://opencaching.atlassian.net/browse/RED-1278

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
