### PR TITLE
OCC-113 match live DB and test DB

### DIFF
--- a/htdocs_symfony/migrations/Version20210811130713.php
+++ b/htdocs_symfony/migrations/Version20210811130713.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OcMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210811130713 extends AbstractMigration
+{
+    public function getDescription()
+    : string
+    {
+        return 'adjust database to match live DB and test DB';
+    }
+
+    public function up(Schema $schema)
+    : void {
+        // add cache_logs/gpdr_deletion
+        $this->addSql(
+            'ALTER TABLE cache_logs ADD COLUMN IF NOT EXISTS gdpr_deletion tinyint(1) NOT NULL DEFAULT 0;'
+        );
+
+        // add cache_logs_archived/gdpr_deletion
+        $this->addSql(
+            'ALTER TABLE cache_logs_archived ADD COLUMN IF NOT EXISTS gdpr_deletion tinyint(1) NOT NULL DEFAULT 0;'
+        );
+
+        // add caches/gdpr_deletion
+        $this->addSql(
+            'ALTER TABLE caches ADD COLUMN IF NOT EXISTS gdpr_deletion tinyint(1) NOT NULL DEFAULT 0;'
+        );
+
+        // add user/gdpr_deletion
+        $this->addSql(
+            'ALTER TABLE user ADD COLUMN IF NOT EXISTS gdpr_deletion tinyint(1) NOT NULL DEFAULT 0;'
+        );
+
+        // add pictures_modified
+        $this->addSql(
+            'CREATE TABLE IF NOT EXISTS pictures_modified (
+                    id int(10) NOT NULL,
+                    date_modified datetime NOT NULL,
+                    operation char(1) NOT NULL,
+                    date_created datetime NOT NULL,
+                    url varchar(255) NOT NULL,
+                    title varchar(250) NOT NULL,
+                    object_id int(10) UNSIGNED NOT NULL,
+                    object_type tinyint(3) UNSIGNED NOT NULL,
+                    spoiler tinyint(1) NOT NULL,
+                    unknown_format tinyint(1) NOT NULL,
+                    display tinyint(1) NOT NULL,
+                    original_id int(10) NOT NULL,
+                    restored_by int(10) NOT NULL,
+                    KEY object_type (object_type, object_id, date_modified),
+                    UNIQUE KEY (id, operation)
+                )
+                ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;'
+        );
+
+        // change caches/wp_oc to varchar(7)
+        $this->addSql(
+            'ALTER TABLE caches MODIFY wp_oc varchar (7) UNIQUE ;'
+        );
+    }
+
+    public function down(Schema $schema)
+    : void {
+    }
+}

--- a/htdocs_symfony/migrations/Version20210811130713.php
+++ b/htdocs_symfony/migrations/Version20210811130713.php
@@ -15,7 +15,7 @@ final class Version20210811130713 extends AbstractMigration
     public function getDescription()
     : string
     {
-        return 'adjust database to match live DB and test DB';
+        return 'create tables existing in live-DB,but not in test-DB';
     }
 
     public function up(Schema $schema)
@@ -60,11 +60,6 @@ final class Version20210811130713 extends AbstractMigration
                     UNIQUE KEY (id, operation)
                 )
                 ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;'
-        );
-
-        // change caches/wp_oc to varchar(7)
-        $this->addSql(
-            'ALTER TABLE caches MODIFY wp_oc varchar (7) UNIQUE ;'
         );
     }
 

--- a/htdocs_symfony/migrations/Version20210811184533.php
+++ b/htdocs_symfony/migrations/Version20210811184533.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OcMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210811184533 extends AbstractMigration
+{
+    public function getDescription()
+    : string
+    {
+        return 'adjust column to match live-DB';
+    }
+
+    public function up(Schema $schema)
+    : void {
+        // change caches/wp_oc to varchar(7)
+        $this->addSql(
+            'ALTER TABLE caches MODIFY wp_oc varchar (7) UNIQUE ;'
+        );
+    }
+
+    public function down(Schema $schema)
+    : void {
+    }
+}

