### PR TITLE
Add name to 'queries' query

### DIFF
--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -500,7 +500,7 @@ $bRememberQuery = isset($_REQUEST['skipqueryid']) ? !$_REQUEST['skipqueryid'] : 
 if ($bRememberQuery) {
     if ($queryid == 0 && $options['showresult'] != 0) { // 'showresult' = "execute query"
         sql(
-            "INSERT INTO `queries` (`user_id`, `options`, `last_queried`) VALUES (0, '&1', NOW())",
+            "INSERT INTO `queries` (`user_id`, `name`, `options`, `last_queried`) VALUES (0, '', '&1', NOW())",
             serialize($options)
         );
         $options['queryid'] = sql_insert_id();


### PR DESCRIPTION
### 1. Why is this change necessary?
Avoids: Error Code: 1364. Field 'name' doesn't have a default value

### 2. What does this change do, exactly?
Add name to 'queries' query

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
