### PR TITLE
Fix/red 1252/fix field note import

### DIFF
--- a/htdocs/src/Oc/FieldNotes/Enum/LogType.php
+++ b/htdocs/src/Oc/FieldNotes/Enum/LogType.php
@@ -32,11 +32,12 @@ class LogType
     /**
      * @var array
      */
-    public const FILE_LOG_TYPE_MAPPING = [
-        'Found it' => self::FOUND,
-        "Didn't find it" => self::NOT_FOUND,
-        'Write note' => self::NOTE,
-        'Needs Maintenance' => self::NEEDS_MAINTENANCE,
+    private const FILE_LOG_TYPE_MAPPING = [
+        'found it' => self::FOUND,
+        "didn't find it" => self::NOT_FOUND,
+        'write note' => self::NOTE,
+        'needs maintenance' => self::NEEDS_MAINTENANCE,
+        'owner maintenance' => self::NOTE,
     ];
 
     /**
@@ -44,6 +45,6 @@ class LogType
      */
     public static function guess(string $fileLogType): ?int
     {
-        return self::FILE_LOG_TYPE_MAPPING[$fileLogType] ?? null;
+        return self::FILE_LOG_TYPE_MAPPING[strtolower($fileLogType)] ?? null;
     }
 }

--- a/htdocs/src/Oc/FieldNotes/Import/FileParser.php
+++ b/htdocs/src/Oc/FieldNotes/Import/FileParser.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\File\File;
  * and break everything but didn't recognize in first place,
  * please increment the following counter as a warning
  * for the next brave soul
- * total_hours_wasted = 42
+ * total_hours_wasted = 43
  */
 class FileParser
 {
@@ -44,8 +44,7 @@ class FileParser
     {
         $lines = [];
         $rows = [];
-        $content = $csv->getContent();
-        $content = mb_convert_encoding($content, 'UTF-8', 'UTF-16LE');
+        $content = $this->decodeToUtf8($csv->getContent());
 
         $rawLines = array_filter(explode("\n", $content));
         $tmpString = '';
@@ -71,5 +70,21 @@ class FileParser
         }
 
         return $rows;
+    }
+
+    private function decodeToUtf8(string $input): string
+    {
+        foreach (array('UTF-16LE', 'UTF-16BE', 'ASCII') as $encoding) {
+            if (mb_check_encoding($input, $encoding)) {
+                $input = mb_convert_encoding($input, 'UTF-8', $encoding);
+                break;
+            }
+        }
+
+        if (!mb_check_encoding($input, 'UTF-8')) {
+            throw new FileFormatException('Unknown encoding');
+        }
+
+        return $input;
     }
 }

--- a/htdocs/src/Oc/FieldNotes/Import/StructMapper.php
+++ b/htdocs/src/Oc/FieldNotes/Import/StructMapper.php
@@ -17,10 +17,10 @@ class StructMapper
 
         foreach ($rows as $row) {
             $fieldNote = new FieldNote();
-            $fieldNote->waypoint = $row[0];
-            $fieldNote->noticedAt = $row[1];
-            $fieldNote->logType = $row[2];
-            $fieldNote->notice = $row[3];
+            $fieldNote->waypoint = $row[0] ?? null;
+            $fieldNote->noticedAt = $row[1] ?? null;
+            $fieldNote->logType = $row[2] ?? null;
+            $fieldNote->notice = $row[3] ?? null;
 
             $fieldNotes[] = $fieldNote;
         }

--- a/htdocs/src/Oc/FieldNotes/Validator/Constraints/DateTimeValidator.php
+++ b/htdocs/src/Oc/FieldNotes/Validator/Constraints/DateTimeValidator.php
@@ -28,6 +28,13 @@ class DateTimeValidator extends ConstraintValidator
      */
     public const FORMAT_SHORT_EXPANDED = 'YYYY-MM-DDThh:mmZ';
 
+    private const VAlID_FORMATS = [
+        self::FORMAT_LONG,
+        self::FORMAT_SHORT,
+        'Y-m-d\TH:i:s.v\Z',
+        'c',
+    ];
+
     /**
      * Checks if the passed value is valid.
      *
@@ -36,10 +43,16 @@ class DateTimeValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint): void
     {
-        $dateFormatLong = PHPDateTime::createFromFormat(self::FORMAT_LONG, $value);
-        $dateFormatShort = PHPDateTime::createFromFormat(self::FORMAT_SHORT, $value);
+        $valid = false;
 
-        if ($dateFormatLong === false && $dateFormatShort === false) {
+        foreach (self::VAlID_FORMATS as $format) {
+            if (false !== PHPDateTime::createFromFormat($format, $value)) {
+                $valid = true;
+                break;
+            }
+        }
+
+        if (!$valid) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('%datetime%', $value)
                 ->setParameter('%expectedFormatLong%', self::FORMAT_LONG_EXPANDED)


### PR DESCRIPTION
### 1. Why is this change necessary?
Some (newer) field notes files are not suported.

### 2. What does this change do, exactly?
Allow for 
* Different text encoding
* More date formats
* Log types with different spellings

### 3. Describe each step to reproduce the issue or behaviour.
* Take a field noted from c:geo and try to import it

### 4. Please link to the relevant issues (if any).
https://opencaching.atlassian.net/browse/RED-1252

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code

### 6. Known issues
* Possible to log a found on not published caches
* Owner maintainance is imported as notes
* League\Csv\Reader may be not realy needed any more
* 