--- a/htdocs_symfony/migrations/Version20210811184716.php
+++ b/htdocs_symfony/migrations/Version20210811184716.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OcMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210811184716 extends AbstractMigration
+{
+    public function getDescription()
+    : string
+    {
+        return 'create tables existing in test-DB,but not in live-DB';
+    }
+
+    public function up(Schema $schema)
+    : void {
+        // add mapresult
+        $this->addSql(
+            'CREATE TABLE IF NOT EXISTS mapresult (
+                    query_id     int(10)  UNSIGNED NOT NULL,
+                    date_created datetime NOT NULL,
+                    PRIMARY KEY (query_id)
+                );
+                CREATE INDEX date_created ON mapresult(date_created);'
+        );
+
+        // add mapresult_data
+        $this->addSql(
+            'CREATE TABLE IF NOT EXISTS mapresult_data (
+                    query_id int(10) UNSIGNED NOT NULL,
+                    cache_id int(10) UNSIGNED NOT NULL,
+                    PRIMARY KEY (query_id, cache_id)
+                );'
+        );
+
+        // add oc_migrations
+        $this->addSql(
+            'CREATE TABLE IF NOT EXISTS oc_migrations (
+                    version        varchar(191) NOT NULL PRIMARY KEY,
+                    executed_at    datetime     NULL,
+                    execution_time int(11)      NULL
+                );'
+        //                COLLATE = utf8_unicode_ci;' //?
+        );
+
+        // add security_role_hierarchy
+        $this->addSql(
+            'CREATE TABLE IF NOT EXISTS security_role_hierarchy (
+                    role_id     int(11) NOT NULL,
+                    sub_role_id int(11) NOT NULL,
+                    CONSTRAINT security_role_hierarchy_pk_2 UNIQUE (role_id, sub_role_id),
+                    CONSTRAINT security_role_hierarchy_security_roles_id_fk FOREIGN KEY (role_id) REFERENCES security_roles(id),
+                    CONSTRAINT security_role_hierarchy_security_roles_id_fk_2 FOREIGN KEY (sub_role_id) REFERENCES security_roles(id),
+                    PRIMARY KEY (role_id, sub_role_id)
+                );'
+        );
+
+        // add security_roles
+        $this->addSql(
+            'CREATE TABLE IF NOT EXISTS security_roles (
+                    id   int(11) AUTO_INCREMENT,
+                    role varchar(100) NOT NULL,
+                    CONSTRAINT security_roles_role_uindex UNIQUE (role),
+                    PRIMARY KEY (id)
+                );'
+        );
+
+        // add user_roles
+        $this->addSql(
+            'CREATE TABLE IF NOT EXISTS user_roles (
+                    id      int(11) AUTO_INCREMENT,
+                    user_id int(10) UNSIGNED NOT NULL,
+                    role_id int(11) NOT NULL,
+                    CONSTRAINT user_roles_user_id_role_id_uindex UNIQUE (user_id, role_id),
+                    CONSTRAINT user_roles_security_roles_id_fk FOREIGN KEY (role_id) REFERENCES security_roles(id),
+                    CONSTRAINT user_roles_user_user_id_fk FOREIGN KEY (user_id) REFERENCES user(user_id),
+                    PRIMARY KEY (id)
+                );'
+        );
+    }
+
+    public function down(Schema $schema)
+    : void {
+    }
+}

--- a/htdocs_symfony/src/Controller/Backend/SupportController.php
+++ b/htdocs_symfony/src/Controller/Backend/SupportController.php
@@ -19,6 +19,7 @@ use Oc\Repository\CacheStatusRepository;
 use Oc\Repository\Exception\RecordNotFoundException;
 use Oc\Repository\Exception\RecordNotPersistedException;
 use Oc\Repository\Exception\RecordsNotFoundException;
+use Oc\Repository\SupportBonuscachesRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -55,9 +56,10 @@ class SupportController extends AbstractController
     /** @var CacheStatusRepository */
     private $cacheStatusRepository;
 
