### PR TITLE
Replace 'font awesome' icons by unicode characters [OC4]

### DIFF
--- a/htdocs_symfony/templates/app/caches/view_listing.html.twig
+++ b/htdocs_symfony/templates/app/caches/view_listing.html.twig
@@ -87,17 +87,17 @@
                         <tr>
                             <th>{{ 'Has logpassword' | trans }}?</th>
                             <td>{% if cache.logpw == 1 %}
-                                    <i class="fas fa-key"><i class="fas fa-check"></i></i>
+                                    &#x1F5DD;
                                 {% else %}
-                                    <i class="fas fa-times"></i>
+                                    &#x274C;
                                 {% endif %}</td>
                         </tr>
                         <tr>
                             <th>{{ 'Published' | trans }}?</th>
                             <td>{% if cache.is_publishdate == 1 %}
-                                    <i class="fas fa-check"></i>
+                                    &#x2705;
                                 {% else %}
-                                    <i class="fas fa-times"></i>
+                                    &#x274C;
                                 {% endif %}</td>
                         </tr>
                         <tr>
@@ -171,7 +171,7 @@
                         </tr>
                         <tr>
                             <th>{{ 'Show on map' | trans }}</th>
-                            <td><a href="{{ path('app_map_show', { 'lat': cache.latitude, 'lon': cache.longitude}) }}"><i class="fas fa-map"></i></a>
+                            <td><a href="{{ path('app_map_show', { 'lat': cache.latitude, 'lon': cache.longitude}) }}">&#x1F5FA;</a>
                             </td>
                         </tr>
                         </thead>

--- a/htdocs_symfony/templates/app/user/detailview.html.twig
+++ b/htdocs_symfony/templates/app/user/detailview.html.twig
@@ -24,22 +24,18 @@
                         <ul>
                             <li><b>{{ 'User ID' | trans }}:</b> {{ user_by_id.userId }}</li>
                             <li><b>{{ 'Email' | trans }}:</b> {{ user_by_id.email }}</li>
-                            <li><b>{{ 'Email validity' | trans }}:</b> {% if user_by_id.emailProblems %}<i class="fas fa-times"></i>
-                                {% else %}<i class="fas fa-check"></i>
+                            <li><b>{{ 'Email validity' | trans }}:</b> {% if user_by_id.emailProblems %}&#x274C;
+                                {% else %}&#x2705;
                                 {% endif %}</li>
                             <li><b>{{ 'Account created' | trans }}:</b> {{ user_by_id.dateCreated | date('d.m.Y H:i:s') }}</li>
                             <li><b>{{ 'Last change' | trans }}:</b> {{ user_by_id.lastModified | date('d.m.Y H:i:s') }}</li>
-                            <li><b>{{ 'User active' | trans }}:</b> {% if user_by_id.isActive %}<i class="fas fa-check"></i>{% else %}<i
-                                        class="fas fa-times"></i>{% endif %}</li>
+                            <li><b>{{ 'User active' | trans }}:</b> {% if user_by_id.isActive %}&#x2705;{% else %}&#x274C;{% endif %}</li>
                             <li><b>{{ 'Activation code' | trans }}
                                     :</b> {% if user_by_id.activationCode %}{{ user_by_id.activationCode }}{% else %}
-                                    <i class="fas fa-times"></i>{% endif %}</li>
-                            <li><b>{{ 'First name' | trans }}:</b> {% if user_by_id.firstname %}{{ user_by_id.firstname }}{% else %}<i
-                                        class="fas fa-times"></i>{% endif %}</li>
-                            <li><b>{{ 'Last name' | trans }}:</b> {% if user_by_id.lastname %}{{ user_by_id.lastname }}{% else %}<i
-                                        class="fas fa-times"></i>{% endif %}</li>
-                            <li><b>{{ 'GDPR deleted' | trans }}:</b> {% if user_by_id.gdprDeletion %}<i class="fas fa-check"></i>{% else %}<i
-                                        class="fas fa-times"></i>{% endif %}</li>
+                                    &#x274C;{% endif %}</li>
+                            <li><b>{{ 'First name' | trans }}:</b> {% if user_by_id.firstname %}{{ user_by_id.firstname }}{% else %}&#x274C;{% endif %}</li>
+                            <li><b>{{ 'Last name' | trans }}:</b> {% if user_by_id.lastname %}{{ user_by_id.lastname }}{% else %}&#x274C;{% endif %}</li>
+                            <li><b>{{ 'GDPR deleted' | trans }}:</b> {% if user_by_id.gdprDeletion %}&#x2705;{% else %}&#x274C;{% endif %}</li>
                         </ul>
                     {% endif %}
                 {% else %}

