### PR TITLE
fix chown/chgrp warnings

### DIFF
--- a/htdocs/config2/settings-sample-dev.inc.php
+++ b/htdocs/config2/settings-sample-dev.inc.php
@@ -14,8 +14,8 @@ if (defined('HTTPS_ENABLED')) {
 }
 
 $opt['debug'] = true;
-$opt['httpd']['user'] = getenv('DDEV_UID');
-$opt['httpd']['group'] = getenv('DDEV_GID');
+$opt['httpd']['user'] = getenv('DDEV_USER');
+$opt['httpd']['group'] = getenv('DDEV_USER');
 
 // show blog and forum news on index.php
 $debug_startpage_news = false;


### PR DESCRIPTION
### 1. Why is this change necessary?
Fix warnings during dev/init Script
`
Warning: chown(): Unable to find uid for 1000 in /var/www/html/htdocs/src/OcLegacy/Cache/WebCache.php on line 80
Warning: chgrp(): Unable to find gid for 1000 in /var/www/html/htdocs/src/OcLegacy/Cache/WebCache.php on line 81
`
