### PR TITLE
English UI: Dateformat is Y-D-M instead of Y-M-D

### DIFF
--- a/htdocs/config2/locale.inc.php
+++ b/htdocs/config2/locale.inc.php
@@ -91,10 +91,10 @@ $opt['locale']['JA']['locales'] = ['ja_JP.utf8', 'ja_JP', 'jp'];
 
 $opt['locale']['EN']['format']['dm'] = '%d/%m';
 $opt['locale']['EN']['format']['dateshort'] = '%d/%m/%y';
-$opt['locale']['EN']['format']['date'] = '%Y-%d-%m';
+$opt['locale']['EN']['format']['date'] = '%Y-%m-%d';
 $opt['locale']['EN']['format']['datelong'] = '%d %B %Y';
-$opt['locale']['EN']['format']['datetime'] = '%Y-%d-%m %I:%M %p';
-$opt['locale']['EN']['format']['datetimesec'] = '%Y-%d-%m %X';
+$opt['locale']['EN']['format']['datetime'] = '%Y-%m-%d %I:%M %p';
+$opt['locale']['EN']['format']['datetimesec'] = '%Y-%m-%d %X';
 $opt['locale']['EN']['format']['time'] = '%I:%M %p';
 $opt['locale']['EN']['format']['timesec'] = '%X';
 $opt['locale']['EN']['format']['phpdate'] = 'Y-m-d';


### PR DESCRIPTION
<!--
Thank you for contributing to opencaching! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?

See issue-626 and discussion on mattermost

### 2. What does this change do, exactly?

fixes the date format when the web page is rendered in English

### 3. Describe each step to reproduce the issue or behaviour.

Just switch the language to English, look at the homepage and see Events dated: 2023-20-09 .... which is wrong

### 4. Please link to the relevant issues (if any).

issue-626

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
