### PR TITLE
fix(RED-1176): Prevent line breaks in date on main page for language en and nl

### DIFF
--- a/htdocs/templates2/ocstyle/res_newcaches.tpl
+++ b/htdocs/templates2/ocstyle/res_newcaches.tpl
@@ -10,7 +10,7 @@
         <li class="newcache_list_multi" style="margin-bottom: 8px;">
             <table class="null" cellspacing="0" cellpadding="0"><tr>
             <td style="vertical-align:top; padding-right:2px; padding-top:2px" rowspan="2">{include file="res_cacheicon_22.tpl" cachetype=$cacheitem.type}</td>
-            <td style="vertical-align:top; ">{$cacheitem.date_created|date_format:$opt.format.date}&nbsp;&nbsp;</td>
+            <td style="vertical-align:top; white-space: nowrap;">{$cacheitem.date_created|date_format:$opt.format.date}&nbsp;&nbsp;</td>
             <td style="text-align:left; width:100%"><b><a class="links" href="viewcache.php?cacheid={$cacheitem.cache_id}">{$cacheitem.name|escape}</a></b> {include file="res_oconly.tpl" oconly=$cacheitem.oconly}
             {t}by{/t}
             <b><a class="links" href="viewprofile.php?userid={$cacheitem.user_id}">{$cacheitem.username|escape}</a></b></td>

--- a/htdocs/templates2/ocstyle/res_newevents.tpl
+++ b/htdocs/templates2/ocstyle/res_newevents.tpl
@@ -6,7 +6,7 @@
         <li class="newcache_list_multi" style="margin-bottom: 8px;">
             <table class="null" cellspacing="0" cellpadding="0"><tr>
             <td style="vertical-align:top; padding-right:2px; padding-top:2px" rowspan="2"><img src="resource2/{$opt.template.style}/images/cacheicon/event-rand{rand min=1 max=4}.gif" alt="{t}Event Geocache{/t}" border="0" width="22" height="22" align="left" style="margin-right: 5px;" /></td>
-            <td style="vertical-align:top; ">{$eventitem.date_hidden|date_format:$opt.format.date}&nbsp;&nbsp;</td>
+            <td style="vertical-align:top; white-space: nowrap;">{$eventitem.date_hidden|date_format:$opt.format.date}&nbsp;&nbsp;</td>
             <td style="text-align:left; width:100%"><b><a class="links" href="viewcache.php?cacheid={$eventitem.cache_id}">{$eventitem.name|escape}</a></b> {include file="res_oconly.tpl" oconly=$eventitem.oconly}
             {t}by{/t}
             <b><a class="links" href="viewprofile.php?userid={$eventitem.user_id}">{$eventitem.username|escape}</a></b></td>


### PR DESCRIPTION
### 1. Why is this change necessary?
The main page in en and nl look bad because there are additional line breaks in the date:
https://www.opencaching.de/?locale=EN
https://www.opencaching.de/?locale=NL

### 2. What does this change do, exactly?
Prevent line breaks with CSS

### 3. Describe each step to reproduce the issue or behavior.
Open the pages
https://www.opencaching.de/?locale=EN
https://www.opencaching.de/?locale=NL

and compare it with
https://www.opencaching.de/?locale=DE

The layout breaks as the hyphens allow for a line break.

### 4. Please link to the relevant issues (if any).
https://opencaching.atlassian.net/browse/RED-1176

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
