### PR TITLE
Hardening the cookies

### DIFF
--- a/htdocs/log.php
+++ b/htdocs/log.php
@@ -101,7 +101,7 @@ if ($cacheId != 0) {
     } else {
         // save masslog acception in cookie that expires on midnight if clicked
         if (isset($_REQUEST['suppressMasslogWarning']) && $_REQUEST['suppressMasslogWarning'] == 1) {
-            setcookie('ocsuppressmasslogwarn', '1', strtotime('tomorrow'));
+            setcookie('ocsuppressmasslogwarn', '1', ['expires' => strtotime('tomorrow'), 'path' => '/', 'secure' => true, 'httponly' => true, 'samesite' => 'Lax']);
         }
     }
 
@@ -216,8 +216,8 @@ if ($cacheId != 0) {
 
     if ($validate['dateOk']) {
         $cookie_logdate = sprintf('%04d%02d%02d', $logDateYear, $logDateMonth, $logDateDay);
-        setcookie('oclogdate1', $cookie_logdate);
-        setcookie('oclogdate2', $cookie_logdate, time() + 4 * 60 * 60);
+        setcookie('oclogdate1', $cookie_logdate, ['expires' => 0, 'path' => '/', 'secure' => true, 'httponly' => true, 'samesite' => 'Lax']);
+        setcookie('oclogdate2', $cookie_logdate, ['expires' => time() + 4 * 60 * 60, 'path' => '/', 'secure' => true, 'httponly' => true, 'samesite' => 'Lax']);
     }
 
     // check log type

--- a/htdocs/src/Oc/Session/SessionDataCookie.php
+++ b/htdocs/src/Oc/Session/SessionDataCookie.php
@@ -99,33 +99,34 @@ class SessionDataCookie implements SessionDataInterface
             setcookie(
                 $opt['session']['cookiename'] . 'data',
                 $value,
-                time() + 365 * 24 * 60 * 60,
-                $opt['session']['path'] ?? '/',
-                $opt['session']['domain'] ?? '',
-                $https_session // https only?
+                [
+                    'expires' => time() + 365 * 24 * 60 * 60,
+                    'path' => $opt['session']['path'] ?? '/',
+                    'domain' => $opt['session']['domain'] ?? '',
+                    'secure' => $https_session,
+                    'httponly' => true,
+                    'samesite' => 'Lax',
+                ]
             );
 
             // if site is requested by http no session data is visible, so set cookie as flag to redirect to https
             setcookie(
                 $opt['session']['cookiename'] . 'https_session',
                 $https_session,
-                time() + 365 * 24 * 60 * 60,
-                $opt['session']['path'] ?? '/',
-                $opt['session']['domain'] ?? '',
-                false, // must be available for http
-                true // communication only, no js
+                [
+                    'expires' => time() + 365 * 24 * 60 * 60,
+                    'path' => $opt['session']['path'] ?? '/',
+                    'domain' => $opt['session']['domain'] ?? '',
+                    'secure' => false, // must be available for http
+                    'httponly' => true,
+                    'samesite' => 'Lax',
+                ]
             );
         }
     }
 
     public function close(): void
     {
-        global $opt;
-
-        setcookie(
-            $opt['session']['cookiename'] . 'data',
-            '',
-            time() - 1
-        );
+        $this->header();
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to opencaching! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?

Modern and more secure cookies.


### 2. What does this change do, exactly?

Migrated to the array-based `setcookie()` API with `secure`, `httponly`, and `samesite=Lax`
Removed unused (missing path and domain) cookie delete.


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] TESTED ON THE TESTSERVER
