### PR TITLE
Fix XSS from open bug bounty from slack message 01

### DIFF
--- a/htdocs/editcache.php
+++ b/htdocs/editcache.php
@@ -123,7 +123,7 @@ if ($error == false) {
         $cache_record = sql_fetch_array($cache_rs);
         sql_free_result($cache_rs);
 
-        if ($cache_record !== false) {
+        if (is_array($cache_record)) {
             if ($cache_record['user_id'] == $usr['userid'] || $login->listingAdmin()) {
                 $tplname = 'editcache';
                 tpl_acceptsAndPurifiesHtmlInput();

--- a/htdocs/lang/de/ocstyle/varset.inc.php
+++ b/htdocs/lang/de/ocstyle/varset.inc.php
@@ -49,7 +49,7 @@ $allowed = ['cacheid', 'userid', 'logid', 'desclang', 'descid'];
 
 foreach($_REQUEST as $varname => $varvalue) {
     if (in_array($varname, $allowed)) {
-        $target .= $varname . '=' . $varvalue . '&';
+        $target .= $varname . '=' . htmlspecialchars($varvalue) . '&';
     }
 }
 if (mb_substr($target, - 1) == '?' || mb_substr($target, - 1) == '&') {

--- a/htdocs/lib/clicompatbase.inc.php
+++ b/htdocs/lib/clicompatbase.inc.php
@@ -506,7 +506,7 @@ function sql_warn($warnmessage): void
 /**
  * @deprecated use DBAL Conenction instead. See adminreports.php for an example implementation
  * @param resource $rs
- * @return array
+ * @return array|false|null
  */
 function sql_fetch_array($rs)
 {

--- a/htdocs/lib2/db.inc.php
+++ b/htdocs/lib2/db.inc.php
@@ -567,7 +567,7 @@ function sql_value_internal($bQuerySlave, $sql, $default)
 /**
  * @deprecated use DBAL Conenction instead. See adminreports.php for an example implementation
  * @param $rs
- * @return array
+ * @return array|false|null
  */
 function sql_fetch_array($rs)
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

XSS found over bug bounty. Cases messaged in [Slack](https://opencaching-de.slack.com/archives/CEJLQR9PS/p1670359006898449?thread_ts=1659471036.462439&cid=CEJLQR9PS).

### 2. What does this change do, exactly?

1. Encode the values in the target URL for the login forms.

### 3. Describe each step to reproduce the issue or behaviour.

See bug bounty submissions.

1. https://www.opencaching.de/editcache.php?cacheid="><img src=x onerror=alert(1);>
2. https://www.opencaching.de/editcache.php?cacheid=FUZZ/fw/syslogViewer.do?port=%22%3E%3C%2Fscript%3E%3Cscript%3Ealert%28document.domain%29%3C%2Fscript%3E

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
