### PR TITLE
fix: 6-field coordinate input not saving

### DIFF
--- a/htdocs/resource2/ocstyle/js/coord_input.js
+++ b/htdocs/resource2/ocstyle/js/coord_input.js
@@ -309,9 +309,20 @@ function init() {
         }
     }
 
+    /** Sync hidden decimal fields from 6-field inputs (used when in 6-field mode). */
+    function on6FieldInput() {
+        var ll = latLonFrom6Fields();
+        hiddenLat.value = ll.latitude;
+        hiddenLon.value = ll.longitude;
+    }
+
     // Wire events
     unified.addEventListener('input', onUnifiedInput);
     toggle.addEventListener('click', toggleMode);
+    [latHemEl, latDegEl, latMinEl, lonHemEl, lonDegEl, lonMinEl].forEach(function(el) {
+        el.addEventListener('input', on6FieldInput);
+        el.addEventListener('change', on6FieldInput);
+    });
 
     // Initial state: show unified, hide 6-field, reveal toggle
     singleSec.style.display = '';


### PR DESCRIPTION
## Summary

- When the user edits the 6 legacy fields directly (without switching back to 1-field mode), the hidden `latitude`/`longitude` decimal fields were never updated
- All backends (`editcache.php`, `newcache.php`, `search.php`, `PresenterCacheNote`) prefer the hidden decimal fields over the 6-field values on POST, so they silently kept the stale initial coordinates
- Fix: wire `input` + `change` listeners on all six fields so the hidden decimal fields stay in sync whenever any field is edited (`change` for the `<select>` hemisphere dropdowns, `input` for the text fields)

## Affected pages

viewcache (personal cache note), editcache, newcache, search