+    /** @var SupportBonuscachesRepository */
+    private $supportBonuscachesRepository;
+
     /**
-     * SupportController constructor.
-     *
      * @param Connection $connection
      * @param CacheAdoptionsRepository $cacheAdoptionsRepository
      * @param CacheCoordinatesRepository $cacheCoordinatesRepository
@@ -66,6 +68,7 @@ class SupportController extends AbstractController
      * @param CacheReportsRepository $cacheReportsRepository
      * @param CacheStatusModifiedRepository $cacheStatusModifiedRepository
      * @param CacheStatusRepository $cacheStatusRepository
+     * @param SupportBonuscachesRepository $supportBonuscachesRepository
      */
     public function __construct(
         Connection $connection,
@@ -75,7 +78,8 @@ class SupportController extends AbstractController
         CachesRepository $cachesRepository,
         CacheReportsRepository $cacheReportsRepository,
         CacheStatusModifiedRepository $cacheStatusModifiedRepository,
-        CacheStatusRepository $cacheStatusRepository
+        CacheStatusRepository $cacheStatusRepository,
+        SupportBonuscachesRepository $supportBonuscachesRepository
     ) {
         $this->connection = $connection;
         $this->cacheAdoptionsRepository = $cacheAdoptionsRepository;
@@ -85,6 +89,7 @@ class SupportController extends AbstractController
         $this->cacheReportsRepository = $cacheReportsRepository;
         $this->cacheStatusModifiedRepository = $cacheStatusModifiedRepository;
         $this->cacheStatusRepository = $cacheStatusRepository;
+        $this->supportBonuscachesRepository = $supportBonuscachesRepository;
     }
 
     /**
@@ -147,6 +152,27 @@ class SupportController extends AbstractController
                                                           'supportCachesForm' => $formSearch->createView(),
                                                           'reportedCaches_by_id' => $fetchedReports
                                                       ]
+        );
+    }
+
+    /**
+     * @return Response
+     * @throws RecordsNotFoundException
+     *
+     * @Route("/bonusCaches", name="support_bonus_caches")
+     */
+    public function listBonusCaches()
+    : Response
+    {
+        $fetchedBonuscaches = $this->getBonusCaches();
+
+        $formSearch = $this->createForm(SupportSearchCaches::class);
+
+        return $this->render(
+            'backend/support/bonusCaches.html.twig', [
+                                                       'supportCachesForm' => $formSearch->createView(),
+                                                       'bonusCaches_by_id' => $fetchedBonuscaches
+                                                   ]
         );
     }
 
@@ -369,11 +395,22 @@ class SupportController extends AbstractController
 
     /**
      * @return array
+     * @throws RecordsNotFoundException
+     */
+    public function getBonusCaches()
+    : array
+    {
+        return $this->supportBonuscachesRepository->fetchAll();
+    }
+
+    /**
+     * @return array
      * @throws RecordNotFoundException
      * @throws RecordsNotFoundException
      */
     public function getReportedCaches()
