### PR TITLE
Extend unified coordinate input to search and new-cache pages

### DIFF
--- a/htdocs/editcache.php
+++ b/htdocs/editcache.php
@@ -261,14 +261,33 @@ if ($error == false) {
                     $name_not_ok = true;
                 }
 
-                if (isset($_POST['latNS'])) {
-                    //get coords from post-form
-                    $coords_latNS = $_POST['latNS'];  // Ocprop
-                    $coords_lonEW = $_POST['lonEW'];  // Ocprop
-                    $coords_lat_h = trim($_POST['lat_h']);  // Ocprop
-                    $coords_lon_h = trim($_POST['lon_h']);  // Ocprop
-                    $coords_lat_min = trim($_POST['lat_min']);  // Ocprop
-                    $coords_lon_min = trim($_POST['lon_min']);  // Ocprop
+                if (isset($_POST['lat_hem']) || isset($_POST['latNS'])) {
+                    //get coords from post-form (new field names from coordinate_input, old from Ocprop)
+                    $coords_latNS = $_POST['lat_hem'] ?? $_POST['latNS'];  // Ocprop
+                    $coords_lonEW = $_POST['lon_hem'] ?? $_POST['lonEW'];  // Ocprop
+                    $coords_lat_h = trim($_POST['lat_deg'] ?? $_POST['lat_h'] ?? '0');  // Ocprop
+                    $coords_lon_h = trim($_POST['lon_deg'] ?? $_POST['lon_h'] ?? '0');  // Ocprop
+                    $coords_lat_min = trim($_POST['lat_min'] ?? '00.000');  // Ocprop
+                    $coords_lon_min = trim($_POST['lon_min'] ?? '00.000');  // Ocprop
+
+                    // If unified input provided valid decimals, sync 6-field values from them
+                    $posted_lat = $_POST['latitude'] ?? '';
+                    $posted_lon = $_POST['longitude'] ?? '';
+                    if ($posted_lat !== '' && $posted_lon !== ''
+                        && is_numeric($posted_lat) && is_numeric($posted_lon)
+                        && ((float)$posted_lat != 0 || (float)$posted_lon != 0)
+                    ) {
+                        $coord_lat = (float)$posted_lat;
+                        $coord_lon = (float)$posted_lon;
+                        $coords_latNS = $coord_lat >= 0 ? 'N' : 'S';
+                        $coords_lonEW = $coord_lon >= 0 ? 'E' : 'W';
+                        $absLat = abs($coord_lat);
+                        $absLon = abs($coord_lon);
+                        $coords_lat_h = (string)floor($absLat);
+                        $coords_lat_min = sprintf('%02.3f', ($absLat - floor($absLat)) * 60);
+                        $coords_lon_h = (string)floor($absLon);
+                        $coords_lon_min = sprintf('%02.3f', ($absLon - floor($absLon)) * 60);
+                    }
                 } else {
                     //get coords from DB
                     $coords_lon = $cache_record['longitude'];
@@ -1108,6 +1127,18 @@ if ($error == false) {
                 tpl_set_var('lat_min', htmlspecialchars($coords_lat_min, ENT_COMPAT, 'UTF-8'));
                 tpl_set_var('lon_h', htmlspecialchars($coords_lon_h, ENT_COMPAT, 'UTF-8'));
                 tpl_set_var('lon_min', htmlspecialchars($coords_lon_min, ENT_COMPAT, 'UTF-8'));
+
+                // Compute decimal lat/lon for the unified coordinate input
+                $h_lat = (float)$coords_lat_h;
+                $m_lat = is_numeric($coords_lat_min) ? (float)$coords_lat_min : 0;
+                $h_lon = (float)$coords_lon_h;
+                $m_lon = is_numeric($coords_lon_min) ? (float)$coords_lon_min : 0;
+                $coord_lat = $h_lat + $m_lat / 60;
+                if ($coords_latNS == 'S') $coord_lat = -$coord_lat;
+                $coord_lon = $h_lon + $m_lon / 60;
+                if ($coords_lonEW == 'W') $coord_lon = -$coord_lon;
+                tpl_set_var('coord_latitude', $coord_lat);
+                tpl_set_var('coord_longitude', $coord_lon);
 
                 tpl_set_var('name_message', ($name_not_ok == true) ? $name_message : '');
                 tpl_set_var('lon_message', ($lon_not_ok == true) ? $coords_message : '');

--- a/htdocs/lang/de/ocstyle/editcache.tpl.php
+++ b/htdocs/lang/de/ocstyle/editcache.tpl.php
@@ -182,21 +182,52 @@ function toggleAttr(id)
     <tr>
         <td valign="top">{t}Coordinates:{/t}</td>
         <td>
-            <select name="latNS" onchange="setListingModified()" >
-                <option value="N"{selLatN}>{t}N{/t}</option>
-                <option value="S"{selLatS}>{t}S{/t}</option>
-            </select>
-            &nbsp;<input type="text" name="lat_h" maxlength="3" value="{lat_h}" class="input30" onchange="setListingModified()" />
-            °&nbsp;<input type="text" name="lat_min" maxlength="6" value="{lat_min}" class="input50" onchange="setListingModified()" />&nbsp;'&nbsp;
-            {lat_message}
-            &nbsp;&nbsp;
-            <select name="lonEW" onchange="setListingModified()" >
-                <option value="E"{selLonE}>{t}E{/t}</option>
-                <option value="W"{selLonW}>{t}W{/t}</option>
-            </select>
-            &nbsp;<input type="text" name="lon_h" maxlength="3" value="{lon_h}" class="input30" onchange="setListingModified()" />
-            °&nbsp;<input type="text" name="lon_min" maxlength="6" value="{lon_min}" class="input50" onchange="setListingModified()" />&nbsp;'&nbsp;
-            {lon_message}
+            <div id="coord_single" style="display:none">
+                <input type="text" id="coord_unified" size="35" placeholder="N00 00.000 E000 00.000"
+                    oninput="if(typeof setListingModified==='function')setListingModified()" />
+                <br />
+                <span id="coord_feedback"></span>
+            </div>
+            <div id="coord_detail">
+            <table>
+              <tr>
+                <td>
+                    <select name="lat_hem" onchange="setListingModified()">
+                        <option value="N"{selLatN}>{t}N{/t}</option>
+                        <option value="S"{selLatS}>{t}S{/t}</option>
+                    </select>
+                </td>
+                <td>
+                    <nobr><input type="text" name="lat_deg" maxlength="2" value="{lat_h}" class="input30" onchange="setListingModified()" /> &deg;</nobr>
+                </td>
+                <td>
+                    <nobr><input type="text" name="lat_min" maxlength="6" value="{lat_min}" class="input50" onchange="setListingModified()" /> '</nobr>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                    <select name="lon_hem" onchange="setListingModified()">
+                        <option value="E"{selLonE}>{t}E{/t}</option>
+                        <option value="W"{selLonW}>{t}W{/t}</option>
+                    </select>
+                </td>
+                <td>
+                    <nobr><input type="text" name="lon_deg" maxlength="3" value="{lon_h}" class="input30" onchange="setListingModified()" /> &deg;</nobr>
+                </td>
+                <td>
+                    <nobr><input type="text" name="lon_min" maxlength="6" value="{lon_min}" class="input50" onchange="setListingModified()" /> '</nobr>
+                </td>
+              </tr>
+            </table>
+            </div>
+            <input type="hidden" name="latitude" id="coord_lat" value="{coord_latitude}" />
+            <input type="hidden" name="longitude" id="coord_lon" value="{coord_longitude}" />
+            <a href="#" id="coord_toggle" style="display:none; font-size:11px"
+               data-label-6="{t}6 fields{/t}"
+               data-label-1="{t}1 field{/t}"
+               data-label-parse-error="{t}Could not parse coordinates{/t}"></a>
+            <script type="module" src="resource2/ocstyle/js/coord_input.js"></script>
+            {lat_message}{lon_message}
         </td>
     </tr>
     <tr><td class="spacer" colspan="2"></td></tr>

--- a/htdocs/newcache.php
+++ b/htdocs/newcache.php
@@ -2,1063 +2,1053 @@
 /***************************************************************************
  * for license information see LICENSE.md
  *  submit a new cache
- *  used template(s): newcache, viewcache, login
+ *  used template(s): newcache
  ***************************************************************************/
 
 use Oc\GeoCache\StatisticPicture;
 use OcLegacy\Editor\EditorConstants;
 
-require_once __DIR__ . '/lib/consts.inc.php';
-$opt['gui'] = GUI_HTML;
-require_once __DIR__ . '/lib/common.inc.php';
+require __DIR__ . '/lib2/web.inc.php';
 require_once __DIR__ . '/lib2/edithelper.inc.php';
 require_once __DIR__ . '/lib2/logic/attribute.class.php';
 
-$no_tpl_build = false;
+// lib2 equivalents of legacy globals
+$locale = $opt['template']['locale'];
+$oc_nodeid = $opt['logic']['node']['id'];
 
-//Preprocessing
-if (!$error) {
-    //must be logged in
-    if ($usr === false) {
-        $tplname = 'login';
+// t() translation helper — needed by newcache.inc.php (defined in lib/common.inc.php
+// for legacy pages; replicated here for lib2 pages)
+if (!function_exists('t')) {
+    function t($str)
+    {
+        global $translate;
+        $str = $translate->t($str, '', basename(__FILE__), __LINE__);
+        $args = func_get_args();
+        for ($nIndex = count($args) - 1; $nIndex > 0; $nIndex--) {
+            $str = str_replace('%' . $nIndex, $args[$nIndex], $str);
+        }
+        return $str;
+    }
+}
 
-        tpl_set_var('username', '');
-        tpl_set_var('target', 'newcache.php');
-        tpl_set_var('message_start', '');
-        tpl_set_var('message_end', '');
-        tpl_set_var('message', $login_required);
-        tpl_set_var('helplink', helppagelink('login'));
+// must be logged in
+if (!$login->logged_in()) {
+    $tpl->redirect('login.php?target=newcache.php');
+}
+
+$tpl->name = 'newcache';
+
+// load template-specific language variables
+$lang = strtolower($locale);
+$style = $opt['template']['style'];
+require_once __DIR__ . '/lang/' . $lang . '/' . $style . '/newcache.inc.php';
+
+// allow HTML input (XSS protection header)
+header('X-XSS-Protection: 0');
+
+$error = false;
+
+//set template replacements — default empty error messages
+$tpl->assign('reset', ''); // obsolete
+$tpl->assign('submit', $submit);
+$tpl->assign('general_error', '');
+$tpl->assign('hidden_since_message', '');
+$tpl->assign('activate_on_message', '');
+$tpl->assign('tos_message', '');
+$tpl->assign('name_message', '');
+$tpl->assign('desc_message', '');
+$tpl->assign('effort_message', '');
+$tpl->assign('size_message', '');
+$tpl->assign('wpgc_message', '');
+$tpl->assign('type_message', '');
+$tpl->assign('diff_message', '');
+$tpl->assign('safari_message', '');
+
+$sel_type = $_POST['type'] ?? 0; // Ocprop
+if (!isset($_POST['size'])) {
+    if ($sel_type == 4 || $sel_type == 5) {
+        $sel_size = 7;
     } else {
-        $errors = false; // set if there was any error
+        $sel_size = -1;
+    }
+} else {
+    $sel_size = $_POST['size'] ?? -1; // Ocprop
+}
+$sel_lang = $_POST['desc_lang'] ?? $default_lang;
+$sel_country = $_POST['country'] ?? $login->getUserCountry(); // Ocprop
+$show_all_countries = $_POST['show_all_countries'] ?? 0;
+$show_all_langs = $_POST['show_all_langs'] ?? 0;
 
-        //set here the template to process
-        $tplname = 'newcache';
-        require_once $stylepath . '/' . $tplname . '.inc.php';
-        tpl_acceptsAndPurifiesHtmlInput();
+//coords — read new field names (coordinate_input.tpl), fall back to old for OCProp
+$latNS = $_POST['lat_hem'] ?? $_POST['latNS'] ?? $default_NS; // Ocprop
+$lon_EW = $_POST['lon_hem'] ?? $_POST['lonEW'] ?? $default_EW; // Ocprop
+$lat_h = trim($_POST['lat_deg'] ?? $_POST['lat_h'] ?? '0'); // Ocprop
+$lon_h = trim($_POST['lon_deg'] ?? $_POST['lon_h'] ?? '0'); // Ocprop
+$lat_min = trim($_POST['lat_min'] ?? '00.000'); // Ocprop
+$lon_min = trim($_POST['lon_min'] ?? '00.000'); // Ocprop
 
-        //set template replacements
-        tpl_set_var('reset', $reset); // obsolete
-        tpl_set_var('submit', $submit);
-        tpl_set_var('general_message', '');
-        tpl_set_var('hidden_since_message', '');
-        tpl_set_var('activate_on_message', '');
-        tpl_set_var('lon_message', '');
-        tpl_set_var('lat_message', '&nbsp;&nbsp;');
-        tpl_set_var('tos_message', '');
-        tpl_set_var('name_message', '');
-        tpl_set_var('desc_message', '');
-        tpl_set_var('effort_message', '');
-        tpl_set_var('size_message', '');
-        tpl_set_var('wpgc_message', '');
-        tpl_set_var('type_message', '');
-        tpl_set_var('diff_message', '');
-        tpl_set_var('safari_message', '');
+// hidden fields from unified coordinate input
+$posted_latitude = $_POST['latitude'] ?? '';
+$posted_longitude = $_POST['longitude'] ?? '';
 
-        $sel_type = $_POST['type'] ?? 0; // Ocprop
-        if (!isset($_POST['size'])) {
-            if ($sel_type == 4 || $sel_type == 5) {
-                $sel_size = 7;
-            } else {
-                $sel_size = -1;
-            }
-        } else {
-            $sel_size = $_POST['size'] ?? -1; // Ocprop
-        }
-        $sel_lang = $_POST['desc_lang'] ?? $default_lang;
-        $sel_country = $_POST['country'] ?? getUserCountry(); // Ocprop
-        $show_all_countries = $_POST['show_all_countries'] ?? 0;
-        $show_all_langs = $_POST['show_all_langs'] ?? 0;
+// If unified input provided valid decimal coords, sync 6-field values from them
+if ($posted_latitude !== '' && $posted_longitude !== ''
+    && is_numeric($posted_latitude) && is_numeric($posted_longitude)
+    && ((float)$posted_latitude != 0 || (float)$posted_longitude != 0)
+) {
+    $coord_lat = (float)$posted_latitude;
+    $coord_lon = (float)$posted_longitude;
+    $latNS = $coord_lat >= 0 ? 'N' : 'S';
+    $lon_EW = $coord_lon >= 0 ? 'E' : 'W';
+    $absLat = abs($coord_lat);
+    $absLon = abs($coord_lon);
+    $lat_h = (string)floor($absLat);
+    $lat_min = sprintf('%02.3f', ($absLat - floor($absLat)) * 60);
+    $lon_h = (string)floor($absLon);
+    $lon_min = sprintf('%02.3f', ($absLon - floor($absLon)) * 60);
+} else {
+    // Compute decimal from 6-field values
+    $h_lat = (float)$lat_h;
+    $m_lat = is_numeric($lat_min) ? (float)$lat_min : 0;
+    $h_lon = (float)$lon_h;
+    $m_lon = is_numeric($lon_min) ? (float)$lon_min : 0;
+    $coord_lat = $h_lat + $m_lat / 60;
+    if ($latNS == 'S') {
+        $coord_lat = -$coord_lat;
+    }
+    $coord_lon = $h_lon + $m_lon / 60;
+    if ($lon_EW == 'W') {
+        $coord_lon = -$coord_lon;
+    }
+}
 
-        //coords
-        $lonEW = $_POST['lonEW'] ?? $default_EW; // Ocprop
-        if ($lonEW == 'E') {
-            tpl_set_var('lonEsel', ' selected="selected"');
-            tpl_set_var('lonWsel', '');
-        } else {
-            tpl_set_var('lonEsel', '');
-            tpl_set_var('lonWsel', ' selected="selected"');
-        }
-        $lon_h = trim($_POST['lon_h'] ?? '0'); // Ocprop
-        tpl_set_var('lon_h', htmlspecialchars($lon_h, ENT_COMPAT, 'UTF-8'));
+// Assign coordinate_input.tpl variables
+$tpl->assign('lat_hem', $latNS);
+$tpl->assign('lon_hem', $lon_EW);
+$tpl->assign('lat_deg', htmlspecialchars($lat_h, ENT_COMPAT, 'UTF-8'));
+$tpl->assign('lon_deg', htmlspecialchars($lon_h, ENT_COMPAT, 'UTF-8'));
+$tpl->assign('lat_min', htmlspecialchars($lat_min, ENT_COMPAT, 'UTF-8'));
+$tpl->assign('lon_min', htmlspecialchars($lon_min, ENT_COMPAT, 'UTF-8'));
+$tpl->assign('coord_latitude', $coord_lat);
+$tpl->assign('coord_longitude', $coord_lon);
 
-        $lon_min = trim($_POST['lon_min'] ?? '00.000'); // Ocprop
-        tpl_set_var('lon_min', htmlspecialchars($lon_min, ENT_COMPAT, 'UTF-8'));
+//name
+$name = trim($_POST['name'] ?? ''); // Ocprop
+$tpl->assign('name', htmlspecialchars($name, ENT_COMPAT, 'UTF-8'));
 
-        $latNS = $_POST['latNS'] ?? $default_NS; // Ocprop
-        if ($latNS == 'N') {
-            tpl_set_var('latNsel', ' selected="selected"');
-            tpl_set_var('latSsel', '');
-        } else {
-            tpl_set_var('latNsel', '');
-            tpl_set_var('latSsel', ' selected="selected"');
-        }
-        $lat_h = trim($_POST['lat_h'] ?? '0'); // Ocprop
-        tpl_set_var('lat_h', htmlspecialchars($lat_h, ENT_COMPAT, 'UTF-8'));
+//shortdesc
+$short_desc = trim($_POST['short_desc'] ?? '');
+$tpl->assign('short_desc', htmlspecialchars($short_desc, ENT_COMPAT, 'UTF-8'));
 
-        $lat_min = trim($_POST['lat_min'] ?? '00.000'); // Ocprop
-        tpl_set_var('lat_min', htmlspecialchars($lat_min, ENT_COMPAT, 'UTF-8'));
-
-        //name
-        $name = trim($_POST['name'] ?? ''); // Ocprop
-        tpl_set_var('name', htmlspecialchars($name, ENT_COMPAT, 'UTF-8'));
-
-        //shortdesc
-        $short_desc = trim($_POST['short_desc'] ?? '');
-        tpl_set_var('short_desc', htmlspecialchars($short_desc, ENT_COMPAT, 'UTF-8'));
-
-        // descMode auslesen, falls nicht gesetzt aus dem Profil laden
-        if (isset($_POST['descMode'])) {
-            // Ocprop
-            $descMode = (int) $_POST['descMode'];
-            if (($descMode < EditorConstants::HTML_MODE) || ($descMode > EditorConstants::EDITOR_MODE)) {
-                $descMode = EditorConstants::EDITOR_MODE;
-            }
-            if (isset($_POST['oldDescMode'])) {
-                $oldDescMode = (int) $_POST['oldDescMode'];
-                if (($oldDescMode < EditorConstants::HTML_MODE) || ($oldDescMode > EditorConstants::EDITOR_MODE)) {
-                    $oldDescMode = $descMode;
-                }
-            } else {
-                $oldDescMode = $descMode;
-            }
-        } else {
-            $descMode = EditorConstants::EDITOR_MODE;
+// descMode auslesen, falls nicht gesetzt aus dem Profil laden
+if (isset($_POST['descMode'])) {
+    // Ocprop
+    $descMode = (int) $_POST['descMode'];
+    if (($descMode < EditorConstants::HTML_MODE) || ($descMode > EditorConstants::EDITOR_MODE)) {
+        $descMode = EditorConstants::EDITOR_MODE;
+    }
+    if (isset($_POST['oldDescMode'])) {
+        $oldDescMode = (int) $_POST['oldDescMode'];
+        if (($oldDescMode < EditorConstants::HTML_MODE) || ($oldDescMode > EditorConstants::EDITOR_MODE)) {
             $oldDescMode = $descMode;
         }
-
-        // Text / normal HTML / HTML editor
-        tpl_set_var('use_tinymce', ($descMode == EditorConstants::EDITOR_MODE) ? 1 : 0);
-        tpl_set_var('descMode', $descMode);
-        tpl_set_var('htmlnotice', $descMode == EditorConstants::HTML_MODE ? $htmlnotice : '');
-
-        //desc
-        if (isset($_POST['desc'])) {
-            $desc = trim(processEditorInput($oldDescMode, $descMode, $_POST['desc'], $representDesc));
-        } else {
-            $desc = '';
-            $representDesc = '';
-        }
-
-        tpl_set_var('desc', htmlspecialchars($representDesc, ENT_COMPAT, 'UTF-8'));
-
-        $headers = tpl_get_var('htmlheaders') . "\n";
-        if ($descMode == EditorConstants::EDITOR_MODE) {
-            // TinyMCE
-            $headers .= '<script language="javascript" type="text/javascript" src="resource2/tinymce/tiny_mce_gzip.js"></script>' . "\n";
-            $headers .= '<script language="javascript" type="text/javascript" src="resource2/tinymce/config/desc.js.php?cacheid=0&lang=' . strtolower(
-                    $locale
-                ) . '"></script>' . "\n";
-        }
-        $headers .= '<script language="javascript" type="text/javascript" src="' . editorJsPath() .
-            '"></script>' . "\n";
-        tpl_set_var('htmlheaders', $headers);
-
-        //effort
-        $search_time = $_POST['search_time'] ?? 0;
-        $way_length = $_POST['way_length'] ?? 0;
-
-        $search_time = mb_ereg_replace(',', '.', $search_time);
-        $way_length = mb_ereg_replace(',', '.', $way_length);
-
-        if (mb_strpos($search_time, ':') == mb_strlen($search_time) - 3) {
-            $st_hours = mb_substr($search_time, 0, mb_strpos($search_time, ':'));
-            $st_minutes = mb_substr($search_time, mb_strlen($st_hours) + 1);
-
-            if (is_numeric($st_hours) && is_numeric($st_minutes)) {
-                if (($st_minutes >= 0) && ($st_minutes < 60)) {
-                    $search_time = $st_hours + $st_minutes / 60;
-                }
-            }
-        }
-
-        $st_hours = floor((float)$search_time);
-        $st_minutes = sprintf('%02.0F', ((float)$search_time - $st_hours) * 60);
-
-        tpl_set_var('search_time', $st_hours . ':' . $st_minutes);
-        tpl_set_var('way_length', $way_length);
-
-
-        //hints
-        $hints = trim($_POST['hints'] ?? '');
-        tpl_set_var('hints', htmlspecialchars($hints, ENT_COMPAT, 'UTF-8'));
-
-        // fuer alte Versionen von OCProp
-        if (isset($_POST['submit']) && !isset($_POST['version2'])) {
-            $hints = iconv("ISO-8859-1", "UTF-8", $hints);
-        }
-
-        //tos
-        $tos = isset($_POST['TOS']) ? 1 : 0; // Ocprop
-        if ($tos === 1) {
-            tpl_set_var('toschecked', ' checked="checked"');
-        } else {
-            tpl_set_var('toschecked', '');
-        }
-
-        //hidden_since
-        $hidden_day = $_POST['hidden_day'] ?? date('d'); // Ocprop
-        $hidden_month = $_POST['hidden_month'] ?? date('m'); // Ocprop
-        $hidden_year = $_POST['hidden_year'] ?? date('Y'); // Ocprop
-        tpl_set_var('hidden_day', htmlspecialchars($hidden_day, ENT_COMPAT, 'UTF-8'));
-        tpl_set_var('hidden_month', htmlspecialchars($hidden_month, ENT_COMPAT, 'UTF-8'));
-        tpl_set_var('hidden_year', htmlspecialchars($hidden_year, ENT_COMPAT, 'UTF-8'));
-
-        //activation date
-        $activate_day = $_POST['activate_day'] ?? date('d');
-        $activate_month = $_POST['activate_month'] ?? date('m');
-        $activate_year = $_POST['activate_year'] ?? date('Y');
-        tpl_set_var('activate_day', htmlspecialchars($activate_day, ENT_COMPAT, 'UTF-8'));
-        tpl_set_var('activate_month', htmlspecialchars($activate_month, ENT_COMPAT, 'UTF-8'));
-        tpl_set_var('activate_year', htmlspecialchars($activate_year, ENT_COMPAT, 'UTF-8'));
-
-        tpl_set_var('publish_now_checked', '');
-        tpl_set_var('publish_later_checked', '');
-        tpl_set_var('publish_notnow_checked', '');
-
-        $publish = $_POST['publish'] ?? 'notnow'; // Ocprop
-        if ($publish == 'now2') {
-            tpl_set_var('publish_now_checked', 'checked');
-        } elseif ($publish == 'later') {
-            tpl_set_var('publish_later_checked', 'checked');
-        } else { // notnow
-            $publish = 'notnow';
-            tpl_set_var('publish_notnow_checked', 'checked');
-        }
-
-        // fill activate hours
-        $activate_hour = (int)($_POST['activate_hour'] ?? date('H'));
-        $activation_hours = '';
-        for ($i = 0; $i <= 23; $i++) {
-            if ($activate_hour === $i) {
-                $activation_hours .= '<option value="' . $i . '" selected="selected">' . $i . '</option>';
-            } else {
-                $activation_hours .= '<option value="' . $i . '">' . $i . '</option>';
-            }
-            $activation_hours .= "\n";
-        }
-        tpl_set_var('activation_hours', $activation_hours);
-
-        //log-password
-        $log_pw = isset($_POST['log_pw']) ? mb_substr(trim($_POST['log_pw']), 0, 20) : '';
-        tpl_set_var('log_pw', htmlspecialchars($log_pw, ENT_COMPAT, 'UTF-8'));
-
-        // gc- and nc-waypoints
-        // fix #4356: gc waypoints are frequently copy&pasted with leading spaces
-        $wp_gc = isset($_POST['wp_gc']) ? strtoupper(trim($_POST['wp_gc'])) : ''; // Ocprop
-        tpl_set_var('wp_gc', htmlspecialchars($wp_gc, ENT_COMPAT, 'UTF-8'));
-
-        //difficulty
-        $difficulty = $_POST['difficulty'] ?? 1; // Ocprop
-        $difficulty_options = '<option value="1">' . $sel_message . '</option>';
-        for ($i = 2; $i <= 10; $i++) {
-            if ($difficulty == $i) {
-                $difficulty_options .= '<option value="' . $i . '" selected="selected">' . $i / 2 . '</option>';
-            } else {
-                $difficulty_options .= '<option value="' . $i . '">' . $i / 2 . '</option>';
-            }
-            $difficulty_options .= "\n";
-        }
-        tpl_set_var('difficulty_options', $difficulty_options);
-
-        //terrain
-        $terrain = $_POST['terrain'] ?? 1; // Ocprop
-        $terrain_options = '<option value="1">' . $sel_message . '</option>';
-        for ($i = 2; $i <= 10; $i++) {
-            if ($terrain == $i) {
-                $terrain_options .= '<option value="' . $i . '" selected="selected">' . $i / 2 . '</option>';
-            } else {
-                $terrain_options .= '<option value="' . $i . '">' . $i / 2 . '</option>';
-            }
-            $terrain_options .= "\n";
-        }
-        tpl_set_var('terrain_options', $terrain_options);
-
-        //sizeoptions
-        $sSelected = ($sel_size == -1) ? ' selected="selected"' : '';
-        $sizes = '<option value="-1"' . $sSelected . '>' .
-            htmlspecialchars(
-                t('Please select!'),
-                ENT_COMPAT,
-                'UTF-8'
-            ) . '</option>';
-        $rsSizes = sql(
-            "SELECT `cache_size`.`id`,
-                    IFNULL(`sys_trans_text`.`text`,
-                    `cache_size`.`name`) AS `name`
-             FROM `cache_size`
-             LEFT JOIN `sys_trans`
-               ON `cache_size`.`trans_id`=`sys_trans`.`id`
-             LEFT JOIN `sys_trans_text`
-               ON `sys_trans`.`id`=`sys_trans_text`.`trans_id`
-               AND `sys_trans_text`.`lang`='" . sql_escape($locale) . "'
-             ORDER BY `cache_size`.`ordinal` ASC"
-        );
-        while ($rSize = sql_fetch_assoc($rsSizes)) {
-            $sSelected = ($rSize['id'] == $sel_size) ? ' selected="selected"' : '';
-            $sizes .= '<option value="' . $rSize['id'] . '"' . $sSelected . '>' .
-                htmlspecialchars(
-                    $rSize['name'],
-                    ENT_COMPAT,
-                    'UTF-8'
-                ) . '</option>';
-        }
-        sql_free_result($rsSizes);
-        tpl_set_var('sizeoptions', $sizes);
-
-        //typeoptions
-        $sSelected = ($sel_type == -1) ? ' selected="selected"' : '';
-        $types = '<option value="-1"' . $sSelected . '>' .
-            htmlspecialchars(
-                t('Please select!'),
-                ENT_COMPAT,
-                'UTF-8'
-            ) . '</option>';
-        $rsTypes = sql(
-            "SELECT `cache_type`.`id`,
-                    IFNULL(`sys_trans_text`.`text`,
-                    `cache_type`.`en`) AS `name`
-             FROM `cache_type`
-             LEFT JOIN `sys_trans`
-               ON `cache_type`.`trans_id`=`sys_trans`.`id`
-             LEFT JOIN `sys_trans_text`
-               ON `sys_trans`.`id`=`sys_trans_text`.`trans_id`
-               AND `sys_trans_text`.`lang`='" . sql_escape($locale) . "'
-             ORDER BY `cache_type`.`ordinal` ASC"
-        );
-        while ($rType = sql_fetch_assoc($rsTypes)) {
-            $sSelected = ($rType['id'] == $sel_type) ? ' selected="selected"' : '';
-            $types .= '<option value="' . $rType['id'] . '"' . $sSelected . '>' .
-                htmlspecialchars(
-                    $rType['name'],
-                    ENT_COMPAT,
-                    'UTF-8'
-                ) . '</option>';
-        }
-        sql_free_result($rsTypes);
-        tpl_set_var('typeoptions', $types);
-
-        if (isset($_POST['show_all_countries_submit'])) {
-            $show_all_countries = 1;
-        } elseif (isset($_POST['show_all_langs_submit'])) {
-            $show_all_langs = 1;
-        }
-
-        $langsoptions = '';
-
-        //check if selected country is in list_default
-        if ($show_all_langs == 0) {
-            $rs = sql(
-                "SELECT `show` FROM `languages_list_default` WHERE `show`='&1' AND `lang`='&2'",
-                $sel_lang,
-                $locale
-            );
-            if (mysqli_num_rows($rs) == 0) {
-                $show_all_langs = 1;
-            }
-            sql_free_result($rs);
-        }
-
-        if ($show_all_langs == 0) {
-            tpl_set_var('show_all_langs', '0');
-            tpl_set_var(
-                'show_all_langs_submit',
-                '<input type="submit" name="show_all_langs_submit" value="' . $show_all . '"/>'
-            );
-
-            $rs = sql(
-                "SELECT `languages`.`short`,
-                        IFNULL(`sys_trans_text`.`text`,
-                        `languages`.`name`) AS `name`
-                 FROM `languages`
-                 INNER JOIN `languages_list_default`
-                   ON `languages`.`short`=`languages_list_default`.`show`
-                 LEFT JOIN `sys_trans`
-                   ON `languages`.`trans_id`=`sys_trans`.`id`
-                 LEFT JOIN `sys_trans_text`
-                   ON `sys_trans`.`id`=`sys_trans_text`.`trans_id`
-                   AND `sys_trans_text`.`lang`='&1'
-                 WHERE `languages_list_default`.`lang`='&1' ORDER BY `name` ASC",
-                $locale
-            );
-        } else {
-            tpl_set_var('show_all_langs', '1');
-            tpl_set_var('show_all_langs_submit', '');
-
-            $rs = sql(
-                "SELECT `languages`.`short`,
-                 IFNULL(`sys_trans_text`.`text`, `languages`.`name`) AS `name`
-                 FROM `languages`
-                 LEFT JOIN `sys_trans`
-                   ON `languages`.`trans_id`=`sys_trans`.`id`
-                 LEFT JOIN `sys_trans_text`
-                   ON `sys_trans`.`id`=`sys_trans_text`.`trans_id`
-                   AND `sys_trans_text`.`lang`='&1'
-                 ORDER BY `name` ASC",
-                $locale
-            );
-        }
-
-        while ($record = sql_fetch_assoc($rs)) {
-            $sSelected = ($record['short'] == $sel_lang) ? ' selected="selected"' : '';
-            $langsoptions .= '<option value="' .
-                htmlspecialchars(
-                    $record['short'],
-                    ENT_COMPAT,
-                    'UTF-8'
-                ) . '"' . $sSelected . '>' .
-                htmlspecialchars(
-                    $record['name'],
-                    ENT_COMPAT,
-                    'UTF-8'
-                ) . '</option>' . "\n";
-        }
-
-        tpl_set_var('langoptions', $langsoptions);
-
-        //countryoptions
-        $countriesoptions = '';
-
-        //check if selected country is in list_default
-        if ($show_all_countries == 0) {
-            $rs = sql(
-                "SELECT `show` FROM `countries_list_default` WHERE `show`='&1' AND `lang`='&2'",
-                $sel_country,
-                $locale
-            );
-            if (mysqli_num_rows($rs) == 0) {
-                $show_all_countries = 1;
-            }
-            sql_free_result($rs);
-        }
-
-        if ($show_all_countries == 0) {
-            tpl_set_var('show_all_countries', '0');
-            tpl_set_var(
-                'show_all_countries_submit',
-                '<input type="submit" id="showallcountries" class="formbutton" name="show_all_countries_submit" value="' . $show_all . '" onclick="submitbutton(\'showallcountries\')" />'
-            );
-
-            $rs = sql(
-                "SELECT `countries`.`short`,
-                        IFNULL(`sys_trans_text`.`text`,
-                        `countries`.`name`) AS `name`
-                 FROM `countries`
-                 INNER JOIN `countries_list_default`
-                   ON `countries_list_default`.`show`=`countries`.`short`
-                 LEFT JOIN `sys_trans`
-                   ON `countries`.`trans_id`=`sys_trans`.`id`
-                 LEFT JOIN `sys_trans_text`
-                   ON `sys_trans`.`id`=`sys_trans_text`.`trans_id`
-                   AND `sys_trans_text`.`lang`='&1'
-                 WHERE `countries_list_default`.`lang`='&1'
-                 ORDER BY `name` ASC",
-                $locale
-            );
-        } else {
-            tpl_set_var('show_all_countries', '1');
-            tpl_set_var('show_all_countries_submit', '');
-
-            $rs = sql(
-                "SELECT `countries`.`short`,
-                        IFNULL(`sys_trans_text`.`text`,
-                        `countries`.`name`) AS `name`
-                 FROM `countries`
-                 LEFT JOIN `sys_trans`
-                   ON `countries`.`trans_id`=`sys_trans`.`id`
-                 LEFT JOIN `sys_trans_text`
-                   ON `sys_trans`.`id`=`sys_trans_text`.`trans_id`
-                   AND `sys_trans_text`.`lang`='&1'
-                ORDER BY `name` ASC",
-                $locale
-            );
-        }
-
-        // $opt['locale'][$locale]['country'] would give country of chosen langugage
-        // build the "country" dropdown list, preselect $sel_country
-        while ($record = sql_fetch_array($rs)) {
-            $sSelected = ($record['short'] == $sel_country) ? ' selected="selected"' : '';
-            $countriesoptions .= '<option value="' .
-                htmlspecialchars(
-                    $record['short'],
-                    ENT_COMPAT,
-                    'UTF-8'
-                ) . '"' . $sSelected . '>' .
-                htmlspecialchars(
-                    $record['name'],
-                    ENT_COMPAT,
-                    'UTF-8'
-                ) . '</option>' . "\n";
-        }
-        sql_free_result($rs);
-
-        tpl_set_var('countryoptions', $countriesoptions);
-
-        // cache-attributes
-        $cache_attribs = isset($_POST['cache_attribs']) ? mb_split(';', $_POST['cache_attribs']) : [];
-
-        // cache-attributes
-        $bBeginLine = true;
-        $nPrevLineAttrCount = 0;
-        $nLineAttrCount = 0;
-
-        $cache_attrib_list = '';
-        $cache_attrib_array = '';
-        $cache_attribs_string = '';
-
-        $rsAttrGroup = sql(
-            "SELECT `attribute_groups`.`id`,
-                    IFNULL(`sys_trans_text`.`text`,
-                    `attribute_groups`.`name`) AS `name`,
-                    `attribute_categories`.`color`
-             FROM `attribute_groups`
-             INNER JOIN `attribute_categories`
-               ON `attribute_groups`.`category_id`=`attribute_categories`.`id`
-             LEFT JOIN `sys_trans`
-               ON `attribute_groups`.`trans_id`=`sys_trans`.`id`
-             LEFT JOIN `sys_trans_text`
-               ON `sys_trans`.`id`=`sys_trans_text`.`trans_id`
-               AND `sys_trans_text`.`lang`='&1'
-             ORDER BY `attribute_groups`.`category_id` ASC, `attribute_groups`.`id` ASC",
-            $locale
-        );
-        while ($rAttrGroup = sql_fetch_assoc($rsAttrGroup)) {
-            $group_line = '';
-
-            $rs = sql(
-                "SELECT `cache_attrib`.`id`,
-                        IFNULL(`ttname`.`text`,`cache_attrib`.`name`) AS `name`,
-                        `cache_attrib`.`icon_undef`,
-                        `cache_attrib`.`icon_large`,
-                        IFNULL(`ttdesc`.`text`, `cache_attrib`.`html_desc`) AS `html_desc`
-                 FROM `cache_attrib`
-                 LEFT JOIN `sys_trans` AS `tname`
-                   ON `cache_attrib`.`trans_id`=`tname`.`id`
-                   AND `cache_attrib`.`name`=`tname`.`text`
-                 LEFT JOIN `sys_trans_text` AS `ttname`
-                   ON `tname`.`id`=`ttname`.`trans_id`
-                   AND `ttname`.`lang`='&1'
-                 LEFT JOIN `sys_trans` AS `tdesc`
-                   ON `cache_attrib`.`html_desc_trans_id`=`tdesc`.`id`
-                   AND `cache_attrib`.`html_desc`=`tdesc`.`text`
-                 LEFT JOIN `sys_trans_text` AS `ttdesc`
-                   ON `tdesc`.`id`=`ttdesc`.`trans_id`
-                   AND `ttdesc`.`lang`='&1'
-                 WHERE `cache_attrib`.`group_id`=" . ((int)$rAttrGroup['id']) . '
-                 AND NOT IFNULL(`cache_attrib`.`hidden`, 0) = 1
-                 AND `cache_attrib`.`selectable` != 0
-                 ORDER BY `cache_attrib`.`group_id`, `cache_attrib`.`id`',
-                $locale
-            );
-            while ($record = sql_fetch_array($rs)) {
-                $line = $cache_attrib_pic;
-
-                $line = mb_ereg_replace('{attrib_id}', $record['id'], $line);
-                $line = mb_ereg_replace('{attrib_text}', escape_javascript($record['name']), $line);
-                if (in_array($record['id'], $cache_attribs)) {
-                    $line = mb_ereg_replace('{attrib_pic}', $record['icon_large'], $line);
-                } else {
-                    $line = mb_ereg_replace('{attrib_pic}', $record['icon_undef'], $line);
-                }
-                $line = mb_ereg_replace('{html_desc}', escape_javascript($record['html_desc']), $line);
-                $line = mb_ereg_replace('{name}', escape_javascript($record['name']), $line);
-                $line = mb_ereg_replace('{color}', $rAttrGroup['color'], $line);
-                $group_line .= $line;
-                $nLineAttrCount++;
-
-                $line = $cache_attrib_js;
-                $line = mb_ereg_replace('{id}', $record['id'], $line);
-                if (in_array($record['id'], $cache_attribs)) {
-                    $line = mb_ereg_replace('{selected}', 1, $line);
-                } else {
-                    $line = mb_ereg_replace('{selected}', 0, $line);
-                }
-                $line = mb_ereg_replace('{img_undef}', $record['icon_undef'], $line);
-                $line = mb_ereg_replace('{img_large}', $record['icon_large'], $line);
-                $line = mb_ereg_replace(
-                    '{conflicting_attribs}',
-                    implode(',', OcLib2\attribute::getConflictingAttribIds($record['id'])),
-                    $line
-                );
-                if ($cache_attrib_array != '') {
-                    $cache_attrib_array .= ',';
-                }
-                $cache_attrib_array .= $line;
-
-                if (in_array($record['id'], $cache_attribs)) {
-                    if ($cache_attribs_string != '') {
-                        $cache_attribs_string .= ';';
-                    }
-                    $cache_attribs_string .= $record['id'];
-                }
-            }
-            sql_free_result($rs);
-
-            if ($group_line != '') {
-                $group_img = $cache_attrib_group;
-                $group_img = mb_ereg_replace('{color}', $rAttrGroup['color'], $group_img);
-                $group_img = mb_ereg_replace('{attribs}', $group_line, $group_img);
-                $group_img = mb_ereg_replace(
-                    '{name}',
-                    htmlspecialchars(
-                        $rAttrGroup['name'],
-                        ENT_COMPAT,
-                        'UTF-8'
-                    ),
-                    $group_img
-                );
-
-                if ($bBeginLine) {
-                    $cache_attrib_list .= '<div class="attribswide">';
-                    $bBeginLine = false;
-                }
-
-                $cache_attrib_list .= $group_img;
-                $nPrevLineAttrCount += $nLineAttrCount;
-
-                $nLineAttrCount = 0;
-            }
-        }
-        sql_free_result($rsAttrGroup);
-        if (!$bBeginLine) {
-            $cache_attrib_list .= '</div>';
-        }
-
-        tpl_set_var('cache_attrib_list', $cache_attrib_list);
-        tpl_set_var('jsattributes_array', $cache_attrib_array);
-        tpl_set_var('cache_attribs', $cache_attribs_string);
-
-        tpl_set_var('firstcache_note', mb_ereg_replace('%1', $opt['page']['sitename'], $firstcache_note));
-
-        if (isset($_POST['submitform'])) {  // Ocprop
-            // check the entered data
-
-            // check coordinates
-            if ($lat_h != '' || $lat_min != '') {
-                if (!mb_ereg_match('^[0-9]{1,3}$', $lat_h)) {
-                    tpl_set_var('lat_message', $error_lat_not_ok);
-                    $error = true;
-                    $lat_h_not_ok = true;
-                } else {
-                    if (($lat_h >= 0) && ($lat_h < 90)) {
-                        $lat_h_not_ok = false;
-                    } else {
-                        tpl_set_var('lat_message', $error_lat_not_ok);
-                        $error = true;
-                        $lat_h_not_ok = true;
-                    }
-                }
-
-                if (is_numeric($lat_min)) {
-                    if (($lat_min >= 0) && ($lat_min < 60)) {
-                        $lat_min_not_ok = false;
-                    } else {
-                        tpl_set_var('lat_message', $error_lat_not_ok);
-                        $error = true;
-                        $lat_min_not_ok = true;
-                    }
-                } else {
-                    tpl_set_var('lat_message', $error_lat_not_ok);
-                    $error = true;
-                    $lat_min_not_ok = true;
-                }
-
-                $latitude = $lat_h + $lat_min / 60;
-                if ($latNS == 'S') {
-                    $latitude = -$latitude;
-                }
-
-                if ($latitude == 0) {
-                    tpl_set_var('lat_message', $error_lat_not_ok);
-                    $error = true;
-                    $lat_min_not_ok = true;
-                }
-            } else {
-                tpl_set_var('lat_message', $error_lat_not_ok);
-                $lat_h_not_ok = true;
-                $lat_min_not_ok = true;
-            }
-
-            if ($lon_h != '' || $lon_min != '') {
-                if (!mb_ereg_match('^[0-9]{1,3}$', $lon_h)) {
-                    tpl_set_var('lon_message', $error_long_not_ok);
-                    $error = true;
-                    $lon_h_not_ok = true;
-                } else {
-                    if (($lon_h >= 0) && ($lon_h < 180)) {
-                        $lon_h_not_ok = false;
-                    } else {
-                        tpl_set_var('lon_message', $error_long_not_ok);
-                        $error = true;
-                        $lon_h_not_ok = true;
-                    }
-                }
-
-                if (is_numeric($lon_min)) {
-                    if (($lon_min >= 0) && ($lon_min < 60)) {
-                        $lon_min_not_ok = false;
-                    } else {
-                        tpl_set_var('lon_message', $error_long_not_ok);
-                        $error = true;
-                        $lon_min_not_ok = true;
-                    }
-                } else {
-                    tpl_set_var('lon_message', $error_long_not_ok);
-                    $error = true;
-                    $lon_min_not_ok = true;
-                }
-
-                $longitude = $lon_h + $lon_min / 60;
-                if ($lonEW == 'W') {
-                    $longitude = -$longitude;
-                }
-
-                if ($longitude == 0) {
-                    tpl_set_var('lon_message', $error_long_not_ok);
-                    $error = true;
-                    $lon_min_not_ok = true;
-                }
-            } else {
-                tpl_set_var('lon_message', $error_long_not_ok);
-                $lon_h_not_ok = true;
-                $lon_min_not_ok = true;
-            }
-
-            $lon_not_ok = $lon_min_not_ok || $lon_h_not_ok;
-            $lat_not_ok = $lat_min_not_ok || $lat_h_not_ok;
-
-            // check for duplicate coords
-            if (!($lon_not_ok || $lat_not_ok)) {
-                $duplicate_wpoc =
-                    sqlValue(
-                        "SELECT MIN(wp_oc)
-                         FROM `caches`
-                         WHERE `status`=1
-                         AND ROUND(`longitude`,6)=ROUND('" . sql_escape($longitude) . "',6)
-                         AND ROUND(`latitude`,6)=ROUND('" . sql_escape($latitude) . "',6)",
-                        null
-                    );
-                if ($duplicate_wpoc) {
-                    tpl_set_var('lon_message', mb_ereg_replace('%1', $duplicate_wpoc, $error_duplicate_coords));
-                    $lon_not_ok = true;
-                }
-            }
-
-            //check effort
-            $time_not_ok = true;
-            if (is_numeric($search_time) || ($search_time == '')) {
-                $time_not_ok = false;
-            }
-            if ($time_not_ok) {
-                tpl_set_var('effort_message', $time_not_ok_message);
-                $error = true;
-            }
-            $way_length_not_ok = true;
-            if (is_numeric($way_length) || ($search_time == '')) {
-                $way_length_not_ok = false;
-            }
-            if ($way_length_not_ok) {
-                tpl_set_var('effort_message', $way_length_not_ok_message);
-                $error = true;
-            }
-
-            //check hidden_since
-            $hidden_date_not_ok = true;
-            if (is_numeric($hidden_day) && is_numeric($hidden_month) && is_numeric($hidden_year)) {
-                $hidden_date_not_ok = (checkdate($hidden_month, $hidden_day, $hidden_year) == false);
-            }
-            if ($hidden_date_not_ok) {
-                tpl_set_var('hidden_since_message', $date_not_ok_message);
-                $error = true;
-            } else if ($publish != 'notnow') {
-                $hidden_date = mktime(0, 0, 0, $hidden_month, $hidden_day, $hidden_year);
-                if ($publish == 'later') {
-                    // Activation hour can be ignored here. This simplifies checking event dates.
-                    $publish_date = mktime(0, 0, 0, $activate_month, $activate_day, $activate_year);
-                } else {
-                    $publish_date = time();
-                }
-                if ($sel_type == 6 && $hidden_date < $publish_date) {
-                    tpl_set_var('hidden_since_message', $event_before_publish_message);
-                    $hidden_date_not_ok = true;
-                    $error = true;
-                } elseif ($sel_type != 6 && $hidden_date > $publish_date) {
-                    tpl_set_var('hidden_since_message', $hide_after_publish_message);
-                    $hidden_date_not_ok = true;
-                    $error = true;
-                }
-            }
-
-            //check GC waypoint
-            $wpgc_not_ok = $wp_gc != "" && !preg_match("/^(?:GC|CX)[0-9A-Z]{3,6}$/", $wp_gc);
-            if ($wpgc_not_ok) {
-                tpl_set_var('wpgc_message', $bad_wpgc_message);
-                $error = true;
-            }
-
-            //check date_activate
-            $activation_date_not_ok = true;
-            if (is_numeric($activate_day)
-                && is_numeric($activate_month)
-                && is_numeric($activate_year)
-                && is_numeric($activate_hour)
-            ) {
-                $activation_date_not_ok = ((checkdate($activate_month, $activate_day, $activate_year) == false)
-                    || $activate_hour < 0 || $activate_hour > 23);
-            }
-            if (!$activation_date_not_ok) {
-                if (!($publish == 'now2' || $publish == 'later' || $publish == 'notnow')) {
-                    $activation_date_not_ok = true;
-                }
-            }
-            if ($activation_date_not_ok) {
-                tpl_set_var('activate_on_message', $date_not_ok_message);
-                $error = true;
-            }
-
-            //name
-            if ($name == '') {
-                tpl_set_var('name_message', $name_not_ok_message);
-                $error = true;
-                $name_not_ok = true;
-            } else {
-                $name_not_ok = false;
-            }
-
-            //tos
-            if ($tos != 1) {
-                tpl_set_var('tos_message', $tos_not_ok_message);
-                $error = true;
-                $tos_not_ok = true;
-            } else {
-                $tos_not_ok = false;
-            }
-
-            //cache-size
-            $size_not_ok = false;
-            if ($sel_size == -1) {
-                tpl_set_var('size_message', $size_not_ok_message);
-                $error = true;
-                $size_not_ok = true;
-            }
-
-            //cache-type
-            $type_not_ok = false;
-            if ($sel_type == -1) {
-                tpl_set_var('type_message', $type_not_ok_message);
-                $error = true;
-                $type_not_ok = true;
-            }
-
-            if ($sel_size != 7 && ($sel_type == 4 || $sel_type == 5)) {
-                if (!$size_not_ok) {
-                    tpl_set_var('size_message', $sizemismatch_message);
-                }
-                $error = true;
-                $size_not_ok = true;
-            }
-
-            //difficulty / terrain
-            $diff_not_ok = false;
-            if ($difficulty < 2 || $difficulty > 10 || $terrain < 2 || $terrain > 10) {
-                tpl_set_var('diff_message', $diff_not_ok_message);
-                $error = true;
-                $diff_not_ok = true;
-            }
-
-            // attributes
-            $attribs_not_ok = false;
-            if (in_array(ATTRIB_ID_SAFARI, $cache_attribs) && $sel_type != 4) {
-                tpl_set_var('safari_message', $safari_not_allowed_message);
-                $error = true;
-                $attribs_not_ok = true;
-            } else {
-                tpl_set_var('safari_message', '');
-            }
-
-            //no errors?
-            if (!($tos_not_ok
-                || $name_not_ok
-                || $hidden_date_not_ok
-                || $activation_date_not_ok
-                || $lon_not_ok
-                || $lat_not_ok
-                || $time_not_ok
-                || $way_length_not_ok
-                || $size_not_ok
-                || $type_not_ok
-                || $diff_not_ok
-                || $attribs_not_ok
-                || $wpgc_not_ok)
-            ) {
-                //sel_status
-                $now = getdate();
-                $today = mktime(0, 0, 0, $now['mon'], $now['mday'], $now['year']);
-                $hidden_date = mktime(0, 0, 0, $hidden_month, $hidden_day, $hidden_year);
-
-                $sel_status = 1; //available
-                if (($hidden_date > $today) && ($sel_type != 6)) {
-                    $sel_status = 2; //currently not available
-                }
-
-                if ($publish == 'now2') {
-                    $activation_date = 'NULL';
-                    $activation_column = ' ';
-                } elseif ($publish == 'later') {
-                    $sel_status = 5;
-                    $activation_date =
-                        "'" . date(
-                            'Y-m-d H:i:s',
-                            mktime(
-                                $activate_hour,
-                                0,
-                                0,
-                                $activate_month,
-                                $activate_day,
-                                $activate_year
-                            )
-                        ) . "'";
-                } elseif ($publish == 'notnow') {
-                    $sel_status = 5;
-                    $activation_date = 'NULL';
-                } else {
-                    // should never happen
-                    $activation_date = 'NULL';
-                }
-
-                //add record to caches table
-                sql(
-                    "INSERT INTO `caches` (
-                        `cache_id`,
-                        `user_id`,
-                        `name`,
-                        `longitude`,
-                        `latitude`,
-                        `type` ,
-                        `status` ,
-                        `country` ,
-                        `date_hidden` ,
-                        `date_activate` ,
-                        `size` ,
-                        `difficulty` ,
-                        `terrain`,
-                        `logpw`,
-                        `search_time`,
-                        `way_length`,
-                        `wp_gc`,
-                        `node`
-                    ) VALUES (
-                        '',
-                        '&1',
-                        '&2',
-                        '&3',
-                        '&4',
-                        '&5',
-                        '&6',
-                        '&7',
-                        '&8',
-                        $activation_date,
-                        '&9',
-                        '&10',
-                        '&11',
-                        '&12',
-                        '&13',
-                        '&14',
-                        '&15',
-                        '&16'
-                        )",
-                    $usr['userid'],
-                    $name,
-                    $longitude,
-                    $latitude,
-                    $sel_type,
-                    $sel_status,
-                    $sel_country,
-                    date('Y-m-d', $hidden_date),
-                    $sel_size,
-                    $difficulty,
-                    $terrain,
-                    $log_pw,
-                    $search_time,
-                    $way_length,
-                    $wp_gc,
-                    $oc_nodeid
-                );
-                $cache_id = mysqli_insert_id($dblink);
-
-                //add record to cache_desc table
-                sql(
-                    "INSERT INTO `cache_desc` (
-                        `id`,
-                        `cache_id`,
-                        `language`,
-                        `desc`,
-                        `desc_html`,
-                        `hint`,
-                        `short_desc`,
-                        `last_modified`,
-                        `desc_htmledit`,
-                        `node`
-                    ) VALUES (
-                        '',
-                        '&1',
-                        '&2',
-                        '&3',
-                        '&4',
-                        '&5',
-                        '&6',
-                        NOW(),
-                        '&7',
-                        '&8'
-                    )",
-                    $cache_id,
-                    $sel_lang,
-                    $desc,
-                    1,
-                    nl2br(htmlspecialchars($hints, ENT_COMPAT, 'UTF-8')),
-                    $short_desc,
-                    ($descMode == EditorConstants::EDITOR_MODE) ? 1 : 0,
-                    $oc_nodeid
-                );
-
-                $acheAttributesCount = count($cache_attribs);
-                // insert cache-attributes
-                for ($i = 0; $i < $acheAttributesCount; $i++) {
-                    if (((int)$cache_attribs[$i]) > 0) {
-                        sql(
-                            "INSERT INTO `caches_attributes` (
-                                 `cache_id`,
-                                 `attrib_id`
-                             ) VALUES (
-                                 '&1',
-                                 '&2'
-                             )",
-                            $cache_id,
-                            (int)$cache_attribs[$i]
-                        );
-                    }
-                }
-
-                // only if cache is published NOW or activate_date is in the past
-                if ($publish == 'now2' ||
-                    ($publish == 'later'
-                        && mktime($activate_hour, 0, 0, $activate_month, $activate_day, $activate_year) <= $today)
-                ) {
-                    StatisticPicture::deleteStatisticPicture($usr['userid']);
-                }
-
-                // redirection
-                tpl_redirect('viewcache.php?cacheid=' . urlencode($cache_id));
-            } else {
-                tpl_set_var('general_message', $error_general);
-            }
+    } else {
+        $oldDescMode = $descMode;
+    }
+} else {
+    $descMode = EditorConstants::EDITOR_MODE;
+    $oldDescMode = $descMode;
+}
+
+// Text / normal HTML / HTML editor
+$tpl->assign('use_tinymce', ($descMode == EditorConstants::EDITOR_MODE) ? 1 : 0);
+$tpl->assign('descMode', $descMode);
+$tpl->assign('show_htmlnotice', $descMode == EditorConstants::HTML_MODE);
+
+//desc
+if (isset($_POST['desc'])) {
+    $desc = trim(processEditorInput($oldDescMode, $descMode, $_POST['desc'], $representDesc));
+} else {
+    $desc = '';
+    $representDesc = '';
+}
+
+$tpl->assign('desc', htmlspecialchars($representDesc, ENT_COMPAT, 'UTF-8'));
+
+// Add editor scripts via Smarty header mechanism
+if ($descMode == EditorConstants::EDITOR_MODE) {
+    $tpl->add_header_javascript('resource2/tinymce/tiny_mce_gzip.js');
+    $tpl->add_header_javascript(
+        'resource2/tinymce/config/desc.js.php?cacheid=0&lang=' . strtolower($locale)
+    );
+}
+$tpl->add_header_javascript(editorJsPath());
+
+//effort
+$search_time = $_POST['search_time'] ?? 0;
+$way_length = $_POST['way_length'] ?? 0;
+
+$search_time = mb_ereg_replace(',', '.', $search_time);
+$way_length = mb_ereg_replace(',', '.', $way_length);
+
+if (mb_strpos($search_time, ':') == mb_strlen($search_time) - 3) {
+    $st_hours = mb_substr($search_time, 0, mb_strpos($search_time, ':'));
+    $st_minutes = mb_substr($search_time, mb_strlen($st_hours) + 1);
+
+    if (is_numeric($st_hours) && is_numeric($st_minutes)) {
+        if (($st_minutes >= 0) && ($st_minutes < 60)) {
+            $search_time = $st_hours + $st_minutes / 60;
         }
     }
 }
 
-if (!$no_tpl_build) {
-    tpl_set_var('scrollposx', (int)($_REQUEST['scrollposx'] ?? 0));
-    tpl_set_var('scrollposy', (int)($_REQUEST['scrollposy'] ?? 0));
+        $st_hours = floor((float)$search_time);
+        $st_minutes = sprintf('%02.0F', ((float)$search_time - $st_hours) * 60);
 
-    // make the template and send it out
-    tpl_BuildTemplate();
+$tpl->assign('search_time', $st_hours . ':' . $st_minutes);
+$tpl->assign('way_length', $way_length);
+
+
+//hints
+$hints = trim($_POST['hints'] ?? '');
+$tpl->assign('hints', htmlspecialchars($hints, ENT_COMPAT, 'UTF-8'));
+
+// fuer alte Versionen von OCProp
+if (isset($_POST['submit']) && !isset($_POST['version2'])) {
+    $hints = iconv("ISO-8859-1", "UTF-8", $hints);
 }
+
+//tos
+$tos = isset($_POST['TOS']) ? 1 : 0; // Ocprop
+if ($tos === 1) {
+    $tpl->assign('toschecked', ' checked="checked"');
+} else {
+    $tpl->assign('toschecked', '');
+}
+
+//hidden_since
+$hidden_day = $_POST['hidden_day'] ?? date('d'); // Ocprop
+$hidden_month = $_POST['hidden_month'] ?? date('m'); // Ocprop
+$hidden_year = $_POST['hidden_year'] ?? date('Y'); // Ocprop
+$tpl->assign('hidden_day', htmlspecialchars($hidden_day, ENT_COMPAT, 'UTF-8'));
+$tpl->assign('hidden_month', htmlspecialchars($hidden_month, ENT_COMPAT, 'UTF-8'));
+$tpl->assign('hidden_year', htmlspecialchars($hidden_year, ENT_COMPAT, 'UTF-8'));
+
+//activation date
+$activate_day = $_POST['activate_day'] ?? date('d');
+$activate_month = $_POST['activate_month'] ?? date('m');
+$activate_year = $_POST['activate_year'] ?? date('Y');
+$tpl->assign('activate_day', htmlspecialchars($activate_day, ENT_COMPAT, 'UTF-8'));
+$tpl->assign('activate_month', htmlspecialchars($activate_month, ENT_COMPAT, 'UTF-8'));
+$tpl->assign('activate_year', htmlspecialchars($activate_year, ENT_COMPAT, 'UTF-8'));
+
+$tpl->assign('publish_now_checked', '');
+$tpl->assign('publish_later_checked', '');
+$tpl->assign('publish_notnow_checked', '');
+
+$publish = $_POST['publish'] ?? 'notnow'; // Ocprop
+if ($publish == 'now2') {
+    $tpl->assign('publish_now_checked', 'checked');
+} elseif ($publish == 'later') {
+    $tpl->assign('publish_later_checked', 'checked');
+} else { // notnow
+    $publish = 'notnow';
+    $tpl->assign('publish_notnow_checked', 'checked');
+}
+
+// fill activate hours
+$activate_hour = (int)($_POST['activate_hour'] ?? date('H'));
+$activation_hours_arr = [];
+for ($i = 0; $i <= 23; $i++) {
+    $activation_hours_arr[] = [
+        'value' => $i,
+        'label' => $i,
+        'selected' => ($activate_hour === $i),
+    ];
+}
+$tpl->assign('activation_hours', $activation_hours_arr);
+
+//log-password
+$log_pw = isset($_POST['log_pw']) ? mb_substr(trim($_POST['log_pw']), 0, 20) : '';
+$tpl->assign('log_pw', htmlspecialchars($log_pw, ENT_COMPAT, 'UTF-8'));
+
+// gc- and nc-waypoints
+// fix #4356: gc waypoints are frequently copy&pasted with leading spaces
+$wp_gc = isset($_POST['wp_gc']) ? strtoupper(trim($_POST['wp_gc'])) : ''; // Ocprop
+$tpl->assign('wp_gc', htmlspecialchars($wp_gc, ENT_COMPAT, 'UTF-8'));
+
+//difficulty
+$difficulty = $_POST['difficulty'] ?? 1; // Ocprop
+$difficulty_arr = [['value' => 1, 'label' => $sel_message, 'selected' => false]];
+for ($i = 2; $i <= 10; $i++) {
+    $difficulty_arr[] = [
+        'value' => $i,
+        'label' => $i / 2,
+        'selected' => ($difficulty == $i),
+    ];
+}
+$tpl->assign('difficulty_options', $difficulty_arr);
+
+//terrain
+$terrain = $_POST['terrain'] ?? 1; // Ocprop
+$terrain_arr = [['value' => 1, 'label' => $sel_message, 'selected' => false]];
+for ($i = 2; $i <= 10; $i++) {
+    $terrain_arr[] = [
+        'value' => $i,
+        'label' => $i / 2,
+        'selected' => ($terrain == $i),
+    ];
+}
+$tpl->assign('terrain_options', $terrain_arr);
+
+//sizeoptions
+$size_arr = [['value' => -1, 'label' => t('Please select!'), 'selected' => ($sel_size == -1)]];
+$rsSizes = sql(
+    "SELECT `cache_size`.`id`,
+            IFNULL(`sys_trans_text`.`text`,
+            `cache_size`.`name`) AS `name`
+     FROM `cache_size`
+     LEFT JOIN `sys_trans`
+       ON `cache_size`.`trans_id`=`sys_trans`.`id`
+     LEFT JOIN `sys_trans_text`
+       ON `sys_trans`.`id`=`sys_trans_text`.`trans_id`
+       AND `sys_trans_text`.`lang`='" . sql_escape($locale) . "'
+     ORDER BY `cache_size`.`ordinal` ASC"
+);
+while ($rSize = sql_fetch_assoc($rsSizes)) {
+    $size_arr[] = [
+        'value' => $rSize['id'],
+        'label' => $rSize['name'],
+        'selected' => ($rSize['id'] == $sel_size),
+    ];
+}
+sql_free_result($rsSizes);
+$tpl->assign('size_options', $size_arr);
+
+//typeoptions
+$type_arr = [['value' => -1, 'label' => t('Please select!'), 'selected' => ($sel_type == -1)]];
+$rsTypes = sql(
+    "SELECT `cache_type`.`id`,
+            IFNULL(`sys_trans_text`.`text`,
+            `cache_type`.`en`) AS `name`
+     FROM `cache_type`
+     LEFT JOIN `sys_trans`
+       ON `cache_type`.`trans_id`=`sys_trans`.`id`
+     LEFT JOIN `sys_trans_text`
+       ON `sys_trans`.`id`=`sys_trans_text`.`trans_id`
+       AND `sys_trans_text`.`lang`='" . sql_escape($locale) . "'
+     ORDER BY `cache_type`.`ordinal` ASC"
+);
+while ($rType = sql_fetch_assoc($rsTypes)) {
+    $type_arr[] = [
+        'value' => $rType['id'],
+        'label' => $rType['name'],
+        'selected' => ($rType['id'] == $sel_type),
+    ];
+}
+sql_free_result($rsTypes);
+$tpl->assign('type_options', $type_arr);
+
+if (isset($_POST['show_all_countries_submit'])) {
+    $show_all_countries = 1;
+} elseif (isset($_POST['show_all_langs_submit'])) {
+    $show_all_langs = 1;
+}
+
+//check if selected lang is in list_default
+if ($show_all_langs == 0) {
+    $rs = sql(
+        "SELECT `show` FROM `languages_list_default` WHERE `show`='&1' AND `lang`='&2'",
+        $sel_lang,
+        $locale
+    );
+    if (mysqli_num_rows($rs) == 0) {
+        $show_all_langs = 1;
+    }
+    sql_free_result($rs);
+}
+
+$lang_arr = [];
+if ($show_all_langs == 0) {
+    $tpl->assign('show_all_langs', '0');
+    $tpl->assign(
+        'show_all_langs_submit',
+        '<input type="submit" name="show_all_langs_submit" value="' . $show_all . '"/>'
+    );
+
+    $rs = sql(
+        "SELECT `languages`.`short`,
+                IFNULL(`sys_trans_text`.`text`,
+                `languages`.`name`) AS `name`
+         FROM `languages`
+         INNER JOIN `languages_list_default`
+           ON `languages`.`short`=`languages_list_default`.`show`
+         LEFT JOIN `sys_trans`
+           ON `languages`.`trans_id`=`sys_trans`.`id`
+         LEFT JOIN `sys_trans_text`
+           ON `sys_trans`.`id`=`sys_trans_text`.`trans_id`
+           AND `sys_trans_text`.`lang`='&1'
+         WHERE `languages_list_default`.`lang`='&1' ORDER BY `name` ASC",
+        $locale
+    );
+} else {
+    $tpl->assign('show_all_langs', '1');
+    $tpl->assign('show_all_langs_submit', '');
+
+    $rs = sql(
+        "SELECT `languages`.`short`,
+         IFNULL(`sys_trans_text`.`text`, `languages`.`name`) AS `name`
+         FROM `languages`
+         LEFT JOIN `sys_trans`
+           ON `languages`.`trans_id`=`sys_trans`.`id`
+         LEFT JOIN `sys_trans_text`
+           ON `sys_trans`.`id`=`sys_trans_text`.`trans_id`
+           AND `sys_trans_text`.`lang`='&1'
+         ORDER BY `name` ASC",
+        $locale
+    );
+}
+
+while ($record = sql_fetch_assoc($rs)) {
+    $lang_arr[] = [
+        'value' => $record['short'],
+        'label' => $record['name'],
+        'selected' => ($record['short'] == $sel_lang),
+    ];
+}
+sql_free_result($rs);
+$tpl->assign('lang_options', $lang_arr);
+
+//countryoptions
+//check if selected country is in list_default
+if ($show_all_countries == 0) {
+    $rs = sql(
+        "SELECT `show` FROM `countries_list_default` WHERE `show`='&1' AND `lang`='&2'",
+        $sel_country,
+        $locale
+    );
+    if (mysqli_num_rows($rs) == 0) {
+        $show_all_countries = 1;
+    }
+    sql_free_result($rs);
+}
+
+$country_arr = [];
+if ($show_all_countries == 0) {
+    $tpl->assign('show_all_countries', '0');
+    $tpl->assign(
+        'show_all_countries_submit',
+        '<input type="submit" id="showallcountries" class="formbutton" name="show_all_countries_submit" value="' . $show_all . '" onclick="submitbutton(\'showallcountries\')" />'
+    );
+
+    $rs = sql(
+        "SELECT `countries`.`short`,
+                IFNULL(`sys_trans_text`.`text`,
+                `countries`.`name`) AS `name`
+         FROM `countries`
+         INNER JOIN `countries_list_default`
+           ON `countries_list_default`.`show`=`countries`.`short`
+         LEFT JOIN `sys_trans`
+           ON `countries`.`trans_id`=`sys_trans`.`id`
+         LEFT JOIN `sys_trans_text`
+           ON `sys_trans`.`id`=`sys_trans_text`.`trans_id`
+           AND `sys_trans_text`.`lang`='&1'
+         WHERE `countries_list_default`.`lang`='&1'
+         ORDER BY `name` ASC",
+        $locale
+    );
+} else {
+    $tpl->assign('show_all_countries', '1');
+    $tpl->assign('show_all_countries_submit', '');
+
+    $rs = sql(
+        "SELECT `countries`.`short`,
+                IFNULL(`sys_trans_text`.`text`,
+                `countries`.`name`) AS `name`
+         FROM `countries`
+         LEFT JOIN `sys_trans`
+           ON `countries`.`trans_id`=`sys_trans`.`id`
+         LEFT JOIN `sys_trans_text`
+           ON `sys_trans`.`id`=`sys_trans_text`.`trans_id`
+           AND `sys_trans_text`.`lang`='&1'
+        ORDER BY `name` ASC",
+        $locale
+    );
+}
+
+// build the "country" dropdown list, preselect $sel_country
+while ($record = sql_fetch_array($rs)) {
+    $country_arr[] = [
+        'value' => $record['short'],
+        'label' => $record['name'],
+        'selected' => ($record['short'] == $sel_country),
+    ];
+}
+sql_free_result($rs);
+$tpl->assign('country_options', $country_arr);
+
+// cache-attributes
+$cache_attribs = isset($_POST['cache_attribs']) ? mb_split(';', $_POST['cache_attribs']) : [];
+
+// cache-attributes — build pre-rendered HTML (kept as-is for now)
+$bBeginLine = true;
+$nPrevLineAttrCount = 0;
+$nLineAttrCount = 0;
+
+$cache_attrib_list = '';
+$cache_attrib_array = '';
+$cache_attribs_string = '';
+
+$rsAttrGroup = sql(
+    "SELECT `attribute_groups`.`id`,
+            IFNULL(`sys_trans_text`.`text`,
+            `attribute_groups`.`name`) AS `name`,
+            `attribute_categories`.`color`
+     FROM `attribute_groups`
+     INNER JOIN `attribute_categories`
+       ON `attribute_groups`.`category_id`=`attribute_categories`.`id`
+     LEFT JOIN `sys_trans`
+       ON `attribute_groups`.`trans_id`=`sys_trans`.`id`
+     LEFT JOIN `sys_trans_text`
+       ON `sys_trans`.`id`=`sys_trans_text`.`trans_id`
+       AND `sys_trans_text`.`lang`='&1'
+     ORDER BY `attribute_groups`.`category_id` ASC, `attribute_groups`.`id` ASC",
+    $locale
+);
+while ($rAttrGroup = sql_fetch_assoc($rsAttrGroup)) {
+    $group_line = '';
+
+    $rs = sql(
+        "SELECT `cache_attrib`.`id`,
+                IFNULL(`ttname`.`text`,`cache_attrib`.`name`) AS `name`,
+                `cache_attrib`.`icon_undef`,
+                `cache_attrib`.`icon_large`,
+                IFNULL(`ttdesc`.`text`, `cache_attrib`.`html_desc`) AS `html_desc`
+         FROM `cache_attrib`
+         LEFT JOIN `sys_trans` AS `tname`
+           ON `cache_attrib`.`trans_id`=`tname`.`id`
+           AND `cache_attrib`.`name`=`tname`.`text`
+         LEFT JOIN `sys_trans_text` AS `ttname`
+           ON `tname`.`id`=`ttname`.`trans_id`
+           AND `ttname`.`lang`='&1'
+         LEFT JOIN `sys_trans` AS `tdesc`
+           ON `cache_attrib`.`html_desc_trans_id`=`tdesc`.`id`
+           AND `cache_attrib`.`html_desc`=`tdesc`.`text`
+         LEFT JOIN `sys_trans_text` AS `ttdesc`
+           ON `tdesc`.`id`=`ttdesc`.`trans_id`
+           AND `ttdesc`.`lang`='&1'
+         WHERE `cache_attrib`.`group_id`=" . ((int)$rAttrGroup['id']) . '
+         AND NOT IFNULL(`cache_attrib`.`hidden`, 0) = 1
+         AND `cache_attrib`.`selectable` != 0
+         ORDER BY `cache_attrib`.`group_id`, `cache_attrib`.`id`',
+        $locale
+    );
+    while ($record = sql_fetch_array($rs)) {
+        $line = $cache_attrib_pic;
+
+        $line = mb_ereg_replace('{attrib_id}', $record['id'], $line);
+        $line = mb_ereg_replace('{attrib_text}', escape_javascript($record['name']), $line);
+        if (in_array($record['id'], $cache_attribs)) {
+            $line = mb_ereg_replace('{attrib_pic}', $record['icon_large'], $line);
+        } else {
+            $line = mb_ereg_replace('{attrib_pic}', $record['icon_undef'], $line);
+        }
+        $line = mb_ereg_replace('{html_desc}', escape_javascript($record['html_desc']), $line);
+        $line = mb_ereg_replace('{name}', escape_javascript($record['name']), $line);
+        $line = mb_ereg_replace('{color}', $rAttrGroup['color'], $line);
+        $group_line .= $line;
+        $nLineAttrCount++;
+
+        $line = $cache_attrib_js;
+        $line = mb_ereg_replace('{id}', $record['id'], $line);
+        if (in_array($record['id'], $cache_attribs)) {
+            $line = mb_ereg_replace('{selected}', 1, $line);
+        } else {
+            $line = mb_ereg_replace('{selected}', 0, $line);
+        }
+        $line = mb_ereg_replace('{img_undef}', $record['icon_undef'], $line);
+        $line = mb_ereg_replace('{img_large}', $record['icon_large'], $line);
+        $line = mb_ereg_replace(
+            '{conflicting_attribs}',
+            implode(',', OcLib2\attribute::getConflictingAttribIds($record['id'])),
+            $line
+        );
+        if ($cache_attrib_array != '') {
+            $cache_attrib_array .= ',';
+        }
+        $cache_attrib_array .= $line;
+
+        if (in_array($record['id'], $cache_attribs)) {
+            if ($cache_attribs_string != '') {
+                $cache_attribs_string .= ';';
+            }
+            $cache_attribs_string .= $record['id'];
+        }
+    }
+    sql_free_result($rs);
+
+    if ($group_line != '') {
+        $group_img = $cache_attrib_group;
+        $group_img = mb_ereg_replace('{color}', $rAttrGroup['color'], $group_img);
+        $group_img = mb_ereg_replace('{attribs}', $group_line, $group_img);
+        $group_img = mb_ereg_replace(
+            '{name}',
+            htmlspecialchars(
+                $rAttrGroup['name'],
+                ENT_COMPAT,
+                'UTF-8'
+            ),
+            $group_img
+        );
+
+        if ($bBeginLine) {
+            $cache_attrib_list .= '<div class="attribswide">';
+            $bBeginLine = false;
+        }
+
+        $cache_attrib_list .= $group_img;
+        $nPrevLineAttrCount += $nLineAttrCount;
+
+        $nLineAttrCount = 0;
+    }
+}
+sql_free_result($rsAttrGroup);
+if (!$bBeginLine) {
+    $cache_attrib_list .= '</div>';
+}
+
+$tpl->assign('cache_attrib_list', $cache_attrib_list);
+$tpl->assign('jsattributes_array', $cache_attrib_array);
+$tpl->assign('cache_attribs', $cache_attribs_string);
+
+$tpl->assign('firstcache_note', mb_ereg_replace('%1', $opt['page']['sitename'], $firstcache_note));
+
+if (isset($_POST['submitform'])) {  // Ocprop
+    // check the entered data
+
+    // check coordinates
+    if ($lat_h != '' || $lat_min != '') {
+        if (!mb_ereg_match('^[0-9]{1,3}$', $lat_h)) {
+            $tpl->assign('coord_error', $error_lat_not_ok);
+            $error = true;
+            $lat_h_not_ok = true;
+        } else {
+            if (($lat_h >= 0) && ($lat_h < 90)) {
+                $lat_h_not_ok = false;
+            } else {
+                $tpl->assign('coord_error', $error_lat_not_ok);
+                $error = true;
+                $lat_h_not_ok = true;
+            }
+        }
+
+        if (is_numeric($lat_min)) {
+            if (($lat_min >= 0) && ($lat_min < 60)) {
+                $lat_min_not_ok = false;
+            } else {
+                $tpl->assign('coord_error', $error_lat_not_ok);
+                $error = true;
+                $lat_min_not_ok = true;
+            }
+        } else {
+            $tpl->assign('coord_error', $error_lat_not_ok);
+            $error = true;
+            $lat_min_not_ok = true;
+        }
+
+        $latitude = $lat_h + $lat_min / 60;
+        if ($latNS == 'S') {
+            $latitude = -$latitude;
+        }
+
+        if ($latitude == 0) {
+            $tpl->assign('coord_error', $error_lat_not_ok);
+            $error = true;
+            $lat_min_not_ok = true;
+        }
+    } else {
+        $tpl->assign('coord_error', $error_lat_not_ok);
+        $lat_h_not_ok = true;
+        $lat_min_not_ok = true;
+    }
+
+    if ($lon_h != '' || $lon_min != '') {
+        if (!mb_ereg_match('^[0-9]{1,3}$', $lon_h)) {
+            $tpl->assign('coord_error', $error_long_not_ok);
+            $error = true;
+            $lon_h_not_ok = true;
+        } else {
+            if (($lon_h >= 0) && ($lon_h < 180)) {
+                $lon_h_not_ok = false;
+            } else {
+                $tpl->assign('coord_error', $error_long_not_ok);
+                $error = true;
+                $lon_h_not_ok = true;
+            }
+        }
+
+        if (is_numeric($lon_min)) {
+            if (($lon_min >= 0) && ($lon_min < 60)) {
+                $lon_min_not_ok = false;
+            } else {
+                $tpl->assign('coord_error', $error_long_not_ok);
+                $error = true;
+                $lon_min_not_ok = true;
+            }
+        } else {
+            $tpl->assign('coord_error', $error_long_not_ok);
+            $error = true;
+            $lon_min_not_ok = true;
+        }
+
+        $longitude = $lon_h + $lon_min / 60;
+        if ($lon_EW == 'W') {
+            $longitude = -$longitude;
+        }
+
+        if ($longitude == 0) {
+            $tpl->assign('coord_error', $error_long_not_ok);
+            $error = true;
+            $lon_min_not_ok = true;
+        }
+    } else {
+        $tpl->assign('coord_error', $error_long_not_ok);
+        $lon_h_not_ok = true;
+        $lon_min_not_ok = true;
+    }
+
+    $lon_not_ok = (isset($lon_min_not_ok) && $lon_min_not_ok) || (isset($lon_h_not_ok) && $lon_h_not_ok);
+    $lat_not_ok = (isset($lat_min_not_ok) && $lat_min_not_ok) || (isset($lat_h_not_ok) && $lat_h_not_ok);
+
+    // check for duplicate coords
+    if (!($lon_not_ok || $lat_not_ok)) {
+        $duplicate_wpoc = sql_value(
+            "SELECT MIN(wp_oc)
+             FROM `caches`
+             WHERE `status`=1
+             AND ROUND(`longitude`,6)=ROUND('&1',6)
+             AND ROUND(`latitude`,6)=ROUND('&2',6)",
+            null,
+            $longitude,
+            $latitude
+        );
+        if ($duplicate_wpoc) {
+            $tpl->assign('coord_error', mb_ereg_replace('%1', $duplicate_wpoc, $error_duplicate_coords));
+            $lon_not_ok = true;
+        }
+    }
+
+    //check effort
+    $time_not_ok = true;
+    if (is_numeric($search_time) || ($search_time == '')) {
+        $time_not_ok = false;
+    }
+    if ($time_not_ok) {
+        $tpl->assign('effort_message', $time_not_ok_message);
+        $error = true;
+    }
+    $way_length_not_ok = true;
+    if (is_numeric($way_length) || ($search_time == '')) {
+        $way_length_not_ok = false;
+    }
+    if ($way_length_not_ok) {
+        $tpl->assign('effort_message', $way_length_not_ok_message);
+        $error = true;
+    }
+
+    //check hidden_since
+    $hidden_date_not_ok = true;
+    if (is_numeric($hidden_day) && is_numeric($hidden_month) && is_numeric($hidden_year)) {
+        $hidden_date_not_ok = (checkdate($hidden_month, $hidden_day, $hidden_year) == false);
+    }
+    if ($hidden_date_not_ok) {
+        $tpl->assign('hidden_since_message', $date_not_ok_message);
+        $error = true;
+    } else if ($publish != 'notnow') {
+        $hidden_date = mktime(0, 0, 0, $hidden_month, $hidden_day, $hidden_year);
+        if ($publish == 'later') {
+            // Activation hour can be ignored here. This simplifies checking event dates.
+            $publish_date = mktime(0, 0, 0, $activate_month, $activate_day, $activate_year);
+        } else {
+            $publish_date = time();
+        }
+        if ($sel_type == 6 && $hidden_date < $publish_date) {
+            $tpl->assign('hidden_since_message', $event_before_publish_message);
+            $hidden_date_not_ok = true;
+            $error = true;
+        } elseif ($sel_type != 6 && $hidden_date > $publish_date) {
+            $tpl->assign('hidden_since_message', $hide_after_publish_message);
+            $hidden_date_not_ok = true;
+            $error = true;
+        }
+    }
+
+    //check GC waypoint
+    $wpgc_not_ok = $wp_gc != "" && !preg_match("/^(?:GC|CX)[0-9A-Z]{3,6}$/", $wp_gc);
+    if ($wpgc_not_ok) {
+        $tpl->assign('wpgc_message', $bad_wpgc_message);
+        $error = true;
+    }
+
+    //check date_activate
+    $activation_date_not_ok = true;
+    if (is_numeric($activate_day)
+        && is_numeric($activate_month)
+        && is_numeric($activate_year)
+        && is_numeric($activate_hour)
+    ) {
+        $activation_date_not_ok = ((checkdate($activate_month, $activate_day, $activate_year) == false)
+            || $activate_hour < 0 || $activate_hour > 23);
+    }
+    if (!$activation_date_not_ok) {
+        if (!($publish == 'now2' || $publish == 'later' || $publish == 'notnow')) {
+            $activation_date_not_ok = true;
+        }
+    }
+    if ($activation_date_not_ok) {
+        $tpl->assign('activate_on_message', $date_not_ok_message);
+        $error = true;
+    }
+
+    //name
+    if ($name == '') {
+        $tpl->assign('name_message', $name_not_ok_message);
+        $error = true;
+        $name_not_ok = true;
+    } else {
+        $name_not_ok = false;
+    }
+
+    //tos
+    if ($tos != 1) {
+        $tpl->assign('tos_message', $tos_not_ok_message);
+        $error = true;
+        $tos_not_ok = true;
+    } else {
+        $tos_not_ok = false;
+    }
+
+    //cache-size
+    $size_not_ok = false;
+    if ($sel_size == -1) {
+        $tpl->assign('size_message', $size_not_ok_message);
+        $error = true;
+        $size_not_ok = true;
+    }
+
+    //cache-type
+    $type_not_ok = false;
+    if ($sel_type == -1) {
+        $tpl->assign('type_message', $type_not_ok_message);
+        $error = true;
+        $type_not_ok = true;
+    }
+
+    if ($sel_size != 7 && ($sel_type == 4 || $sel_type == 5)) {
+        if (!$size_not_ok) {
+            $tpl->assign('size_message', $sizemismatch_message);
+        }
+        $error = true;
+        $size_not_ok = true;
+    }
+
+    //difficulty / terrain
+    $diff_not_ok = false;
+    if ($difficulty < 2 || $difficulty > 10 || $terrain < 2 || $terrain > 10) {
+        $tpl->assign('diff_message', $diff_not_ok_message);
+        $error = true;
+        $diff_not_ok = true;
+    }
+
+    // attributes
+    $attribs_not_ok = false;
+    if (in_array(ATTRIB_ID_SAFARI, $cache_attribs) && $sel_type != 4) {
+        $tpl->assign('safari_message', $safari_not_allowed_message);
+        $error = true;
+        $attribs_not_ok = true;
+    } else {
+        $tpl->assign('safari_message', '');
+    }
+
+    //no errors?
+    if (!($tos_not_ok
+        || $name_not_ok
+        || $hidden_date_not_ok
+        || $activation_date_not_ok
+        || $lon_not_ok
+        || $lat_not_ok
+        || $time_not_ok
+        || $way_length_not_ok
+        || $size_not_ok
+        || $type_not_ok
+        || $diff_not_ok
+        || $attribs_not_ok
+        || $wpgc_not_ok)
+    ) {
+        //sel_status
+        $now = getdate();
+        $today = mktime(0, 0, 0, $now['mon'], $now['mday'], $now['year']);
+        $hidden_date = mktime(0, 0, 0, $hidden_month, $hidden_day, $hidden_year);
+
+        $sel_status = 1; //available
+        if (($hidden_date > $today) && ($sel_type != 6)) {
+            $sel_status = 2; //currently not available
+        }
+
+        if ($publish == 'now2') {
+            $activation_date = 'NULL';
+        } elseif ($publish == 'later') {
+            $sel_status = 5;
+            $activation_date =
+                "'" . date(
+                    'Y-m-d H:i:s',
+                    mktime(
+                        $activate_hour,
+                        0,
+                        0,
+                        $activate_month,
+                        $activate_day,
+                        $activate_year
+                    )
+                ) . "'";
+        } elseif ($publish == 'notnow') {
+            $sel_status = 5;
+            $activation_date = 'NULL';
+        } else {
+            // should never happen
+            $activation_date = 'NULL';
+        }
+
+        //add record to caches table
+        sql(
+            "INSERT INTO `caches` (
+                `cache_id`,
+                `user_id`,
+                `name`,
+                `longitude`,
+                `latitude`,
+                `type` ,
+                `status` ,
+                `country` ,
+                `date_hidden` ,
+                `date_activate` ,
+                `size` ,
+                `difficulty` ,
+                `terrain`,
+                `logpw`,
+                `search_time`,
+                `way_length`,
+                `wp_gc`,
+                `node`
+            ) VALUES (
+                '',
+                '&1',
+                '&2',
+                '&3',
+                '&4',
+                '&5',
+                '&6',
+                '&7',
+                '&8',
+                $activation_date,
+                '&9',
+                '&10',
+                '&11',
+                '&12',
+                '&13',
+                '&14',
+                '&15',
+                '&16'
+                )",
+            $login->userid,
+            $name,
+            $longitude,
+            $latitude,
+            $sel_type,
+            $sel_status,
+            $sel_country,
+            date('Y-m-d', $hidden_date),
+            $sel_size,
+            $difficulty,
+            $terrain,
+            $log_pw,
+            $search_time,
+            $way_length,
+            $wp_gc,
+            $oc_nodeid
+        );
+        $cache_id = sql_insert_id();
+
+        //add record to cache_desc table
+        sql(
+            "INSERT INTO `cache_desc` (
+                `id`,
+                `cache_id`,
+                `language`,
+                `desc`,
+                `desc_html`,
+                `hint`,
+                `short_desc`,
+                `last_modified`,
+                `desc_htmledit`,
+                `node`
+            ) VALUES (
+                '',
+                '&1',
+                '&2',
+                '&3',
+                '&4',
+                '&5',
+                '&6',
+                NOW(),
+                '&7',
+                '&8'
+            )",
+            $cache_id,
+            $sel_lang,
+            $desc,
+            1,
+            nl2br(htmlspecialchars($hints, ENT_COMPAT, 'UTF-8')),
+            $short_desc,
+            ($descMode == EditorConstants::EDITOR_MODE) ? 1 : 0,
+            $oc_nodeid
+        );
+
+        $cacheAttributesCount = count($cache_attribs);
+        // insert cache-attributes
+        for ($i = 0; $i < $cacheAttributesCount; $i++) {
+            if (((int)$cache_attribs[$i]) > 0) {
+                sql(
+                    "INSERT INTO `caches_attributes` (
+                         `cache_id`,
+                         `attrib_id`
+                     ) VALUES (
+                         '&1',
+                         '&2'
+                     )",
+                    $cache_id,
+                    (int)$cache_attribs[$i]
+                );
+            }
+        }
+
+        // only if cache is published NOW or activate_date is in the past
+        if ($publish == 'now2' ||
+            ($publish == 'later'
+                && mktime($activate_hour, 0, 0, $activate_month, $activate_day, $activate_year) <= $today)
+        ) {
+            StatisticPicture::deleteStatisticPicture($login->userid);
+        }
+
+        // redirection
+        $tpl->redirect('viewcache.php?cacheid=' . urlencode($cache_id));
+    } else {
+        $tpl->assign('general_error', $error_general);
+    }
+}
+
+$tpl->assign('scrollposx', (int)($_REQUEST['scrollposx'] ?? 0));
+$tpl->assign('scrollposy', (int)($_REQUEST['scrollposy'] ?? 0));
+
+// make the template and send it out
+$tpl->display();

--- a/htdocs/resource2/misc/shared/coords.js
+++ b/htdocs/resource2/misc/shared/coords.js
@@ -1,0 +1,78 @@
+/***************************************************************************
+ * for license information see LICENSE.md
+ * Author: hxdimpf
+ ***************************************************************************/
+
+/**
+ * Shared coordinate conversion utilities (ESM module).
+ *
+ * Used by coord_input.js (unified coordinate input) and map3.
+ */
+
+/** Zero-pad an integer to the given width. */
+export function pad(n, width) {
+  const s = n.toString();
+  return s.length >= width ? s : '0'.repeat(width - s.length) + s;
+}
+
+/** Format decimal lat/lon as "N49 01.012 E008 22.444". */
+export function coords2Dm(lat, lon) {
+  const latOut = lat < 0 ? 'S' : 'N';
+  const lonOut = lon < 0 ? 'W' : 'E';
+  lat = Math.abs(lat);
+  lon = Math.abs(lon);
+
+  let latDeg = Math.trunc(lat);
+  let lonDeg = Math.trunc(lon);
+
+  let latDegFrac = Number((lat - latDeg).toFixed(14));
+  let lonDegFrac = Number((lon - lonDeg).toFixed(14));
+
+  let latMin = 60 * latDegFrac;
+  let lonMin = 60 * lonDegFrac;
+
+  let latMinInt = Math.trunc(latMin);
+  let lonMinInt = Math.trunc(lonMin);
+
+  let latMinFrac = Number((latMin - latMinInt).toFixed(3));
+  let lonMinFrac = Number((lonMin - lonMinInt).toFixed(3));
+
+  if (latMinFrac === 1) {
+    latMinFrac = 0;
+    latMinInt++;
+    if (latMinInt === 60) { latMinInt = 0; latDeg++; }
+  }
+  if (lonMinFrac === 1) {
+    lonMinFrac = 0;
+    lonMinInt++;
+    if (lonMinInt === 60) { lonMinInt = 0; lonDeg++; }
+  }
+
+  return `${latOut}${pad(latDeg, 2)} ${pad(latMinInt, 2)}.${pad(1000 * latMinFrac, 3)} ` +
+         `${lonOut}${pad(lonDeg, 3)} ${pad(lonMinInt, 2)}.${pad(1000 * lonMinFrac, 3)}`;
+}
+
+/** Parse a "N49 01.012 E008 22.444" string back to decimal {latitude, longitude}. */
+export function coords2LatLon(coords) {
+  const parts = coords.split(' ');
+
+  const ns = parts[0][0];
+  const ew = parts[2][0];
+
+  const ndeg = parts[0].substr(1, parts[0].length - 1);
+  const nmin = parts[1][0] + parts[1][1];
+
+  const edeg = parts[2].substr(1, parts[2].length - 1);
+  const emin = parts[3][0] + parts[3][1];
+
+  const nfrac = parts[1][3] + parts[1][4] + parts[1][5];
+  const efrac = parts[3][3] + parts[3][4] + parts[3][5];
+
+  const latSign = (ns == 'N') ? 1 : -1;
+  const lonSign = (ew == 'E') ? 1 : -1;
+
+  const latitude  = ((Number(ndeg) + Number(nmin) / 60 + Number(nfrac) / 60000) * latSign).toFixed(14);
+  const longitude = ((Number(edeg) + Number(emin) / 60 + Number(efrac) / 60000) * lonSign).toFixed(14);
+
+  return { latitude, longitude };
+}

--- a/htdocs/resource2/ocstyle/js/coord_input.js
+++ b/htdocs/resource2/ocstyle/js/coord_input.js
@@ -2,388 +2,343 @@
  * for license information see LICENSE.md
  ***************************************************************************/
 /**
- * Unified coordinate input field — parser + UI logic.
+ * Unified coordinate input field — parser + UI logic (ESM module).
  *
  * Adds a single text input above the legacy 6-field coordinate form.
  * On input/paste the parser populates hidden lat/lon fields for POST.
  * A toggle link switches between unified and 6-field modes.
  */
-(function () {
-    'use strict';
+import { coords2Dm, pad } from '../../misc/shared/coords.js';
 
-    // ── helpers ──────────────────────────────────────────────────────
+// ── conversion: lat/lon ↔ 6-field values ────────────────────────
 
-    /** Replace unicode symbols with ASCII equivalents and collapse whitespace. */
-    function normalize(str) {
-        return str
-            .replace(/[\u00B0\u00BA]/g, '°')
-            .replace(/[\u2032\u2019\u0060\u00B4]/g, "'")
-            .replace(/[\u2033\u201D]/g, '"')
-            .replace(/,/g, ' ')
-            .replace(/\s+/g, ' ')
-            .trim();
+/** Convert parsed 6-component result to decimal lat/lon. */
+function toLatLon(r) {
+    var lat = r.latDeg + r.latMin / 60;
+    if (r.latHem === 'S') lat = -lat;
+    var lon = r.lonDeg + r.lonMin / 60;
+    if (r.lonHem === 'W') lon = -lon;
+    return { latitude: lat, longitude: lon };
+}
+
+/** Convert decimal lat/lon to 6-field values for legacy fields. */
+function toFields(lat, lon) {
+    var latHem = lat >= 0 ? 'N' : 'S';
+    var lonHem = lon >= 0 ? 'E' : 'W';
+    lat = Math.abs(lat);
+    lon = Math.abs(lon);
+
+    var latDeg = Math.trunc(lat);
+    var lonDeg = Math.trunc(lon);
+
+    var latDegFrac = Number((lat - latDeg).toFixed(14));
+    var lonDegFrac = Number((lon - lonDeg).toFixed(14));
+
+    var latMin = 60 * latDegFrac;
+    var lonMin = 60 * lonDegFrac;
+
+    var latMinInt = Math.trunc(latMin);
+    var lonMinInt = Math.trunc(lonMin);
+
+    var latMinFrac = Number((latMin - latMinInt).toFixed(3));
+    var lonMinFrac = Number((lonMin - lonMinInt).toFixed(3));
+
+    if (latMinFrac === 1) {
+        latMinFrac = 0; latMinInt++;
+        if (latMinInt === 60) { latMinInt = 0; latDeg++; }
+    }
+    if (lonMinFrac === 1) {
+        lonMinFrac = 0; lonMinInt++;
+        if (lonMinInt === 60) { lonMinInt = 0; lonDeg++; }
     }
 
-    function pad(n, width) {
-        var s = n.toString();
-        return s.length >= width ? s : '0'.repeat(width - s.length) + s;
+    return {
+        latHem: latHem, latDeg: latDeg,
+        latMin: pad(latMinInt, 2) + '.' + pad(1000 * latMinFrac, 3),
+        lonHem: lonHem, lonDeg: lonDeg,
+        lonMin: pad(lonMinInt, 2) + '.' + pad(1000 * lonMinFrac, 3)
+    };
+}
+
+// ── parser ──────────────────────────────────────────────────────
+
+/** Replace unicode symbols with ASCII equivalents and collapse whitespace. */
+function normalize(str) {
+    return str
+        .replace(/[\u00B0\u00BA]/g, '\u00B0')
+        .replace(/[\u2032\u2019\u0060\u00B4]/g, "'")
+        .replace(/[\u2033\u201D]/g, '"')
+        .replace(/,/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+/**
+ * Parse a coordinate string into its 6 components.
+ * Returns { latHem, latDeg, latMin, lonHem, lonDeg, lonMin } or null.
+ */
+function parseCoordinates(raw) {
+    var s = normalize(raw);
+    if (s === '') return null;
+
+    var result;
+
+    result = parseWithHemispheres(s);
+    if (result) return validate(result);
+
+    result = parseDecimalDegrees(s);
+    if (result) return validate(result);
+
+    return null;
+}
+
+function parseWithHemispheres(s) {
+    var hems = [];
+    var re = /[NSEW]/gi;
+    var m;
+    while ((m = re.exec(s)) !== null) {
+        hems.push({ letter: m[0].toUpperCase(), index: m.index });
     }
+    if (hems.length !== 2) return null;
 
-    // ── conversion: lat/lon ↔ display string ────────────────────────
-
-    /** Format decimal lat/lon as "N49 01.012 E008 22.444". */
-    function coords2Dm(lat, lon) {
-        var latOut = lat < 0 ? 'S' : 'N';
-        var lonOut = lon < 0 ? 'W' : 'E';
-        lat = Math.abs(lat);
-        lon = Math.abs(lon);
-
-        var latDeg = Math.trunc(lat);
-        var lonDeg = Math.trunc(lon);
-
-        var latDegFrac = Number((lat - latDeg).toFixed(14));
-        var lonDegFrac = Number((lon - lonDeg).toFixed(14));
-
-        var latMin = 60 * latDegFrac;
-        var lonMin = 60 * lonDegFrac;
-
-        var latMinInt = Math.trunc(latMin);
-        var lonMinInt = Math.trunc(lonMin);
-
-        var latMinFrac = Number((latMin - latMinInt).toFixed(3));
-        var lonMinFrac = Number((lonMin - lonMinInt).toFixed(3));
-
-        if (latMinFrac === 1) {
-            latMinFrac = 0; latMinInt++;
-            if (latMinInt === 60) { latMinInt = 0; latDeg++; }
+    var ns = null, ew = null;
+    for (var i = 0; i < 2; i++) {
+        if (hems[i].letter === 'N' || hems[i].letter === 'S') {
+            if (ns !== null) return null;
+            ns = i;
+        } else {
+            if (ew !== null) return null;
+            ew = i;
         }
-        if (lonMinFrac === 1) {
-            lonMinFrac = 0; lonMinInt++;
-            if (lonMinInt === 60) { lonMinInt = 0; lonDeg++; }
-        }
+    }
+    if (ns === null || ew === null) return null;
 
-        return latOut + pad(latDeg, 2) + ' ' + pad(latMinInt, 2) + '.' + pad(1000 * latMinFrac, 3) + ' ' +
-               lonOut + pad(lonDeg, 3) + ' ' + pad(lonMinInt, 2) + '.' + pad(1000 * lonMinFrac, 3);
+    var parts = splitByHemispheres(s, hems, ns, ew);
+    if (!parts) return null;
+
+    var lat = parseNumberPart(parts.lat);
+    var lon = parseNumberPart(parts.lon);
+    if (!lat || !lon) return null;
+
+    return {
+        latHem: hems[ns].letter, latDeg: lat.deg, latMin: lat.min,
+        lonHem: hems[ew].letter, lonDeg: lon.deg, lonMin: lon.min
+    };
+}
+
+function splitByHemispheres(s, hems, nsIdx, ewIdx) {
+    var first = hems[0], second = hems[1];
+    var firstIsNS = (nsIdx === 0);
+
+    var chars = s.split('');
+    chars[first.index] = '|';
+    chars[second.index] = '|';
+    var segments = chars.join('').split('|');
+    var numberParts = [];
+    for (var i = 0; i < segments.length; i++) {
+        var trimmed = segments[i].trim();
+        if (trimmed !== '') numberParts.push(trimmed);
     }
 
-    /** Convert parsed 6-component result to decimal lat/lon. */
-    function toLatLon(r) {
-        var lat = r.latDeg + r.latMin / 60;
-        if (r.latHem === 'S') lat = -lat;
-        var lon = r.lonDeg + r.lonMin / 60;
-        if (r.lonHem === 'W') lon = -lon;
+    if (numberParts.length === 2) {
+        if (firstIsNS) {
+            return { lat: numberParts[0], lon: numberParts[1] };
+        } else {
+            return { lat: numberParts[1], lon: numberParts[0] };
+        }
+    }
+    return null;
+}
+
+function parseNumberPart(s) {
+    s = s.trim();
+
+    // DMS: deg° min' sec" (require ' between min and sec)
+    var dms = s.match(/^(\d{1,3})\s*°?\s*(\d{1,2})\s*['′]\s*(\d{1,2}(?:\.\d+)?)\s*["″]?\s*$/);
+    if (dms) {
+        return { deg: parseInt(dms[1], 10), min: parseInt(dms[2], 10) + parseFloat(dms[3]) / 60 };
+    }
+
+    // Decimal minutes: deg° min.mmm' (require ° or space between deg and min)
+    var dm = s.match(/^(\d{1,3})\s*[°\s]\s*(\d{1,2}(?:\.\d+)?)\s*['′]?\s*$/);
+    if (dm) {
+        return { deg: parseInt(dm[1], 10), min: parseFloat(dm[2]) };
+    }
+
+    // Decimal degrees: deg.ddddd
+    var dd = s.match(/^(\d{1,3}(?:\.\d+)?)\s*°?\s*$/);
+    if (dd) {
+        var total = parseFloat(dd[1]);
+        var d = Math.floor(total);
+        return { deg: d, min: (total - d) * 60 };
+    }
+
+    return null;
+}
+
+function parseDecimalDegrees(s) {
+    var m = s.match(/^([+-]?\d{1,3}(?:\.\d+)?)\s+([+-]?\d{1,3}(?:\.\d+)?)$/);
+    if (!m) return null;
+
+    var lat = parseFloat(m[1]);
+    var lon = parseFloat(m[2]);
+
+    return {
+        latHem: lat >= 0 ? 'N' : 'S', latDeg: Math.floor(Math.abs(lat)), latMin: (Math.abs(lat) - Math.floor(Math.abs(lat))) * 60,
+        lonHem: lon >= 0 ? 'E' : 'W', lonDeg: Math.floor(Math.abs(lon)), lonMin: (Math.abs(lon) - Math.floor(Math.abs(lon))) * 60
+    };
+}
+
+function validate(r) {
+    if (r.latDeg < 0 || r.latDeg > 90) return null;
+    if (r.lonDeg < 0 || r.lonDeg > 180) return null;
+    if (r.latMin < 0 || r.latMin >= 60) return null;
+    if (r.lonMin < 0 || r.lonMin >= 60) return null;
+    if (r.latDeg === 90 && r.latMin > 0) return null;
+    if (r.lonDeg === 180 && r.lonMin > 0) return null;
+    return r;
+}
+
+// ── DOM wiring ──────────────────────────────────────────────────
+
+function init() {
+    var unified   = document.getElementById('coord_unified');
+    var feedback  = document.getElementById('coord_feedback');
+    var toggle    = document.getElementById('coord_toggle');
+    var detail    = document.getElementById('coord_detail');
+    var singleSec = document.getElementById('coord_single');
+    var hiddenLat = document.getElementById('coord_lat');
+    var hiddenLon = document.getElementById('coord_lon');
+
+    if (!unified || !feedback || !toggle || !detail || !singleSec || !hiddenLat || !hiddenLon) return;
+
+    var latHemEl = document.getElementsByName('lat_hem')[0];
+    var latDegEl = document.getElementsByName('lat_deg')[0];
+    var latMinEl = document.getElementsByName('lat_min')[0];
+    var lonHemEl = document.getElementsByName('lon_hem')[0];
+    var lonDegEl = document.getElementsByName('lon_deg')[0];
+    var lonMinEl = document.getElementsByName('lon_min')[0];
+
+    if (!latHemEl || !latDegEl || !latMinEl || !lonHemEl || !lonDegEl || !lonMinEl) return;
+
+    var showing6 = false;
+    var label6 = toggle.getAttribute('data-label-6') || '6 fields';
+    var label1 = toggle.getAttribute('data-label-1') || '1 field';
+    var labelParseError = toggle.getAttribute('data-label-parse-error') || 'Could not parse coordinates';
+
+    /** Populate 6 legacy fields from lat/lon. */
+    function populateFields(lat, lon) {
+        var f = toFields(lat, lon);
+        latHemEl.value = f.latHem;
+        latDegEl.value = f.latDeg;
+        latMinEl.value = f.latMin;
+        lonHemEl.value = f.lonHem;
+        lonDegEl.value = f.lonDeg;
+        lonMinEl.value = f.lonMin;
+    }
+
+    /** Compute lat/lon from 6 legacy fields. */
+    function latLonFrom6Fields() {
+        var hem1 = latHemEl.value === 'N' ? 1 : -1;
+        var hem2 = lonHemEl.value === 'E' ? 1 : -1;
+        var lat = ((parseFloat(latDegEl.value) || 0) + (parseFloat(latMinEl.value) || 0) / 60) * hem1;
+        var lon = ((parseFloat(lonDegEl.value) || 0) + (parseFloat(lonMinEl.value) || 0) / 60) * hem2;
         return { latitude: lat, longitude: lon };
     }
 
-    /** Convert decimal lat/lon to 6-field values for legacy fields. */
-    function toFields(lat, lon) {
-        var latHem = lat >= 0 ? 'N' : 'S';
-        var lonHem = lon >= 0 ? 'E' : 'W';
-        lat = Math.abs(lat);
-        lon = Math.abs(lon);
-
-        var latDeg = Math.trunc(lat);
-        var lonDeg = Math.trunc(lon);
-
-        var latDegFrac = Number((lat - latDeg).toFixed(14));
-        var lonDegFrac = Number((lon - lonDeg).toFixed(14));
-
-        var latMin = 60 * latDegFrac;
-        var lonMin = 60 * lonDegFrac;
-
-        var latMinInt = Math.trunc(latMin);
-        var lonMinInt = Math.trunc(lonMin);
-
-        var latMinFrac = Number((latMin - latMinInt).toFixed(3));
-        var lonMinFrac = Number((lonMin - lonMinInt).toFixed(3));
-
-        if (latMinFrac === 1) {
-            latMinFrac = 0; latMinInt++;
-            if (latMinInt === 60) { latMinInt = 0; latDeg++; }
-        }
-        if (lonMinFrac === 1) {
-            lonMinFrac = 0; lonMinInt++;
-            if (lonMinInt === 60) { lonMinInt = 0; lonDeg++; }
-        }
-
-        return {
-            latHem: latHem, latDeg: latDeg,
-            latMin: pad(latMinInt, 2) + '.' + pad(1000 * latMinFrac, 3),
-            lonHem: lonHem, lonDeg: lonDeg,
-            lonMin: pad(lonMinInt, 2) + '.' + pad(1000 * lonMinFrac, 3)
-        };
+    function clearFields() {
+        latDegEl.value = '';
+        latMinEl.value = '';
+        lonDegEl.value = '';
+        lonMinEl.value = '';
     }
 
-    // ── parser ──────────────────────────────────────────────────────
-
-    /**
-     * Parse a coordinate string into its 6 components.
-     * Returns { latHem, latDeg, latMin, lonHem, lonDeg, lonMin } or null.
-     */
-    function parseCoordinates(raw) {
-        var s = normalize(raw);
-        if (s === '') return null;
-
-        var result;
-
-        result = parseWithHemispheres(s);
-        if (result) return validate(result);
-
-        result = parseDecimalDegrees(s);
-        if (result) return validate(result);
-
-        return null;
+    /** Handle input in the unified field. */
+    function onUnifiedInput() {
+        var val = unified.value.trim();
+        if (val === '') {
+            feedback.textContent = '';
+            feedback.style.color = '';
+            hiddenLat.value = '';
+            hiddenLon.value = '';
+            clearFields();
+            return;
+        }
+        var r = parseCoordinates(val);
+        if (r) {
+            var ll = toLatLon(r);
+            hiddenLat.value = ll.latitude;
+            hiddenLon.value = ll.longitude;
+            populateFields(ll.latitude, ll.longitude);
+            feedback.textContent = '\u2713 ' + coords2Dm(ll.latitude, ll.longitude);
+            feedback.style.color = '#060';
+        } else {
+            feedback.textContent = '\u2717 ' + labelParseError;
+            feedback.style.color = '#c00';
+            hiddenLat.value = '';
+            hiddenLon.value = '';
+            clearFields();
+        }
     }
 
-    function parseWithHemispheres(s) {
-        var hems = [];
-        var re = /[NSEW]/gi;
-        var m;
-        while ((m = re.exec(s)) !== null) {
-            hems.push({ letter: m[0].toUpperCase(), index: m.index });
-        }
-        if (hems.length !== 2) return null;
-
-        var ns = null, ew = null;
-        for (var i = 0; i < 2; i++) {
-            if (hems[i].letter === 'N' || hems[i].letter === 'S') {
-                if (ns !== null) return null;
-                ns = i;
-            } else {
-                if (ew !== null) return null;
-                ew = i;
-            }
-        }
-        if (ns === null || ew === null) return null;
-
-        var parts = splitByHemispheres(s, hems, ns, ew);
-        if (!parts) return null;
-
-        var lat = parseNumberPart(parts.lat);
-        var lon = parseNumberPart(parts.lon);
-        if (!lat || !lon) return null;
-
-        return {
-            latHem: hems[ns].letter, latDeg: lat.deg, latMin: lat.min,
-            lonHem: hems[ew].letter, lonDeg: lon.deg, lonMin: lon.min
-        };
-    }
-
-    function splitByHemispheres(s, hems, nsIdx, ewIdx) {
-        var first = hems[0], second = hems[1];
-        var firstIsNS = (nsIdx === 0);
-
-        var chars = s.split('');
-        chars[first.index] = '|';
-        chars[second.index] = '|';
-        var segments = chars.join('').split('|');
-        var numberParts = [];
-        for (var i = 0; i < segments.length; i++) {
-            var trimmed = segments[i].trim();
-            if (trimmed !== '') numberParts.push(trimmed);
-        }
-
-        if (numberParts.length === 2) {
-            if (firstIsNS) {
-                return { lat: numberParts[0], lon: numberParts[1] };
-            } else {
-                return { lat: numberParts[1], lon: numberParts[0] };
-            }
-        }
-        return null;
-    }
-
-    function parseNumberPart(s) {
-        s = s.trim();
-
-        // DMS: deg° min' sec" (require ' between min and sec)
-        var dms = s.match(/^(\d{1,3})\s*°?\s*(\d{1,2})\s*['′]\s*(\d{1,2}(?:\.\d+)?)\s*["″]?\s*$/);
-        if (dms) {
-            return { deg: parseInt(dms[1], 10), min: parseInt(dms[2], 10) + parseFloat(dms[3]) / 60 };
-        }
-
-        // Decimal minutes: deg° min.mmm' (require ° or space between deg and min)
-        var dm = s.match(/^(\d{1,3})\s*[°\s]\s*(\d{1,2}(?:\.\d+)?)\s*['′]?\s*$/);
-        if (dm) {
-            return { deg: parseInt(dm[1], 10), min: parseFloat(dm[2]) };
-        }
-
-        // Decimal degrees: deg.ddddd
-        var dd = s.match(/^(\d{1,3}(?:\.\d+)?)\s*°?\s*$/);
-        if (dd) {
-            var total = parseFloat(dd[1]);
-            var d = Math.floor(total);
-            return { deg: d, min: (total - d) * 60 };
-        }
-
-        return null;
-    }
-
-    function parseDecimalDegrees(s) {
-        var m = s.match(/^([+-]?\d{1,3}(?:\.\d+)?)\s+([+-]?\d{1,3}(?:\.\d+)?)$/);
-        if (!m) return null;
-
-        var lat = parseFloat(m[1]);
-        var lon = parseFloat(m[2]);
-
-        return {
-            latHem: lat >= 0 ? 'N' : 'S', latDeg: Math.floor(Math.abs(lat)), latMin: (Math.abs(lat) - Math.floor(Math.abs(lat))) * 60,
-            lonHem: lon >= 0 ? 'E' : 'W', lonDeg: Math.floor(Math.abs(lon)), lonMin: (Math.abs(lon) - Math.floor(Math.abs(lon))) * 60
-        };
-    }
-
-    function validate(r) {
-        if (r.latDeg < 0 || r.latDeg > 90) return null;
-        if (r.lonDeg < 0 || r.lonDeg > 180) return null;
-        if (r.latMin < 0 || r.latMin >= 60) return null;
-        if (r.lonMin < 0 || r.lonMin >= 60) return null;
-        if (r.latDeg === 90 && r.latMin > 0) return null;
-        if (r.lonDeg === 180 && r.lonMin > 0) return null;
-        return r;
-    }
-
-    // ── DOM wiring ──────────────────────────────────────────────────
-
-    function init() {
-        var unified   = document.getElementById('coord_unified');
-        var feedback  = document.getElementById('coord_feedback');
-        var toggle    = document.getElementById('coord_toggle');
-        var detail    = document.getElementById('coord_detail');
-        var singleSec = document.getElementById('coord_single');
-        var hiddenLat = document.getElementById('coord_lat');
-        var hiddenLon = document.getElementById('coord_lon');
-
-        if (!unified || !feedback || !toggle || !detail || !singleSec || !hiddenLat || !hiddenLon) return;
-
-        var latHemEl = document.getElementsByName('lat_hem')[0];
-        var latDegEl = document.getElementsByName('lat_deg')[0];
-        var latMinEl = document.getElementsByName('lat_min')[0];
-        var lonHemEl = document.getElementsByName('lon_hem')[0];
-        var lonDegEl = document.getElementsByName('lon_deg')[0];
-        var lonMinEl = document.getElementsByName('lon_min')[0];
-
-        if (!latHemEl || !latDegEl || !latMinEl || !lonHemEl || !lonDegEl || !lonMinEl) return;
-
-        var showing6 = false;
-        var label6 = toggle.getAttribute('data-label-6') || '6 fields';
-        var label1 = toggle.getAttribute('data-label-1') || '1 field';
-        var labelParseError = toggle.getAttribute('data-label-parse-error') || 'Could not parse coordinates';
-
-        /** Populate 6 legacy fields from lat/lon. */
-        function populateFields(lat, lon) {
-            var f = toFields(lat, lon);
-            latHemEl.value = f.latHem;
-            latDegEl.value = f.latDeg;
-            latMinEl.value = f.latMin;
-            lonHemEl.value = f.lonHem;
-            lonDegEl.value = f.lonDeg;
-            lonMinEl.value = f.lonMin;
-        }
-
-        /** Compute lat/lon from 6 legacy fields. */
-        function latLonFrom6Fields() {
-            var hem1 = latHemEl.value === 'N' ? 1 : -1;
-            var hem2 = lonHemEl.value === 'E' ? 1 : -1;
-            var lat = ((parseFloat(latDegEl.value) || 0) + (parseFloat(latMinEl.value) || 0) / 60) * hem1;
-            var lon = ((parseFloat(lonDegEl.value) || 0) + (parseFloat(lonMinEl.value) || 0) / 60) * hem2;
-            return { latitude: lat, longitude: lon };
-        }
-
-        function clearFields() {
-            latDegEl.value = '';
-            latMinEl.value = '';
-            lonDegEl.value = '';
-            lonMinEl.value = '';
-        }
-
-        /** Handle input in the unified field. */
-        function onUnifiedInput() {
-            var val = unified.value.trim();
-            if (val === '') {
-                feedback.textContent = '';
-                feedback.style.color = '';
-                hiddenLat.value = '';
-                hiddenLon.value = '';
-                clearFields();
-                return;
-            }
-            var r = parseCoordinates(val);
-            if (r) {
-                var ll = toLatLon(r);
-                hiddenLat.value = ll.latitude;
-                hiddenLon.value = ll.longitude;
-                populateFields(ll.latitude, ll.longitude);
+    /** Switch between unified and 6-field modes. */
+    function toggleMode(e) {
+        if (e) e.preventDefault();
+        showing6 = !showing6;
+        try { localStorage.setItem('oc_coord_6fields', showing6 ? '1' : '0'); } catch (ex) {}
+        if (showing6) {
+            singleSec.style.display = 'none';
+            detail.style.display = '';
+            toggle.textContent = label1 + ' \u25B4';
+        } else {
+            detail.style.display = 'none';
+            singleSec.style.display = '';
+            toggle.textContent = label6 + ' \u25BE';
+            var ll = latLonFrom6Fields();
+            hiddenLat.value = ll.latitude;
+            hiddenLon.value = ll.longitude;
+            if (ll.latitude !== 0 || ll.longitude !== 0) {
+                unified.value = coords2Dm(ll.latitude, ll.longitude);
                 feedback.textContent = '\u2713 ' + coords2Dm(ll.latitude, ll.longitude);
                 feedback.style.color = '#060';
             } else {
-                feedback.textContent = '\u2717 ' + labelParseError;
-                feedback.style.color = '#c00';
-                hiddenLat.value = '';
-                hiddenLon.value = '';
-                clearFields();
+                unified.value = '';
+                feedback.textContent = '';
+                feedback.style.color = '';
             }
-        }
-
-        /** Switch between unified and 6-field modes. */
-        function toggleMode(e) {
-            if (e) e.preventDefault();
-            showing6 = !showing6;
-            try { localStorage.setItem('oc_coord_6fields', showing6 ? '1' : '0'); } catch (ex) {}
-            if (showing6) {
-                singleSec.style.display = 'none';
-                detail.style.display = '';
-                toggle.textContent = label1 + ' \u25B4';
-            } else {
-                detail.style.display = 'none';
-                singleSec.style.display = '';
-                toggle.textContent = label6 + ' \u25BE';
-                var ll = latLonFrom6Fields();
-                hiddenLat.value = ll.latitude;
-                hiddenLon.value = ll.longitude;
-                if (ll.latitude !== 0 || ll.longitude !== 0) {
-                    unified.value = coords2Dm(ll.latitude, ll.longitude);
-                    feedback.textContent = '\u2713 ' + coords2Dm(ll.latitude, ll.longitude);
-                    feedback.style.color = '#060';
-                } else {
-                    unified.value = '';
-                    feedback.textContent = '';
-                    feedback.style.color = '';
-                }
-            }
-        }
-
-        // Wire events
-        unified.addEventListener('input', onUnifiedInput);
-        toggle.addEventListener('click', toggleMode);
-
-        // Initial state: show unified, hide 6-field, reveal toggle
-        singleSec.style.display = '';
-        detail.style.display = 'none';
-        toggle.style.display = '';
-        toggle.textContent = label6 + ' \u25BE';
-
-        // Restore user's preferred mode
-        try {
-            if (localStorage.getItem('oc_coord_6fields') === '1') {
-                toggleMode(null);
-            }
-        } catch (ex) {}
-
-        // Populate unified field from stored lat/lon
-        var storedLat = parseFloat(hiddenLat.value);
-        var storedLon = parseFloat(hiddenLon.value);
-        if (!isNaN(storedLat) && !isNaN(storedLon) && (storedLat !== 0 || storedLon !== 0)) {
-            unified.value = coords2Dm(storedLat, storedLon);
-            populateFields(storedLat, storedLon);
-            feedback.textContent = '\u2713 ' + coords2Dm(storedLat, storedLon);
-            feedback.style.color = '#060';
         }
     }
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', init);
-    } else {
-        init();
-    }
+    // Wire events
+    unified.addEventListener('input', onUnifiedInput);
+    toggle.addEventListener('click', toggleMode);
 
-})();
+    // Initial state: show unified, hide 6-field, reveal toggle
+    singleSec.style.display = '';
+    detail.style.display = 'none';
+    toggle.style.display = '';
+    toggle.textContent = label6 + ' \u25BE';
+
+    // Restore user's preferred mode
+    try {
+        if (localStorage.getItem('oc_coord_6fields') === '1') {
+            toggleMode(null);
+        }
+    } catch (ex) {}
+
+    // Populate unified field from stored lat/lon
+    var storedLat = parseFloat(hiddenLat.value);
+    var storedLon = parseFloat(hiddenLon.value);
+    if (!isNaN(storedLat) && !isNaN(storedLon) && (storedLat !== 0 || storedLon !== 0)) {
+        unified.value = coords2Dm(storedLat, storedLon);
+        populateFields(storedLat, storedLon);
+        feedback.textContent = '\u2713 ' + coords2Dm(storedLat, storedLon);
+        feedback.style.color = '#060';
+    }
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+} else {
+    init();
+}

--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -387,15 +387,22 @@ if ($queryid != 0) {
         $options['searchtype'] = 'bycoords';
 
         // Ocprop: all of the following options
-        if (isset($_REQUEST['lat']) && isset($_REQUEST['lon'])) {
+        if (isset($_REQUEST['latitude']) && isset($_REQUEST['longitude'])
+            && $_REQUEST['latitude'] !== '' && $_REQUEST['longitude'] !== ''
+        ) {
+            // unified coordinate input (hidden fields from coord_input.js)
+            $options['lat'] = $_REQUEST['latitude'] + 0;
+            $options['lon'] = $_REQUEST['longitude'] + 0;
+        } elseif (isset($_REQUEST['lat']) && isset($_REQUEST['lon'])) {
             $options['lat'] = $_REQUEST['lat'] + 0;
             $options['lon'] = $_REQUEST['lon'] + 0;
         } else {
-            $options['latNS'] = isset($_REQUEST['latNS']) ? $_REQUEST['latNS'] : 'N';
-            $options['lonEW'] = isset($_REQUEST['lonEW']) ? $_REQUEST['lonEW'] : 'E';
+            // 6-field mode: accept both new names (coordinate_input.tpl) and legacy names
+            $options['latNS'] = $_REQUEST['lat_hem'] ?? $_REQUEST['latNS'] ?? 'N';
+            $options['lonEW'] = $_REQUEST['lon_hem'] ?? $_REQUEST['lonEW'] ?? 'E';
 
-            $options['lat_h'] = isset($_REQUEST['lat_h']) ? $_REQUEST['lat_h'] : 0;
-            $options['lon_h'] = isset($_REQUEST['lon_h']) ? $_REQUEST['lon_h'] : 0;
+            $options['lat_h'] = $_REQUEST['lat_deg'] ?? $_REQUEST['lat_h'] ?? 0;
+            $options['lon_h'] = $_REQUEST['lon_deg'] ?? $_REQUEST['lon_h'] ?? 0;
             $options['lat_min'] = isset($_REQUEST['lat_min']) ? $_REQUEST['lat_min'] : 0;
             $options['lon_min'] = isset($_REQUEST['lon_min']) ? $_REQUEST['lon_min'] : 0;
         }
@@ -1813,82 +1820,58 @@ function outputSearchForm($options)
         isset($options['waypoint']) ? htmlspecialchars($options['waypoint'], ENT_COMPAT, 'UTF-8') : ''
     );
 
-    // ... from coords
-    if (!isset($options['lat_h'])) {
-        if ($login->logged_in()) {
-            $rs = sql(
-                "SELECT `latitude`, `longitude`
-                 FROM `user`
-                 WHERE `user_id`='" . sql_escape($login->userid) . "'"
-            );
-            $record = sql_fetch_array($rs);
-            $lon = $record['longitude'];
-            $lat = $record['latitude'];
-            sql_free_result($rs);
-
-            $tpl->assign('lonE_sel', $lon >= 0);
-            $tpl->assign('lonW_sel', $lon < 0);
-            $tpl->assign('latN_sel', $lat >= 0);
-            $tpl->assign('latS_sel', $lat < 0);
-
-            $lon_h = floor($lon);
-            $lat_h = floor($lat);
-
-            $lon_min = ($lon - $lon_h) * 60;
-            $lat_min = ($lat - $lat_h) * 60;
-
-            if ($lat < 0 && $lat_h < 0) {
-                $lat_min = 60 - $lat_min;
-            }
-            if ($lon < 0 && $lon_h < 0) {
-                $lon_min = 60 - $lon_min;
-            }
-
-            $tpl->assign('lat_min', sprintf('%02.3f', $lat_min));
-            $tpl->assign('lon_min', sprintf('%02.3f', $lon_min));
-
-            if ($lat < 0 && $lat_h < 0) {
-                $lat_h = - $lat_h;
-                if ($lat_min != 0) {
-                    $lat_h = $lat_h - 1;
-                }
-            }
-            if ($lon < 0 && $lon_h < 0) {
-                $lon_h = - $lon_h;
-                if ($lon_min != 0) {
-                    $lon_h = $lon_h - 1;
-                }
-            }
-            $tpl->assign('lat_h', $lat_h);
-            $tpl->assign('lon_h', $lon_h);
-        } else {
-            $tpl->assign('lat_h', '00');
-            $tpl->assign('lon_h', '000');
-            $tpl->assign('lat_min', '00.000');
-            $tpl->assign('lon_min', '00.000');
+    // ... from coords — assign variables for coordinate_input.tpl
+    if (isset($options['lat']) && isset($options['lon'])) {
+        // decimal lat/lon available (from unified input or direct params)
+        $lat = $options['lat'] + 0;
+        $lon = $options['lon'] + 0;
+    } elseif (isset($options['lat_h'])) {
+        // 6-field values submitted — reconstruct decimal
+        $lat_h = $options['lat_h'] + 0;
+        $lon_h = $options['lon_h'] + 0;
+        $lat_min_val = $options['lat_min'] + 0;
+        $lon_min_val = $options['lon_min'] + 0;
+        $lat = $lat_h + $lat_min_val / 60;
+        $lon = $lon_h + $lon_min_val / 60;
+        if (isset($options['latNS']) && $options['latNS'] == 'S') {
+            $lat = -$lat;
         }
+        if (isset($options['lonEW']) && $options['lonEW'] == 'W') {
+            $lon = -$lon;
+        }
+    } elseif ($login->logged_in()) {
+        // default: user's home coordinates
+        $rs = sql(
+            "SELECT `latitude`, `longitude`
+             FROM `user`
+             WHERE `user_id`='" . sql_escape($login->userid) . "'"
+        );
+        $record = sql_fetch_array($rs);
+        $lon = $record['longitude'] + 0;
+        $lat = $record['latitude'] + 0;
+        sql_free_result($rs);
     } else {
-        $tpl->assign('lat_h', isset($options['lat_h']) ? htmlspecialchars($options['lat_h']) : '00');
-        $tpl->assign('lon_h', isset($options['lon_h']) ? htmlspecialchars($options['lon_h']) : '000');
-        $tpl->assign('lat_min', isset($options['lat_min']) ? htmlspecialchars($options['lat_min']) : '00.000');
-        $tpl->assign('lon_min', isset($options['lon_min']) ? htmlspecialchars($options['lon_min']) : '00.000');
-
-        if ($options['lonEW'] == 'W') {
-            $tpl->assign('lonE_sel', '');
-            $tpl->assign('lonW_sel', 'selected="selected"');
-        } else {
-            $tpl->assign('lonE_sel', 'selected="selected"');
-            $tpl->assign('lonW_sel', '');
-        }
-
-        if ($options['latNS'] == 'S') {
-            $tpl->assign('latS_sel', 'selected="selected"');
-            $tpl->assign('latN_sel', '');
-        } else {
-            $tpl->assign('latS_sel', '');
-            $tpl->assign('latN_sel', 'selected="selected"');
-        }
+        $lat = 0;
+        $lon = 0;
     }
+
+    // Convert decimal lat/lon to 6-field values for coordinate_input.tpl
+    $tpl->assign('coord_latitude', $lat);
+    $tpl->assign('coord_longitude', $lon);
+    $tpl->assign('lat_hem', $lat >= 0 ? 'N' : 'S');
+    $tpl->assign('lon_hem', $lon >= 0 ? 'E' : 'W');
+
+    $absLat = abs($lat);
+    $absLon = abs($lon);
+    $lat_deg = floor($absLat);
+    $lon_deg = floor($absLon);
+    $lat_min = ($absLat - $lat_deg) * 60;
+    $lon_min = ($absLon - $lon_deg) * 60;
+
+    $tpl->assign('lat_deg', $lat_deg);
+    $tpl->assign('lon_deg', $lon_deg);
+    $tpl->assign('lat_min', sprintf('%02.3f', $lat_min));
+    $tpl->assign('lon_min', sprintf('%02.3f', $lon_min));
 
     $dfromortplz_checked = in_array($options['searchtype'], ['byplz', 'byort']);
     $dfromwaypoint_checked = ($options['searchtype'] == 'bywaypoint');

--- a/htdocs/src/Oc/Libse/Coordinate/PresenterCoordinate.php
+++ b/htdocs/src/Oc/Libse/Coordinate/PresenterCoordinate.php
@@ -108,6 +108,8 @@ class PresenterCoordinate
         $template->assign(self::lon_hem, $formatter->formatLonHem($coordinate));
         $template->assign(self::lon_deg, $formatter->formatLonDeg($coordinate));
         $template->assign(self::lon_min, $formatter->formatLonMin($coordinate));
+        $template->assign('coord_latitude', $coordinate->latitude());
+        $template->assign('coord_longitude', $coordinate->longitude());
 
         if (!$this->valid) {
             $template->assign(self::coord_error, $this->translator->translate('Invalid coordinate'));

--- a/htdocs/templates2/ocstyle/coordinate_input.tpl
+++ b/htdocs/templates2/ocstyle/coordinate_input.tpl
@@ -53,3 +53,4 @@
    data-label-6="{t escape=js}6 fields{/t}"
    data-label-1="{t escape=js}1 field{/t}"
    data-label-parse-error="{t escape=js}Could not parse coordinates{/t}"></a>
+<script type="module" src="resource2/ocstyle/js/coord_input.js"></script>

--- a/htdocs/templates2/ocstyle/newcache.tpl
+++ b/htdocs/templates2/ocstyle/newcache.tpl
@@ -1,0 +1,380 @@
+{***************************************************************************
+* You can find the license in the docs directory
+*
+*  submit a new cache
+***************************************************************************}
+
+<script type="text/javascript" src="resource2/ocstyle/js/wz_tooltip.js"></script>
+<script type="text/javascript">
+<!--
+var maAttributes = new Array({$jsattributes_array});
+
+{literal}
+function _chkVirtual () {
+  if (document.editform.type.value == "4" || document.editform.type.value == "5") {
+    document.editform.size.value = "7";
+    document.editform.size.disabled = true;
+  }
+  else
+  {
+    document.editform.size.disabled = false;
+  }
+  return false;
+}
+
+function rebuildCacheAttr()
+{
+    var i = 0;
+    var sAttr = '';
+
+    for (i = 0; i < maAttributes.length; i++)
+    {
+        if (maAttributes[i][1] == 1)
+        {
+            if (sAttr != '') sAttr += ';';
+            sAttr = sAttr + maAttributes[i][0];
+
+            document.getElementById('attr' + maAttributes[i][0]).src = maAttributes[i][3];
+        }
+        else
+            document.getElementById('attr' + maAttributes[i][0]).src = maAttributes[i][2];
+
+        document.getElementById('cache_attribs').value = sAttr;
+
+    }
+}
+
+function toggleAttr(id)
+{
+    var i = 0;
+
+    for (i = 0; i < maAttributes.length; i++)
+    {
+        if (maAttributes[i][0] == id)
+        {
+            if (maAttributes[i][1] == 0) {
+                maAttributes[i][1] = 1;
+                for (a = 0; a < maAttributes[i][4].length; a++)
+                    for (n = 0; n < maAttributes.length; n++)
+                        if (maAttributes[n][0] == maAttributes[i][4][a]) {
+                            maAttributes[n][1] = 0;
+                            break;
+                        }
+            }
+            else
+                maAttributes[i][1] = 0;
+
+            rebuildCacheAttr();
+            break;
+        }
+    }
+}
+//-->
+{/literal}
+</script>
+
+<div class="content2-pagetitle">
+    <img src="resource2/ocstyle/images/misc/32x32-add-cache.png" style="margin-right: 10px;" width="32" height="32" alt="" />
+    {t}Submit a new cache{/t}
+</div>
+
+<form action="newcache.php" method="post" enctype="application/x-www-form-urlencoded" name="editform" dir="ltr">
+<input type="hidden" name="show_all_countries" value="{$show_all_countries}"/>
+<input type="hidden" name="show_all_langs" value="{$show_all_langs}"/>
+<input type="hidden" name="version2" value="1"/>
+<input type="hidden" id="cache_attribs" name="cache_attribs" value="{$cache_attribs}" />
+<input id="descMode" type="hidden" name="descMode" value="1" />
+<input id="oldDescMode" type="hidden" name="oldDescMode" value="1" />
+<input type="hidden" name="scrollposx" value="{$scrollposx}" />
+<input type="hidden" name="scrollposy" value="{$scrollposy}" />
+<table class="table">
+    {if $general_error}
+    {$general_error}
+    {/if}
+    <tr><td class="spacer" colspan="2"></td></tr>
+    <tr>
+        <td class="help" colspan="2">
+            <img src="resource2/ocstyle/images/misc/hint.gif" border="0" width="15" height="11" alt="{t}Notice{/t}" title="{t}Notice{/t}" />
+            {$firstcache_note}
+        </td>
+    </tr>
+    <tr><td class="spacer" colspan="2"></td></tr>
+    <tr>
+        <td>{t}Name:{/t}</td>
+        <td><input type="text" name="name" value="{$name}" maxlength="60" class="input400" />{$name_message}</td>
+    </tr>
+    <tr><td class="spacer" colspan="2"></td></tr>
+    <tr>
+        <td>{t}Cachetype:{/t}</td>
+        <td>
+            <select name="type" class="input200" onChange="return _chkVirtual()">
+                {foreach from=$type_options item=item}
+                    <option value="{$item.value}" {if $item.selected}selected="selected"{/if}>{$item.label|escape}</option>
+                {/foreach}
+            </select>{$type_message}
+        </td>
+    </tr>
+    <tr>
+        <td>{t}Size:{/t}</td>
+        <td>
+            <select name="size" class="input200" onChange="return _chkVirtual()">
+                {foreach from=$size_options item=item}
+                    <option value="{$item.value}" {if $item.selected}selected="selected"{/if}>{$item.label|escape}</option>
+                {/foreach}
+            </select>{$size_message}
+        </td>
+    </tr>
+    <tr><td class="spacer" colspan="2"></td></tr>
+    <tr>
+        <td valign="top">{t}Coordinates:{/t}</td>
+        <td>
+            {include file='coordinate_input.tpl'}
+        </td>
+    </tr>
+    <tr><td class="spacer" colspan="2"></td></tr>
+    <tr>
+        <td>{t}Country:{/t}</td>
+        <td>
+            <select name="country" class="input200">
+                {foreach from=$country_options item=item}
+                    <option value="{$item.value|escape}" {if $item.selected}selected="selected"{/if}>{$item.label|escape}</option>
+                {/foreach}
+            </select>
+            &nbsp;{$show_all_countries_submit}
+        </td>
+    </tr>
+    <tr><td class="spacer" colspan="2"></td></tr>
+    <tr><td>{t}Rating:{/t}</td>
+        <td>
+            {t}Difficulty:{/t}
+            <select name="difficulty" class="input60">
+                {foreach from=$difficulty_options item=item}
+                    <option value="{$item.value}" {if $item.selected}selected="selected"{/if}>{$item.label}</option>
+                {/foreach}
+            </select>&nbsp;&nbsp;
+            {t}Terrain:{/t}
+            <select name="terrain" class="input60">
+                {foreach from=$terrain_options item=item}
+                    <option value="{$item.value}" {if $item.selected}selected="selected"{/if}>{$item.label}</option>
+                {/foreach}
+            </select> {$diff_message}
+        </td>
+    </tr>
+    <tr><td>{t}Time and effort (optional):{/t}</td>
+      <td>
+            {t}Time effort:{/t}
+      <input type="text" name="search_time" maxLength="10" value="{$search_time}" class="input30" /> {t}h{/t}
+            &nbsp;&nbsp;
+            {t}Distance:{/t}
+            <input type="text" name="way_length" maxlength="10" value="{$way_length}" class="input30" /> {t}km{/t} &nbsp; {$effort_message}
+      </td>
+    </tr>
+    <tr>
+        <td>&nbsp;</td>
+        <td class="help"><img src="resource2/ocstyle/images/misc/hint.gif" border="0" width="15" height="11" alt="{t}Notice{/t}" title="{t}Notice{/t}" />
+            {t}The effort is of course only be estimated and can vary depending on environmental influences.
+                 If you can not make sufficiently detailed information, write 0 (zero) in both fields.
+                 (See also: <a href="articles.php?page=cacheinfo#time" target="_blank">description</a>){/t}
+        </td>
+    </tr>
+
+    <tr>
+        <td>{t}Waypoints:{/t}</td>
+        <!-- allow wp_gc copy&paste with leading spaces; will be trimmed later -->
+        <td>geocaching.com: <input type="text" name="wp_gc" value="{$wp_gc}" maxlength="12" class="input70w waypoint" />
+            {$wpgc_message}
+        </td>
+    </tr>
+    <tr>
+        <td>&nbsp;</td>
+        <td class="help"><img src="resource2/ocstyle/images/misc/hint.gif" border="0" width="15" height="11" alt="{t}Notice{/t}" title="{t}Notice{/t}" />
+            {t}If the cache was published at another geocaching website, enter the corresponding waypoint here.{/t} <u>{t}Important:{/t}</u> {t}The geocache description at Opencaching must be kept up to date! Description changes on other websites must be applied to the Opencaching listing timely.{/t}<br />
+        </td>
+    </tr>
+    <tr><td class="spacer" colspan="2">&nbsp;</td></tr>
+    <tr>
+        <td class="header-small" colspan="2">
+            <div class="content2-container bg-blue02">
+                <p class="content-title-noshade-size2">
+                    <img src="resource2/ocstyle/images/description/22x22-tools.png" width="22" height="22" align="middle" border="0" />
+                    {t}Cache attributes{/t}&nbsp;&nbsp;
+                </p>
+            </div>
+        </td>
+    </tr>
+    <tr>
+        <td colspan="2">{$cache_attrib_list}{$safari_message}</td>
+    </tr>
+    <tr><td class="spacer" colspan="2">&nbsp;</td></tr>
+    <tr>
+        <td class="header-small" colspan="2">
+            <div class="content2-container bg-blue02">
+                <p class="content-title-noshade-size2">
+                    <img src="resource2/ocstyle/images/description/22x22-description.png" width="22" height="22" align="middle" border="0" />
+                    {t}Description{/t}
+                </p>
+            </div>
+        </td>
+    </tr>
+    <tr><td class="spacer" colspan="2"></td></tr>
+    <tr>
+        <td>{t}Language:{/t}</td>
+        <td>
+            <select name="desc_lang" class="input200">
+                {foreach from=$lang_options item=item}
+                    <option value="{$item.value|escape}" {if $item.selected}selected="selected"{/if}>{$item.label|escape}</option>
+                {/foreach}
+            </select>
+            {$show_all_langs_submit}
+        </td>
+    </tr>
+    <tr>
+      <td class="help" colspan="2">
+            <img src="resource2/ocstyle/images/misc/hint.gif" border="0" width="15" height="11" alt="{t}Notice{/t}" title="{t}Notice{/t}" />
+          {t}You can add more descriptions in other languages publishing the cache.{/t}
+        </td>
+    </tr>
+    <tr><td class="spacer" colspan="2"></td></tr>
+    <tr>
+        <td>{t}Short description:{/t}</td>
+        <td><input type="text" name="short_desc" maxlength="120" value="{$short_desc}" class="input400"/></td>
+    </tr>
+
+    <tr><td class="spacer" colspan="2"></td></tr>
+    <tr>
+        <td colspan="2">{t}Description:{/t} {$desc_message}</td>
+    </tr>
+    <tr>
+        <td colspan="2">
+            <div class="menuBar">
+                <span id="descHtmlEdit" class="buttonNormal" onclick="btnSelect(3)" onmouseover="btnMouseOver(3)" onmouseout="btnMouseOut(3)">{t}Editor{/t}</span>
+                <span class="buttonSplitter">|</span>
+                <span id="descHtml" class="buttonNormal" onclick="btnSelect(2)" onmouseover="btnMouseOver(2)" onmouseout="btnMouseOut(2)">{t}&lt;html&gt;{/t}</span>
+            </div>
+        </td>
+    </tr>
+    <tr>
+        <td colspan="2">
+            <span id="scriptwarning" class="errormsg">{t}JavaScript is disabled in your browser, you can enter text only. To use HTML, or the editor, please enable JavaScript.{/t}</span>
+        </td>
+    </tr>
+    <tr>
+        <td colspan="2">
+            <textarea id="desc" name="desc" class="cachedesc">{$desc}</textarea>
+        </td>
+    </tr>
+    {if $show_htmlnotice}
+    <tr><td class="spacer" colspan="2"></td></tr>
+    <tr>
+        <td class="help" colspan="2">
+            <img src="resource2/ocstyle/images/misc/hint.gif" border="0" width="15" height="11" alt="{t}Notice{/t}" title="{t}Notice{/t}" />
+            {t}Your HTML code will be changed again by a special filter. This is necessary to avoid dangerous HTML-tags,
+                 such as &lt;script&gt;. A list of allowed HTML tags, you can find
+                 <a href="articles.php?page=htmltags">here</a>{/t}
+        </td>
+    </tr>
+    {/if}
+    <tr><td class="spacer" colspan="2"></td></tr>
+    <tr>
+        <td colspan="2">{t}Additional note, will be shown encrypted:{/t}</td>
+    </tr>
+    <tr>
+        <td colspan="2">
+            <textarea name="hints" class="hint mceNoEditor">{$hints}</textarea>
+        </td>
+    </tr>
+
+    <tr><td class="spacer" colspan="2">&nbsp;</td></tr>
+    <tr>
+        <td class="header-small" colspan="2">
+            <div class="content2-container bg-blue02">
+                <p class="content-title-noshade-size2">
+                    <img src="resource2/ocstyle/images/description/22x22-misc.png" width="22" height="22" align="middle" border="0" />
+                    {t}Others{/t}
+                </p>
+            </div>
+        </td>
+    </tr>
+    <tr>
+        <td class="help" colspan="2">
+            <img src="resource2/ocstyle/images/misc/hint.gif" border="0" width="15" height="11" alt="{t}Notice{/t}" title="{t}Notice{/t}" />
+            {t}You can add additional pictures after creating the cache.{/t}
+        </td>
+    </tr>
+    <tr><td class="spacer" colspan="2"></td></tr>
+    <tr>
+        <td class="strong">{t}Hidden since:{/t}</td>
+        <td>
+            <input class="input20" type="text" name="hidden_day" maxlength="2" value="{$hidden_day}"/>.
+            <input class="input20" type="text" name="hidden_month" maxlength="2" value="{$hidden_month}"/>.
+            <input class="input40" type="text" name="hidden_year" maxlength="4" value="{$hidden_year}"/>
+            {$hidden_since_message}
+        </td>
+    </tr>
+    <tr>
+        <td>&nbsp;</td>
+        <td class="help">
+            <img src="resource2/ocstyle/images/misc/hint.gif" border="0" width="15" height="11" alt="{t}Notice{/t}" title="{t}Notice{/t}" />
+            {t}For Events: The date of event!{/t}
+        </td>
+    </tr>
+
+    <tr><td class="spacer" colspan="2"></td></tr>
+
+    <tr>
+        <td class="strong">{t}Publication:{/t}</td>
+        <td class="aligned space">
+            <input type="radio" class="radio" name="publish" id="publish_now" value="now2" {$publish_now_checked} />&nbsp;<label for="publish_now">{t}Publish now{/t}</label><br />
+            <input type="radio" class="radio" name="publish" id="publish_later" value="later" {$publish_later_checked} />&nbsp;<label for="publish_later">{t}Publish on{/t}</label>&nbsp;
+            <input class="input20" type="text" name="activate_day" maxlength="2" value="{$activate_day}"/>.
+            <input class="input20" type="text" name="activate_month" maxlength="2" value="{$activate_month}"/>.
+            <input class="input40" type="text" name="activate_year" maxlength="4" value="{$activate_year}"/>&nbsp;
+            <select name="activate_hour" class="input60">
+                {foreach from=$activation_hours item=item}
+                    <option value="{$item.value}" {if $item.selected}selected="selected"{/if}>{$item.label}</option>
+                {/foreach}
+            </select>&nbsp;{t}#time_suffix_label#{/t}&nbsp;{$activate_on_message}<br />
+            <input type="radio" class="radio" name="publish" id="publish_notnow" value="notnow" {$publish_notnow_checked} />&nbsp;<label for="publish_notnow">{t}Do not publish now.{/t}</label>
+        </td>
+    </tr>
+
+    <tr><td class="spacer" colspan="2"></td></tr>
+    <tr>
+        <td><nobr>{t}Password for 'found' logs:{/t}</nobr></td>
+        <td><input class="input100" type="text" name="log_pw" value="{$log_pw}" maxlength="20"/> &nbsp; {t}(leave blank for no password){/t}</td>
+    </tr>
+    <tr>
+        <td>&nbsp;</td>
+        <td class="help">
+            <img src="resource2/ocstyle/images/misc/hint.gif" border="0" width="15" height="11" alt="{t}Notice{/t}" title="{t}Notice{/t}" />
+            {t}Please note the <a href="articles.php?page=cacheinfo#logpw" target="_blank">description</a>{/t}
+        </td>
+    </tr>
+
+    <tr><td class="spacer" colspan="2"></td></tr>
+    <tr>
+        <td colspan="2" class="aligned">
+            <input class="checkbox" type="checkbox" name="TOS" value="1"{$toschecked}/>
+            {t}I have read and agree to the <a href="articles.php?page=impressum#tos" target="_blank">Opencaching.de Terms of Service</a> and the <a href="articles.php?page=impressum#datalicense" target="_blank">Opencaching.de Datalicense</a>{/t}
+            {$tos_message}
+        </td>
+    </tr>
+    <tr><td class="spacer" colspan="2"></td></tr>
+    <tr><td class="spacer" colspan="2"></td></tr>
+    <tr>
+        <td class="header-small" colspan="2">
+        <!-- <input type="reset" name="reset" value="{$reset}" class="formbutton" onclick="flashbutton('reset')" />&nbsp;&nbsp; -->
+        <input type="submit" name="submitform" value="{$submit}" class="formbutton" onclick="submitbutton('submitform') "/>
+        </td>
+    </tr>
+    <tr><td class="spacer"></td></tr>
+</table>
+</form>
+
+
+<script type="text/javascript">
+<!--
+    var descMode = {$descMode};
+    OcInitEditor();
+//-->
+</script>

--- a/htdocs/templates2/ocstyle/search.tpl
+++ b/htdocs/templates2/ocstyle/search.tpl
@@ -199,15 +199,21 @@ function _sbd_click(submitType)
         }
     }
 
-    if (isNaN(document.searchbydistance.lon_h.value) || isNaN(document.searchbydistance.lon_min.value) || document.searchbydistance.lon_h.value == "" || document.searchbydistance.lon_min.value == "") {
-        alert("{/literal}{t}Longitude must be a number!\nFormat: hh° mm.mmm{/t}{literal}");
-        resetbutton('submit_dist');
-        return false;
-    }
-    if (isNaN(document.searchbydistance.lat_h.value) || isNaN(document.searchbydistance.lat_min.value) || document.searchbydistance.lat_h.value == "" || document.searchbydistance.lat_min.value == "") {
-        alert("{/literal}{t}Latitude must be a number!\nFormat: hh° mm.mmm{/t}{literal}");
-        resetbutton('submit_dist');
-        return false;
+    var coordLat = document.getElementById('coord_lat');
+    var coordLon = document.getElementById('coord_lon');
+    if (coordLat && coordLon && coordLat.value !== '' && coordLon.value !== '') {
+        // unified input has valid parsed coordinates — skip 6-field check
+    } else {
+        if (isNaN(document.searchbydistance.lon_deg.value) || isNaN(document.searchbydistance.lon_min.value) || document.searchbydistance.lon_deg.value == "" || document.searchbydistance.lon_min.value == "") {
+            alert("{/literal}{t}Longitude must be a number!\nFormat: hh° mm.mmm{/t}{literal}");
+            resetbutton('submit_dist');
+            return false;
+        }
+        if (isNaN(document.searchbydistance.lat_deg.value) || isNaN(document.searchbydistance.lat_min.value) || document.searchbydistance.lat_deg.value == "" || document.searchbydistance.lat_min.value == "") {
+            alert("{/literal}{t}Latitude must be a number!\nFormat: hh° mm.mmm{/t}{literal}");
+            resetbutton('submit_dist');
+            return false;
+        }
     }
 
     return true;
@@ -721,23 +727,21 @@ function switchAttributeCat2()
         </tr>
         <tr class="search_bydistance">
             <td valign="top"><input type="radio" tabindex="6" id="sbcoords" name="searchto" value="searchbycoords" {if $dfromcoords_checked}checked="checked"{/if}><label for="sbcoords">... {t}from coordinates:{/t}</label></td>
-            <td valign="top">
-                <select tabindex="7" name="latNS" onfocus="bydistance_set_radiobutton(2)">
-                    <option value="N" {if $latN_sel}selected="selected"{/if}>{t}N{/t}</option>
-                    <option value="S" {if $latS_sel}selected="selected"{/if}>{t}S{/t}</option>
-                </select>&nbsp;
-                <input type="text" tabindex="8" name="lat_h" maxlength="2" value="{$lat_h}" class="input30" onfocus="bydistance_set_radiobutton(2)"/>&nbsp;°&nbsp;
-                <input type="text" tabindex="9" name="lat_min" maxlength="6" value="{$lat_min}" class="input50" onfocus="bydistance_set_radiobutton(2)"/>&nbsp;'&nbsp;
-                <br />
-                <select tabindex="10" name="lonEW" onfocus="bydistance_set_radiobutton(2)">
-                    <option value="E" {if $lonE_sel}selected="selected"{/if}>{t}E{/t}</option>
-                    <option value="W" {if $lonW_sel}selected="selected"{/if}>{t}W{/t}</option>
-                </select>&nbsp;
-                <input type="text" tabindex="11" name="lon_h" maxlength="3" value="{$lon_h}" class="input30" onfocus="bydistance_set_radiobutton(2)"/>&nbsp;°&nbsp;
-                <input type="text" tabindex="12" name="lon_min" maxlength="6" value="{$lon_min}" class="input50" onfocus="bydistance_set_radiobutton(2)"/>&nbsp;'&nbsp;
+            <td valign="top" id="search_coord_wrapper">
+                {include file='coordinate_input.tpl'}
             </td>
             <td><input type="submit" tabindex="13" name="submit_dist" value="{t}Search{/t}" class="formbutton" onclick="submitbutton('submit_dist')" /></td>
         </tr>
+        <script>
+        (function() {ldelim}
+            var wrapper = document.getElementById('search_coord_wrapper');
+            if (wrapper) {ldelim}
+                wrapper.addEventListener('focus', function() {ldelim}
+                    bydistance_set_radiobutton(2);
+                {rdelim}, true);
+            {rdelim}
+        {rdelim})();
+        </script>
     </form>
 
     <tr class="search_byname"><td class="separator"></td></tr>

--- a/htdocs/viewcache.php
+++ b/htdocs/viewcache.php
@@ -349,7 +349,6 @@ if ($login->userid != 0) {
 }
 
 $tpl->assign('enableCacheNote', $login->userid != 0);
-$tpl->add_header_javascript('resource2/ocstyle/js/coord_input.js');
 
 /* Logentries */
 


### PR DESCRIPTION
Add the unified coordinate input widget (from PR #946) to the search page (search by distance) and the submit-new-cache page.

search.php / search.tpl:
- Replace inline 6-field coordinate markup with the shared coordinate_input.tpl include
- Accept hidden latitude/longitude from unified input, fall back to 6-field and legacy param names for backwards compatibility
- Skip 6-field JS validation when unified input has parsed coordinates

newcache.php / newcache.tpl:
- Convert from legacy template system (lib/common.inc.php, tpl_set_var, .tpl.php) to Smarty (lib2/web.inc.php, $tpl->assign, .tpl)
- Replace inline coordinate fields with coordinate_input.tpl include
- Convert dropdown option lists from pre-built HTML to PHP arrays with Smarty {foreach} loops
- Add t() compatibility wrapper for newcache.inc.php translations

coord_input.js:
- Refactor from IIFE to ESM module
- Extract shared helpers (coords2Dm, pad, coords2LatLon) to resource2/misc/shared/coords.js
- Load via <script type="module"> in coordinate_input.tpl itself so every page including the template gets the script automatically

coordinate_input.tpl:
- Add self-contained <script type="module"> for coord_input.js

viewcache.php:
- Remove add_header_javascript call (script now loads from template)

### 1. Why is this change necessary?

See PR #946

### 2. What does this change do, exactly?

See description above