--- a/htdocs_symfony/templates/backend/support/bonusCaches.html.twig
+++ b/htdocs_symfony/templates/backend/support/bonusCaches.html.twig
@@ -47,9 +47,8 @@
                     {% for bonusCache in bonusCaches_by_id %}
                         <tr>
                             <td>{{ bonusCache.wpOc }}</td>
-                            <td>{% if bonusCache.isBonusCache %}<i class="fas fa-check"></i>{% else %}<i class="fas fa-times"></i>{% endif %}</td>
-                            <td>{% if bonusCache.belongsToBonusCache %}{{ bonusCache.belongsToBonusCache }}{% else %}<i
-                                        class="fas fa-times"></i>{% endif %}</td>
+                            <td>{% if bonusCache.isBonusCache %}&#x2705;{% else %}&#x274C;{% endif %}</td>
+                            <td>{% if bonusCache.belongsToBonusCache %}{{ bonusCache.belongsToBonusCache }}{% else %}&#x274C;{% endif %}</td>
                             <td>
                                 {% if bonusCache.isBonusCache %}
                                 <a class="btn btn-primary"

--- a/htdocs_symfony/templates/backend/support/databaseQueries.html.twig
+++ b/htdocs_symfony/templates/backend/support/databaseQueries.html.twig
@@ -225,7 +225,7 @@
                         <td>{{ item.commentCreated | date('d.m.Y H:i:s') }}</td>
                         <td>{{ item.commentLastModified | date('d.m.Y H:i:s') }}</td>
                         <td>
-                            <a href="{{ path('backend_support_occ', { 'wpID': '0', 'userID': item.ocUserId }) }}"><i class="fas fa-check"></i></a>
+                            <a href="{{ path('backend_support_occ', { 'wpID': '0', 'userID': item.ocUserId }) }}">&#x2705;</a>
                         </td>
                     </tr>
                 {% endfor %}

--- a/htdocs_symfony/templates/backend/support/occ.html.twig
+++ b/htdocs_symfony/templates/backend/support/occ.html.twig
@@ -19,10 +19,10 @@
                         <li>{{ 'User' | trans }}: {{ occ_user_data.username }}</li>
                         <li>{{ 'Last login' | trans }}: {{ occ_user_data.lastLogin | date('d.m.Y') }}</li>
                         <li>{{ 'Email validity' | trans }}:
-                            {% if occ_user_data.emailProblems %}<i class="fas fa-times"></i>
-                            {% else %}<i class="fas fa-check"></i>
+                            {% if occ_user_data.emailProblems %}&#x274C;
+                            {% else %}&#x2705;
                             {% endif %}</li>
-                        <li>{{ 'Send message' | trans }}: <i class="fas fa-envelope"></i> <span class="badge badge-danger">"Send Message" muss noch warten, bis die Funktion eingebaut wurde..</span>
+                        <li>{{ 'Send message' | trans }}: &#x1F582; <span class="badge badge-danger">"Send Message" muss noch warten, bis die Funktion eingebaut wurde..</span>
                         </li>
                     </ul>
                 </td>
@@ -79,11 +79,10 @@
                     <td>Node: OC
                         <ul>
                             <li>{{ 'Cache' | trans }}: {{ occ_cache_data.wpOc }} / {{ occ_cache_data.name }}</li>
-                            <li>{{ 'Watch Listing' | trans }}: <i class="fas fa-eye"></i> <span class="badge badge-danger">muss noch warten, bis die Funktion eingebaut wurde..</span>
-                            <li>{{ 'Assign listing for check' | trans }}: <i class="fas fa-exclamation-triangle"></i> <span
-                                        class="badge badge-danger">muss noch warten, bis die Funktion eingebaut wurde..</span>
-                            <li>{{ 'Report listing' | trans }}: <i class="fas fa-exclamation-circle"></i> <span class="badge badge-danger">muss noch warten, bis die Funktion eingebaut wurde..</span>
-                            </li>
+                            <li>{{ 'Watch Listing' | trans }}: &#x1F441; <span class="badge badge-danger">muss noch warten, bis die Funktion eingebaut wurde..</span></li>
+                            <li>{{ 'Assign listing for check' | trans }}: &#x2757; <span
+                                        class="badge badge-danger">muss noch warten, bis die Funktion eingebaut wurde..</span></li></li>
+                            <li>{{ 'Report listing' | trans }}: &#x2757; <span class="badge badge-danger">muss noch warten, bis die Funktion eingebaut wurde..</span></li>
                         </ul>
                     </td>
                 </tr>