-    : array {
+    : array
+    {
         return $this->cacheReportsRepository->fetchAll();
     }
 

--- a/htdocs_symfony/src/Entity/SupportBonuscachesEntity.php
+++ b/htdocs_symfony/src/Entity/SupportBonuscachesEntity.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oc\Entity;
+
+use Oc\Repository\AbstractEntity;
+
+/**
+ * Class SupportBonuscachesEntity
+ *
+ * @package Oc\Entity
+ */
+class SupportBonuscachesEntity extends AbstractEntity
+{
+    /** @var int */
+    public $id;
+
+    /** @var string */
+    public $wpOc;
+
+    /** @var bool */
+    public $isBonusCache;
+
+    /** @var string */
+    public $belongsToBonusCache;
+
+    /**
+     * @return bool
+     */
+    public function isNew()
+    : bool
+    {
+        return $this->id === null;
+    }
+}

--- a/htdocs_symfony/src/Repository/SupportBonuscachesRepository.php
+++ b/htdocs_symfony/src/Repository/SupportBonuscachesRepository.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oc\Repository;
+
+use Doctrine\DBAL\Connection;
+use Oc\Entity\SupportBonuscachesEntity;
+use Oc\Repository\Exception\RecordAlreadyExistsException;
+use Oc\Repository\Exception\RecordNotFoundException;
+use Oc\Repository\Exception\RecordNotPersistedException;
+use Oc\Repository\Exception\RecordsNotFoundException;
+
+/**
+ * Class SupportBonuscachesRepository
+ *
+ * @package Oc\Repository
+ */
+class SupportBonuscachesRepository
+{
+    const TABLE = 'support_bonuscaches';
+
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * @return array
+     * @throws RecordsNotFoundException
+     */
+    public function fetchAll()
+    : array
+    {
+        $statement = $this->connection->createQueryBuilder()
+            ->select('*')
+            ->from(self::TABLE)
+            ->execute();
+
+        $result = $statement->fetchAll();
+
+        if ($statement->rowCount() === 0) {
+            throw new RecordsNotFoundException('No records found');
+        }
+
+        $records = [];
+
+        foreach ($result as $item) {
+            $records[] = $this->getEntityFromDatabaseArray($item);
+        }
+
+        return $records;
+    }
+
+    /**
+     * @param array $where
+     *
+     * @return SupportBonuscachesEntity
+     * @throws RecordNotFoundException
+     */
+    public function fetchOneBy(array $where = [])
+    : SupportBonuscachesEntity {
+        $queryBuilder = $this->connection->createQueryBuilder()
+            ->select('*')
+            ->from(self::TABLE)
+            ->setMaxResults(1);
+
+        if (count($where) > 0) {
+            foreach ($where as $column => $value) {
+                $queryBuilder->andWhere($column . ' = ' . $queryBuilder->createNamedParameter($value));
+            }
+        }
+
+        $statement = $queryBuilder->execute();
+
+        $result = $statement->fetch();
+
+        if ($statement->rowCount() === 0) {
+            throw new RecordNotFoundException('Record with given where clause not found');
+        }
+
+        return $this->getEntityFromDatabaseArray($result);
+    }
+
+    /**
+     * @param array $where
+     *
+     * @return array
+     * @throws RecordsNotFoundException
+     */
+    public function fetchBy(array $where = [])
+    : array {
+        $queryBuilder = $this->connection->createQueryBuilder()
+            ->select('*')
+            ->from(self::TABLE);
+
+        if (count($where) > 0) {
+            foreach ($where as $column => $value) {
+                $queryBuilder->andWhere($column . ' = ' . $queryBuilder->createNamedParameter($value));
+            }
+        }
+
+        $statement = $queryBuilder->execute();
+
+        $result = $statement->fetchAll();
+
+        if ($statement->rowCount() === 0) {
+            throw new RecordsNotFoundException('No records with given where clause found');
+        }
+
+        $entities = [];
+
+        foreach ($result as $item) {
+            $entities[] = $this->getEntityFromDatabaseArray($item);
+        }
+
+        return $entities;
+    }
+
+    /**
+     * @param SupportBonuscachesEntity $entity
+     *
+     * @return SupportBonuscachesEntity
+     * @throws RecordAlreadyExistsException
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function create(SupportBonuscachesEntity $entity)
+    : SupportBonuscachesEntity {
+        if (!$entity->isNew()) {
+            throw new RecordAlreadyExistsException('The entity does already exist.');
+        }
+
+        $databaseArray = $this->getDatabaseArrayFromEntity($entity);
+
+        $this->connection->insert(
+            self::TABLE,
+            $databaseArray
+        );
+
+        $entity->id = (int) $this->connection->lastInsertId();
+
+        return $entity;
+    }
+
+    /**
+     * @param SupportBonuscachesEntity $entity
+     *
+     * @return SupportBonuscachesEntity
+     * @throws RecordNotPersistedException
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function update(SupportBonuscachesEntity $entity)
+    : SupportBonuscachesEntity {
+        if ($entity->isNew()) {
+            throw new RecordNotPersistedException('The entity does not exist.');
+        }
+
+        $databaseArray = $this->getDatabaseArrayFromEntity($entity);
+
+        $this->connection->update(
+            self::TABLE,
+            $databaseArray,
+            ['id' => $entity->id]
+        );
+
+        return $entity;
+    }
+
+    /**
+     * @param SupportBonuscachesEntity $entity
+     *
+     * @return SupportBonuscachesEntity
+     * @throws RecordNotPersistedException
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws \Doctrine\DBAL\Exception\InvalidArgumentException
+     */
+    public function remove(SupportBonuscachesEntity $entity)
+    : SupportBonuscachesEntity {
+        if ($entity->isNew()) {
+            throw new RecordNotPersistedException('The entity does not exist.');
+        }
+
+        $this->connection->delete(
+            self::TABLE,
+            ['id' => $entity->id]
+        );
+
+        $entity->id = null;
+
+        return $entity;
+    }
+
+    /**
+     * @param SupportBonuscachesEntity $entity
+     *
+     * @return array
+     */
+    public function getDatabaseArrayFromEntity(SupportBonuscachesEntity $entity)
+    : array {
+        return [
+            'id' => $entity->id,
+            'wp_oc' => $entity->wpOc,
+            'is_bonus_cache' => $entity->isBonusCache,
+            'belongs_to_bonus_cache' => $entity->belongsToBonusCache,
+        ];
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return SupportBonuscachesEntity
+     */
+    public function getEntityFromDatabaseArray(array $data)
+    : SupportBonuscachesEntity {
+        $entity = new SupportBonuscachesEntity();
+        $entity->id = (int) $data['id'];
+        $entity->wpOc = (string) $data['wp_oc'];
+        $entity->isBonusCache = (bool) $data['is_bonus_cache'];
+        $entity->belongsToBonusCache = (string) $data['belongs_to_bonus_cache'];
+
+        return $entity;
+    }
+}

--- a/htdocs_symfony/templates/backend/support/bonusCaches.html.twig
+++ b/htdocs_symfony/templates/backend/support/bonusCaches.html.twig
@@ -1,0 +1,43 @@
+{% extends 'backend/base.html.twig' %}
+
+{% block page_content %}
+
+    {% include '/backend/support/support.header.html.twig' %}
+
+    <h3><br/>{{ 'Bonus caches' | trans }}..</h3>
+
+    <div>
+        {% if bonusCaches_by_id is defined %}
+            <div> Found: {{ bonusCaches_by_id|length }} Cache(s)</div>
+            {% if bonusCaches_by_id %}
+                <table class="table table-striped table-hover">
+                    <thead class="thead-dark">
+                    <tr>
+                        <th scope="col" class="asc">{{ 'OC code' | trans }}</th>
+                        <th scope="col" class="asc">{{ 'Is a bonus cache?' | trans }}</th>
+                        <th scope="col" class="asc">{{ 'Belongs to bonus cache' | trans }}</th>
+                        <th scope="col">&nbsp;</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for bonusCache in bonusCaches_by_id %}
+                        <tr>
+                            <td>{{ bonusCache.wpOc }}</td>
+                            <td>{% if (bonusCache.isBonusCache) %}<i class="fas fa-check"></i>{% else %}<i class="fas fa-times"></i>{% endif %}</td>
+                            <td>{% if (bonusCache.belongsToBonusCache) %}{{ bonusCache.belongsToBonusCache }}{% else %}<i
+                                        class="fas fa-times"></i>{% endif %}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            {% else %}
+                <br/><br/>
+                <span>{{ 'No caches found' | trans }}..</span>
+            {% endif %}
+        {% endif %}
+
+    </div>
+
+    <hr>
+
+{% endblock %}

--- a/htdocs_symfony/templates/backend/support/support.header.html.twig
+++ b/htdocs_symfony/templates/backend/support/support.header.html.twig
@@ -20,11 +20,15 @@
 
     </section>
 
-    <section class="container col-md-3">
+    <section class="container col-md-2">
         <a href="{{ path('backend_support_reported_caches') }}">{{ 'Reported caches' | trans }}</a>
     </section>
 
-    <section class="container col-md-3">
+    <section class="container col-md-2">
+        <a href="{{ path('backend_support_bonus_caches') }}">{{ 'Bonus caches' | trans }}</a>
+    </section>
+
+    <section class="container col-md-2">
         <a href="{{ path('backend_support_db_queries') }}">{{ 'Database queries' | trans }}</a>
     </section>
 </div>


### PR DESCRIPTION
Entsprechend  https://opencaching.atlassian.net/browse/OCC-113 anbei die migration-Scripte, um die Unterschiede zwischen Live- und Test-DB auszugleichen. Falls einige Tabellen hier (noch) nicht hingehören (insbesondere in Version20210811184716), bitte Bescheid geben. Dann nehm ich sie wieder raus.

p.s. dass hier die Dateien von 'OCC-112 Bonuscaches' mit reingerutscht ist, war nicht geplant. Hatte da schon Sachen lokal gemergt, um an anderer Stelle weiterzukommen.. :-/