### PR TITLE
Detect invalid field note; deal with warnings (RED-1252)

### DIFF
--- a/htdocs/src/Oc/FieldNotes/Import/FileParser.php
+++ b/htdocs/src/Oc/FieldNotes/Import/FileParser.php
@@ -40,6 +40,9 @@ class FileParser
         return $this->structMapper->map($rows);
     }
 
+     /**
+      * @throws FileFormatException
+      */
     private function getRowsFromCsv(Reader $csv): array
     {
         $content = $csv->getContent();
@@ -48,6 +51,9 @@ class FileParser
         return $rows;
     }
 
+    /**
+     * @throws FileFormatException
+     */
     private function decodeToUtf8(string $input): string
     {
         if (!isset($input[2])) {
@@ -77,6 +83,9 @@ class FileParser
         return $output;
     }
 
+    /**
+     * @throws FileFormatException
+     */
     private function parseCsv(
         string $input,
         string $delimiter = ",",
@@ -90,6 +99,9 @@ class FileParser
 
         $parsed = array();
         while ($data = fgetcsv($tempFile, 0, $delimiter, $enclosure, $escape)) {
+            if (count($data) !== 4) {
+                throw new FileFormatException('Invalid field note: Row without 4 columns.');
+            }
             $parsed[] = $data;
         }
 

--- a/htdocs/src/Oc/FieldNotes/Import/ImportService.php
+++ b/htdocs/src/Oc/FieldNotes/Import/ImportService.php
@@ -64,6 +64,7 @@ class ImportService
     {
         $success = true;
         $errors = [];
+        $fieldNotes = null;
 
         try {
             $fieldNotes = $this->fileParser->parseFile($formData->file);


### PR DESCRIPTION
### 1. Why is this change necessary?

If you upload a non field note file, it crashes.

### 2. What does this change do, exactly?
* Check column count
* Fix some warnings

### 3. Describe each step to reproduce the issue or behaviour.
* Take README file and try to import it

### 4. Please link to the relevant issues (if any).

https://opencaching.atlassian.net/browse/RED-1252

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