--- a/htdocs_symfony/templates/backend/support/occ_gpx_import.html.twig
+++ b/htdocs_symfony/templates/backend/support/occ_gpx_import.html.twig
@@ -63,14 +63,14 @@
                                 <td>{{ fetchedListingInfo.nodeListingCoordinatesLon }}</td>
                                 <td>{{ fetchedListingInfo.nodeListingCoordinatesLat }}</td>
                                 <td>{% if fetchedListingInfo.nodeListingAvailable == 1 %}
-                                        <i class="fas fa-check"></i>
+                                        &#x2705;
                                     {% else %}
-                                        <i class="fas fa-times"></i>
+                                        &#x274C;
                                     {% endif %}</td>
                                 <td>{% if fetchedListingInfo.nodeListingArchived == 1 %}
-                                        <i class="fas fa-check"></i>
+                                        &#x2705;
                                     {% else %}
-                                        <i class="fas fa-times"></i>
+                                        &#x274C;
                                     {% endif %}</td>
                                 <td>{{ fetchedListingInfo.lastModified | date('d.m.Y') }}</td>
                             </tr>

--- a/htdocs_symfony/templates/backend/support/searchedCaches.html.twig
+++ b/htdocs_symfony/templates/backend/support/searchedCaches.html.twig
@@ -34,10 +34,10 @@
                             <td>{{ report.name }}</td>
                             <td><a href="{{ path('app_user_by_id', { 'userID': report.user_id}) }}">{{ report.username }}</a></td>
                             <td>{{ report.email }}</td>
-                            <td><a href="{{ path('backend_support_cache_history', { 'wpID': report.wp_oc }) }}"><i class="fas fa-check"></i></a></td>
-                            <td><a href="{{ path('backend_support_occ', { 'wpID': report.wp_oc, 'userID': report.user_id }) }}"><i class="fas fa-check"></i></a></td>
-                            <td><a href="{{ path('backend_support_user_account_details', { 'userID': report.user_id }) }}"><i class="fas fa-check"></i></a></td>
-                            <td><a href="{{ path('backend_support_vandalism', { 'wpID': report.wp_oc, 'userID': report.user_id }) }}"><i class="fas fa-check"></i></a></td>
+                            <td><a href="{{ path('backend_support_cache_history', { 'wpID': report.wp_oc }) }}">&#x2705;</a></td>
+                            <td><a href="{{ path('backend_support_occ', { 'wpID': report.wp_oc, 'userID': report.user_id }) }}">&#x2705;</a></td>
+                            <td><a href="{{ path('backend_support_user_account_details', { 'userID': report.user_id }) }}">&#x2705;</a></td>
+                            <td><a href="{{ path('backend_support_vandalism', { 'wpID': report.wp_oc, 'userID': report.user_id }) }}">&#x2705;</a></td>
                         </tr>
                     {% endfor %}
                     </tbody>

--- a/htdocs_symfony/templates/backend/support/userDetails.html.twig
+++ b/htdocs_symfony/templates/backend/support/userDetails.html.twig
@@ -14,27 +14,24 @@
                     <li><b>{{ 'Details for user' | trans }}:</b> {{ user_account_details.username }}</li>
                     <li><b>{{ 'User ID' | trans }}:</b> {{ user_account_details.userId }}</li>
                     <li><b>{{ 'Email' | trans }}:</b> {{ user_account_details.email }}</li>
-                    <li><b>{{ 'Email validity' | trans }}:</b> {% if user_account_details.emailProblems %}<i class="fas fa-times"></i>
-                        {% else %}<i class="fas fa-check"></i>
+                    <li><b>{{ 'Email validity' | trans }}:</b> {% if user_account_details.emailProblems %}&#x274C;
+                        {% else %}&#x2705;
                         {% endif %}</li>
                     <li><b>{{ 'Account created' | trans }}:</b> {{ user_account_details.dateCreated | date('d.m.Y H:i:s') }}</li>
                     <li><b>{{ 'Last change' | trans }}:</b> {{ user_account_details.lastModified | date('d.m.Y H:i:s') }}</li>
