### PR TITLE
Optimize query for attended now also count for favorites (RED-1321)

### DIFF
--- a/htdocs/lib2/logic/user.class.php
+++ b/htdocs/lib2/logic/user.class.php
@@ -545,20 +545,7 @@ class user
                  FROM (SELECT cache_id
                        FROM cache_logs
                        WHERE user_id = "&1"
-                       AND type = 1
-                       GROUP BY cache_id
-                ) as tmp
-                ',
-                0,
-                $this->getUserId()
-            )
-            +
-            sql_value(
-                'SELECT COUNT(*)
-                 FROM (SELECT cache_id
-                       FROM cache_logs
-                       WHERE user_id = "&1"
-                       AND type = 7
+                       AND type IN (1, 7)
                        GROUP BY cache_id
                 ) as tmp
                 ',


### PR DESCRIPTION
### 1. Why is this change necessary?

Two queries are slower than one.


### 2. What does this change do, exactly?
Optimize query for attended now also count for favorites (RED-1321)

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
