### PR TITLE
RED-1232 removed .it and .fr as far as possible

### DIFF
--- a/htdocs/config2/settings-sample.inc.php
+++ b/htdocs/config2/settings-sample.inc.php
@@ -222,9 +222,6 @@ function post_config(): void
         case 'www.opencaching.de':
             config_domain_www_opencaching_de();
             break;
-        case 'www.opencaching.it':
-            config_domain_www_opencaching_it();
-            break;
         default:
             $tpl->redirect('https://www.opencaching.de/index.php');
     }

--- a/htdocs/lang/de/ocstyle/email/fr/notify_newcache.email
+++ b/htdocs/lang/de/ocstyle/email/fr/notify_newcache.email
@@ -16,10 +16,10 @@ Vous pouvez visualiser et modifier les paramètres de votre rayon de recherche
 au titre {site_url}myprofile.php.
 
 Bonne Geocaching,
-l'équipe Opencaching.de / Opencaching.fr
+l'équipe Opencaching.de
 
 ---
 Cet e-mail a été généré automatiquement. Merci de ne pas y répondre.
-Si tu veux contacter Opencaching.de/.fr, tu trouveras toutes les options sur
+Si tu veux contacter Opencaching.de, tu trouveras toutes les options sur
 {site_url}articles.php?page=contact.
 En cas d'urgence, tu peux utiliser l'adresse e-mail {email_contact}.

--- a/htdocs/lang/de/ocstyle/email/fr/notify_newoconly.email
+++ b/htdocs/lang/de/ocstyle/email/fr/notify_newoconly.email
@@ -16,10 +16,10 @@ Vous pouvez visualiser et modifier les paramètres de votre rayon de recherche
 et les notifications OConly au titre {site_url}myprofile.php.
 
 Bonne Geocaching,
-l'équipe Opencaching.de / Opencaching.fr
+l'équipe Opencaching.de
 
 ---
 Cet e-mail a été généré automatiquement. Merci de ne pas y répondre.
-Si tu veux contacter Opencaching.de/.fr, tu trouveras toutes les options sur
+Si tu veux contacter Opencaching.de, tu trouveras toutes les options sur
 {site_url}articles.php?page=contact.
 En cas d'urgence, tu peux utiliser l'adresse e-mail {email_contact}.

--- a/htdocs/lang/de/ocstyle/email/fr/removed_log.email
+++ b/htdocs/lang/de/ocstyle/email/fr/removed_log.email
@@ -19,6 +19,6 @@ Vous pouvez contacter %cache_owner% via le lien suivant:
 
 ---
 Cet e-mail a été généré automatiquement. Merci de ne pas y répondre. 
-Si tu veux contacter Opencaching.de/.fr, tu trouveras toutes les options sur
+Si tu veux contacter Opencaching.de, tu trouveras toutes les options sur
 {site_url}articles.php?page=contact
 En cas d'urgence, tu peux utiliser l'adresse e-mail {email_contact}.

--- a/htdocs/lang/de/ocstyle/email/fr/watchlist.email
+++ b/htdocs/lang/de/ocstyle/email/fr/watchlist.email
@@ -18,10 +18,10 @@ Vous pouvez visualiser et modifier les paramètres de votre liste de suivi
 au titre {site_url}mywatches.php?action=edit.
 
 Bonne Geocaching,
-l'équipe Opencaching.de / Opencaching.fr
+l'équipe Opencaching.de
 
 ---
 Cet e-mail a été généré automatiquement. Merci de ne pas y répondre. 
-Si tu veux contacter Opencaching.de/.fr, tu trouveras toutes les options sur
+Si tu veux contacter Opencaching.de, tu trouveras toutes les options sur
 {site_url}articles.php?page=contact.
 En cas d'urgence, tu peux utiliser l'adresse e-mail {email_contact}.

--- a/htdocs/lang/de/ocstyle/email/it/notify_newcache.email
+++ b/htdocs/lang/de/ocstyle/email/it/notify_newcache.email
@@ -16,10 +16,10 @@ Puoi vedere e modificare i settaggi del tuo raggio di ricerca qui:
 {site_url}myprofile.php.
 
 Happy Geocaching,
-the Opencaching.de / Opencaching.it Team
+the Opencaching.de Team
 
 ---
 Questa E-Mail è stata generata automaticamente - per favore non rispondere.
-Se vuoi contattare Opencaching.de/.it, fai riferimento alla pagina 
+Se vuoi contattare Opencaching.de, fai riferimento alla pagina
 {site_url}articles.php?page=contact.
 In casi urgenti puoi inviare una e-mail a: {email_contact}.

--- a/htdocs/lang/de/ocstyle/email/it/notify_newoconly.email
+++ b/htdocs/lang/de/ocstyle/email/it/notify_newoconly.email
@@ -16,10 +16,10 @@ Puoi vedere e modificare i settaggi del tuo raggio di ricerca qui:
 {site_url}myprofile.php.
 
 Happy Geocaching,
