### PR TITLE
Remove links to deleted mdb-files (OCC-137)

### DIFF
--- a/htdocs/templates2/ocstyle/sys_main.tpl
+++ b/htdocs/templates2/ocstyle/sys_main.tpl
@@ -36,14 +36,6 @@
     <link rel="apple-touch-icon" sizes="144x144"
           href="resource2/{$opt.template.style}/images/oclogo/apple-touch-icon-ipad-retina.png"/>
 
-    {if $core_hq_message}
-        <!-- Bootstrap core CSS -->
-        <link href="../../resource2/mdb-free/css/bootstrap.min.css" rel="stylesheet">
-        <!-- Material Design Bootstrap -->
-        <link href="../../resource2/mdb-free/css/mdb.min.css" rel="stylesheet">
-        <!-- Your custom styles (optional) -->
-        <link href="../../resource2/mdb-free/css/style.css" rel="stylesheet">
-    {/if}
     <link rel="stylesheet" type="text/css" media="screen,projection"
           href="resource2/{$opt.template.style}/css/style_screen.css?ft={$screen_css_time}"/>
     <!--[if lt IE 9]>
@@ -497,14 +489,5 @@
 {/if}
 {/if}
 
-<!-- SCRIPTS -->
-<!-- JQuery -->
-<script type="text/javascript" src="../../resource2/mdb-free/js/jquery-3.3.1.min.js"></script>
-<!-- Bootstrap tooltips -->
-<script type="text/javascript" src="../../resource2/mdb-free/js/popper.min.js"></script>
-<!-- Bootstrap core JavaScript -->
-<script type="text/javascript" src="../../resource2/mdb-free/js/bootstrap.min.js"></script>
-<!-- MDB core JavaScript -->
-<script type="text/javascript" src="../../resource2/mdb-free/js/mdb.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### 1. Why is this change necessary?
There are mdb-free js files requested on each page. The files are deleted and the calls return a 404.
The wrong calls slow down the site loading and should be removed.

### 2. What does this change do, exactly?

Remove the links to the files in the main template.

### 3. Describe each step to reproduce the issue or behavior.

* Open the inspector in your browser
* Load any page
* See the 404 messages in the console

### 4. Please link to the relevant issues (if any).
https://opencaching.atlassian.net/browse/OCC-137

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