-                    <li><b>{{ 'User active' | trans }}:</b> {% if user_account_details.isActive %}<i class="fas fa-check"></i>{% else %}<i
-                                class="fas fa-times"></i>{% endif %}</li>
+                    <li><b>{{ 'User active' | trans }}:</b> {% if user_account_details.isActive %}&#x2705;{% else %}&#x274C;{% endif %}</li>
                     <li><b>{{ 'Activation code' | trans }}
                             :</b> {% if user_account_details.activationCode %}{{ user_account_details.activationCode }}{% else %}
-                            <i class="fas fa-times"></i>{% endif %}</li>
-                    <li><b>{{ 'First name' | trans }}:</b> {% if user_account_details.firstname %}{{ user_account_details.firstname }}{% else %}<i
-                                class="fas fa-times"></i>{% endif %}</li>
-                    <li><b>{{ 'Last name' | trans }}:</b> {% if user_account_details.lastname %}{{ user_account_details.lastname }}{% else %}<i
-                                class="fas fa-times"></i>{% endif %}</li>
-                    <li><b>{{ 'Log entries' | trans }}:</b> <i class="fas fa-times"></i> <span class="badge badge-danger">muss noch warten, bis die Funktion implementiert werden kann..</span>
+                            &#x274C;{% endif %}</li>
+                    <li><b>{{ 'First name' | trans }}:</b> {% if user_account_details.firstname %}{{ user_account_details.firstname }}{% else %}&#x274C;{% endif %}</li>
+                    <li><b>{{ 'Last name' | trans }}:</b> {% if user_account_details.lastname %}{{ user_account_details.lastname }}{% else %}&#x274C;{% endif %}</li>
+                    <li><b>{{ 'Log entries' | trans }}:</b> &#x274C; <span class="badge badge-danger">muss noch warten, bis die Funktion implementiert werden kann..</span>
                     </li>
-                    <li><b>{{ 'Caches hidden' | trans }}:</b> <i class="fas fa-times"></i> <span class="badge badge-danger">muss noch warten, bis die Funktion implementiert werden kann..</span>
+                    <li><b>{{ 'Caches hidden' | trans }}:</b> &#x274C; <span class="badge badge-danger">muss noch warten, bis die Funktion implementiert werden kann..</span>
                     </li>
-                    <li><b>{{ 'Active caches hidden' | trans }}:</b> <i class="fas fa-times"></i> <span class="badge badge-danger">muss noch warten, bis die Funktion implementiert werden kann..</span>
+                    <li><b>{{ 'Active caches hidden' | trans }}:</b> &#x274C; <span class="badge badge-danger">muss noch warten, bis die Funktion implementiert werden kann..</span>
                     </li>
-                    <li><b>{{ 'Cache reports' | trans }}:</b> <i class="fas fa-times"></i> <span class="badge badge-danger">muss noch warten, bis die Funktion implementiert werden kann..</span>
+                    <li><b>{{ 'Cache reports' | trans }}:</b> &#x274C; <span class="badge badge-danger">muss noch warten, bis die Funktion implementiert werden kann..</span>
                     </li>
                     <li><b>{{ 'Last login' | trans }}:</b> {{ user_account_details.lastLogin | date('d.m.Y') }}</li>
                     <li><b>{{ 'User login is blocked until' | trans }}:</b>

--- a/htdocs_symfony/templates/base.html.twig
+++ b/htdocs_symfony/templates/base.html.twig
@@ -87,7 +87,7 @@
                     <input class="form-control form-control-navbar" type="search" placeholder="Search" aria-label="Search"
                            aria-describedby="button-magnifier">
                     <div class="input-group-append">
-                        <span class="input-group-text" id="button-magnifier"><i class="fas fa-search"></i></span>
+                        <span class="input-group-text" id="button-magnifier">&#x1F50D;</i></span>
                     </div>
                 </div>
             </form>
@@ -129,7 +129,7 @@
             ,
             <a href="#">{{ 'Contact' | trans }}</a>
             ,
-            <i class="fas fa-copyright"></i> opencaching.de {{ "now" | date("Y") }}
+            &#xA9; opencaching.de {{ "now" | date("Y") }}
         </footer>
     {% endblock %}
 


### PR DESCRIPTION
By removing AdminLTE "font awesome" icons were no longer useable.
Replaced them by unicode characters for the time being.