-the Opencaching.de / Opencaching.it Team
+the Opencaching.de Team
 
 ---
 Questa E-Mail è stata generata automaticamente - per favore non rispondere.
-Se vuoi contattare Opencaching.de/.it, fai riferimento alla pagina 
+Se vuoi contattare Opencaching.de, fai riferimento alla pagina
 {site_url}articles.php?page=contact.
 In casi urgenti puoi inviare una e-mail a: {email_contact}.

--- a/htdocs/lang/de/ocstyle/email/it/removed_log.email
+++ b/htdocs/lang/de/ocstyle/email/it/removed_log.email
@@ -19,6 +19,6 @@ Puoi contattare %cache_owner% tramite questo link:
 
 ---
 Questa E-Mail è stata generata automaticamente - per favore non rispondere.
-Se vuoi contattare Opencaching.de/.it, fai riferimento alla pagina 
+Se vuoi contattare Opencaching.de, fai riferimento alla pagina
 {site_url}articles.php?page=contact.
 In casi urgenti puoi inviare una e-mail a: {email_contact}.

--- a/htdocs/lang/de/ocstyle/email/it/watchlist.email
+++ b/htdocs/lang/de/ocstyle/email/it/watchlist.email
@@ -18,10 +18,10 @@ Puoi vedere e modificare la tua lista delle cache osservate qui:
 {site_url}mywatches.php?action=edit.
 
 Happy Geocaching,
-the Opencaching.de / Opencaching.it Team
+the Opencaching.de Team
 
 ---
 Questa E-Mail è stata generata automaticamente - per favore non rispondere.
-Se vuoi contattare Opencaching.de/.it, fai riferimento alla pagina 
+Se vuoi contattare Opencaching.de, fai riferimento alla pagina
 {site_url}articles.php?page=contact.
 In casi urgenti puoi inviare una e-mail a: {email_contact}.

--- a/htdocs/lang/de/ocstyle/main.tpl.php
+++ b/htdocs/lang/de/ocstyle/main.tpl.php
@@ -256,8 +256,6 @@ foreach ($opt['template']['locales'] as $k => $lang) {
                     <div style="text-align: center;" class="nodeflags">
                         <a href="http://www.opencaching.cz" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-cz.png" width="100" height="22" /></a><br />
                         <a href="https://www.opencaching.de" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-de.png" width="100" height="22" /></a><br />
-                        <a href="https://www.opencaching.fr" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-fr.png" width="100" height="22" /></a><br />
-                        <a href="https://www.opencaching.it" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-it.png" width="100" height="22" /></a><br />
                         <a href="http://www.opencaching.nl" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-nl.png" width="100" height="22" /></a><br />
                         <a href="https://opencaching.pl" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-pl.png" width="100" height="22" /></a><br />
                         <a href="http://www.opencaching.ro" target="_blank"><img src="resource2/ocstyle/images/nodes/oc-ro.png" width="100" height="22" /></a><br />

--- a/htdocs/templates2/ocstyle/articles/EN/team.tpl
+++ b/htdocs/templates2/ocstyle/articles/EN/team.tpl
@@ -8,8 +8,7 @@
 </div>
 <div class="content-txtbox-noshade" style="padding-right: 25px;">
 
-    <p>We would like to introduce our team of volunteers, which is restlessly working behind the scenery for you, the users of opencaching.de,
-       opencaching.it and opencaching.fr.</p>
+    <p>We would like to introduce our team of volunteers, which is restlessly working behind the scenery for you, the users of opencaching.de.</p>
 
     <p>We appreciate your suggetions and comments. On the
         <a href="https://www.opencaching.de/articles.php?page=contact">contact page</a>

--- a/htdocs/templates2/ocstyle/articles/EN/verein.tpl
+++ b/htdocs/templates2/ocstyle/articles/EN/verein.tpl
@@ -24,6 +24,6 @@
 <p>We depend on your donations to finance the technical operation of the website. We will be glad to recieve your support via our <a href="./articles.php?page=donations" target="_blank">donations page</a>; a few Euros will already help us.</p>
 
 <h5>Where can I ask further questions on the association?</h5>
-<p>You are welcome to contact the chairman at <a href="mailto:verein@opencaching.de">verein@opencaching.de</a>./p>
+<p>You are welcome to contact the chairman at <a href="mailto:verein@opencaching.de">verein@opencaching.de</a>.</p>
 
 </div>


### PR DESCRIPTION
Nachtrag zu RED-1232, https://github.com/OpencachingDeutschland/oc-server3/pull/839

Soweit möglich und sinnvoll wurden weitere Vorkommen von opencaching.it und .fr entfernt.