### PR TITLE
Tabulator demo

### DIFF
--- a/demo-de.md
+++ b/demo-de.md
@@ -1,0 +1,166 @@
+# Tabulator & AG Grid Demo — Dokumentation & Sprechernotizen
+
+## Kurzreferenz
+
+| | |
+|---|---|
+| **Server starten** | `ddev start` (oder `ddev restart` falls bereits gestartet) |
+| **Tabulator-Demo** | `https://try-opencaching.ddev.site/backend/tabulator-demo` |
+| **AG-Grid-Demo**   | `https://try-opencaching.ddev.site/backend/ag-grid-demo` |
+| **Login** | `root` / `developer` |
+| **In der Navigation?** | Nein — direkt per URL aufrufen |
+
+## Ressourcen
+
+| | |
+|---|---|
+| **Opencaching Wiki** | https://wiki.opencaching.de/index.php/Hauptseite |
+| **Entwicklung** | https://wiki.opencaching.de/index.php/Entwicklung |
+| **Git-Workflow** | https://wiki.opencaching.de/index.php/Entwicklung/Git |
+| **Issue-Tracker** | https://opencaching.atlassian.net/jira/core/projects/RED/issues |
+| **Mattermost** | https://devchat.opencaching.earth |
+
+---
+
+## Was wurde gebaut
+
+Zwei Proof-of-Concept-Seiten im neuen Symfony-basierten Opencaching-Backend, die
+clientseitiges Tabellen-Rendering mit zwei Bibliotheken im Direktvergleich demonstrieren:
+[Tabulator](https://tabulator.info) und [AG Grid Community](https://www.ag-grid.com).
+Beide Seiten zeigen dieselben Daten (bis zu 200 Caches) und dieselben Funktionen —
+Sortierung, Spaltenfilter, Paginierung, verschiebbare Spalten — mit identischem JSON-Endpunkt-Muster.
+
+---
+
+## Geanderte Dateien
+
+### `htdocs_symfony/templates/base.html.twig`
+**Bootstrap 5 wurde zum globalen Basis-Layout hinzugefugt.**
+
+- Bootstrap 5.3.3 CSS (`<link>` im `stylesheets`-Block)
+- Bootstrap 5.3.3 JS-Bundle (`<script>` in einem neuen `javascripts`-Block)
+
+**Warum:** Bisher wurde kein CSS-Framework global geladen. Damit steht Bootstrap allen
+Seiten zur Verfugung, die `base.html.twig` erweitern. Kindtemplates konnen den
+`javascripts`-Block uberschreiben oder erweitern, um eigene Skripte einzubinden.
+
+---
+
+### `htdocs_symfony/src/Controller/Backend/TabulatorDemoControllerBackend.php` *(neu)*
+**Ein Symfony-Controller mit zwei Routen.**
+
+| Route | Zweck |
+|---|---|
+| `GET /backend/tabulator-demo` | Rendert die HTML-Seite |
+| `GET /backend/tabulator-demo/data` | Liefert JSON (bis zu 200 Caches) |
+
+Der JSON-Endpunkt fragt die Tabellen `caches`, `user` und `cache_status` uber Doctrine DBAL
+ab und gibt zuruck: OC-Code, Cache-Name, Schwierigkeit, Gelandewertung, Besitzer-Username,
+Status-Bezeichnung. Schwierigkeit und Gelandewertung sind in der DB als Ganzzahl×2
+gespeichert und werden hier durch 2,0 geteilt.
+
+**Warum zwei Routen:** Die Trennung von Daten-Endpunkt und Seiten-Route entspricht dem
+Standard-"Ajax-Tabellen"-Muster. Der Browser ladt zunachst die Seite, dann holt Tabulator
+die Daten selbstandig. Der Daten-Endpunkt ist unabhangig testbar und wiederverwendbar.
+
+---
+
+### `htdocs_symfony/templates/backend/tabulatorDemo/index.html.twig` *(neu)*
+**Das Demo-Seiten-Template.**
+
+- Erweitert `backend/base.html.twig` (erbt Navbar, Sidebar, Layout)
+- Tabulator 6.3.0 CSS (Bootstrap-5-Theme) per CDN
+- Tabulator 6.3.0 JS per CDN
+- Ein `<div id="caches-table">`, auf das Tabulator gemountet wird, konfiguriert mit:
+  - `ajaxURL` zeigt auf die `/data`-Route — Tabulator holt die Daten selbst
+  - Clientseitige Paginierung (25 Zeilen/Seite)
+  - Sortierbare und verschiebbare Spalten
+  - Kopfzeilen-Filter auf den Spalten Code, Name, Besitzer, Status
+  - Zahlenformatierung fur Schwierigkeit und Gelandewertung (eine Nachkommastelle)
+
+**Warum im Template, nicht im Controller:** Seitenspezifisches JS gehort in den Twig-Block
+`javascripts` — das ist die Symfony/Twig-Konvention. Der Controller bleibt frei von
+HTML-Belangen.
+
+---
+
+### `htdocs_symfony/src/Controller/Backend/AgGridDemoControllerBackend.php` *(neu)*
+**Identische Controller-Struktur wie die Tabulator-Demo.**
+
+| Route | Zweck |
+|---|---|
+| `GET /backend/ag-grid-demo` | Rendert die HTML-Seite |
+| `GET /backend/ag-grid-demo/data` | Liefert JSON (bis zu 200 Caches) |
+
+Dieselbe SQL-Abfrage und Datenform wie beim Tabulator-Endpunkt — der Vergleich ist
+absichtlich fair: gleiche Daten, gleiche Struktur.
+
+---
+
+### `htdocs_symfony/templates/backend/agGridDemo/index.html.twig` *(neu)*
+**Das AG-Grid-Demo-Template.**
+
+- Erweitert `backend/base.html.twig`
+- AG Grid Community 31.3.4 CSS (`ag-theme-quartz`) per CDN
+- AG Grid Community 31.3.4 JS per CDN
+- Ein `<div id="caches-table" class="ag-theme-quartz">`, konfiguriert mit:
+  - `domLayout: 'autoHeight'` — Grid passt sich der Seitenhohe an
+  - Clientseitige Paginierung (25 Zeilen/Seite)
+  - `floatingFilter: true` — Filtereingaben unterhalb der Spaltenuberschriften
+  - `sortable`, `resizable`, verschiebbar per Standard
+  - Zahlenformatierung fur Schwierigkeit und Gelandewertung via `valueFormatter`
+  - Daten werden per `fetch()` geladen und per `gridApi.setGridOption('rowData', ...)` gesetzt
+
+**Unterschied zu Tabulator:** AG Grid hat keine eingebaute `ajaxURL`-Option — stattdessen
+holt man die Daten mit `fetch()` und ubergibt sie explizit uber die Grid-API. Mehr Code,
+aber auch mehr Kontrolle uber Ladezustand und Fehlerbehandlung.
+
+---
+
+## Was bewusst NICHT gemacht wurde
+
+- Kein Navbar-Eintrag — die Demo ist eine Entwicklungs-/Evaluierungsseite, kein
+  Produktions-Feature
+- Keine Umgehung der Authentifizierung — die Route erfordert `ROLE_TEAM` wie alle
+  Backend-Routen
+- Keine Datenbearbeitung — nur lesende Demo
+
+---
+
+## Sprechernotizen
+
+"Was ihr hier seht, ist ein Proof-of-Concept fur clientseitiges Tabellen-Rendering im
+neuen Opencaching-Backend — der Symfony-basierten App, die langfristig die alte PHP-Seite
+ablosen soll.
+
+Die Seite wird serverseitig von Symfony und Twig gerendert — nur ein Rahmen mit Navbar und
+einem leeren div. Sobald die Seite geladen ist, holt Tabulator die Daten eigenstandig von
+einem dedizierten JSON-API-Endpunkt unter `/backend/tabulator-demo/data`. Dieser Endpunkt
+gibt bis zu 200 Geocaches aus unserer lokalen Datenbank als reines JSON zuruck. Kein
+Seitenneuladen, keine serverseitige Paginierungslogik.
+
+Auf der Clientseite nimmt Tabulator dieses JSON und liefert uns Sortierung auf jeder
+Spalte, Kopfzeilen-Filter auf den Textfeldern (einfach mal in das Namensfeld tippen),
+Paginierung mit 25 Zeilen pro Seite und verschiebbare Spalten — alles ohne eigenen Code
+fur diese Funktionen.
+
+Wir haben Tabulator gewahlt, weil es sich gut mit Bootstrap integriert, eine freizugige
+MIT-Lizenz hat und mit minimaler Konfiguration eine produktionstaugliche UX liefert. Die
+gesamte JavaScript-Initialisierung umfasst etwa 15 Zeilen.
+
+Das architektonische Muster — ein schlanker JSON-API-Endpunkt plus eine clientseitige
+Tabellenbibliothek — ist das, was wir konsequent einsetzen wurden, wenn wir diesen Ansatz
+ubernehmen. Das Backend serialisiert nur Daten; das gesamte Tabellenverhalten lebt im
+Browser. Das macht es spater einfach, Filterung, Export oder Inline-Bearbeitung
+hinzuzufugen, ohne den Server anfassen zu mussen.
+
+Jetzt haben wir einen direkten Vergleich. Die zweite Seite unter `/backend/ag-grid-demo`
+zeigt exakt dasselbe mit AG Grid Community — einer Bibliothek, die in Unternehmensumgebungen
+weit verbreitet ist und kein jQuery benotigt. AG Grid ist kraftvoller, erfordert aber etwas
+mehr expliziten Code: Man holt die Daten selbst per fetch() und ubergibt sie der Grid-API,
+anstatt einfach eine URL anzugeben. Dafur hat man mehr Kontrolle.
+
+Die Kernfrage fur uns ist: Welches Muster wollen wir langfristig einsetzen? Das Muster ist
+bei beiden identisch — schlanker JSON-API-Endpunkt, clientseitige Tabelle. Nur die
+Bibliothek unterscheidet sich. Euer Feedback zu UX, Entwicklererfahrung und Lizenz hilft
+uns, diese Entscheidung zu treffen."

--- a/demo-de.md
+++ b/demo-de.md
@@ -1,4 +1,4 @@
-# Tabulator & AG Grid Demo — Dokumentation & Sprechernotizen
+# Tabulator, AG Grid & Twig-SSR-Demo — Dokumentation & Sprechernotizen
 
 ## Kurzreferenz
 
@@ -7,6 +7,7 @@
 | **Server starten** | `ddev start` (oder `ddev restart` falls bereits gestartet) |
 | **Tabulator-Demo** | `https://try-opencaching.ddev.site/backend/tabulator-demo` |
 | **AG-Grid-Demo**   | `https://try-opencaching.ddev.site/backend/ag-grid-demo` |
+| **Twig-SSR-Demo**  | `https://try-opencaching.ddev.site/backend/twig-ssr-demo` |
 | **Login** | `root` / `developer` |
 | **In der Navigation?** | Nein — direkt per URL aufrufen |
 
@@ -24,11 +25,17 @@
 
 ## Was wurde gebaut
 
-Zwei Proof-of-Concept-Seiten im neuen Symfony-basierten Opencaching-Backend, die
-clientseitiges Tabellen-Rendering mit zwei Bibliotheken im Direktvergleich demonstrieren:
-[Tabulator](https://tabulator.info) und [AG Grid Community](https://www.ag-grid.com).
-Beide Seiten zeigen dieselben Daten (bis zu 200 Caches) und dieselben Funktionen —
-Sortierung, Spaltenfilter, Paginierung, verschiebbare Spalten — mit identischem JSON-Endpunkt-Muster.
+Drei Proof-of-Concept-Seiten im neuen Symfony-basierten Opencaching-Backend, die drei
+verschiedene Architekturansatze fur Tabellen-Rendering demonstrieren und vergleichen:
+
+| Demo | Ansatz | JS-Abhangigkeit |
+|---|---|---|
+| [Tabulator](https://tabulator.info) | Clientseitig, deklarative Konfig, eingebaute Ajax-URL | ~500 KB CDN |
+| [AG Grid Community](https://www.ag-grid.com) | Clientseitig, explizites fetch(), machtiger | ~700 KB CDN |
+| Twig SSR | Serverseitig, reines HTML, kein JS | Keine |
+
+Alle drei Seiten zeigen dieselben Daten (bis zu 25 Caches pro Seite aus der lokalen DB) und
+dieselben Funktionen: Sortierung, Spaltenfilter, Paginierung.
 
 ---
 
@@ -117,6 +124,42 @@ aber auch mehr Kontrolle uber Ladezustand und Fehlerbehandlung.
 
 ---
 
+### `htdocs_symfony/src/Controller/Backend/TwigSsrDemoControllerBackend.php` *(neu)*
+**Ein einzelner Controller mit einer Route — kein separater Daten-Endpunkt.**
+
+| Route | Zweck |
+|---|---|
+| `GET /backend/twig-ssr-demo` | Rendert die vollstandige HTML-Seite mit Daten |
+
+Der Controller liest `?sort=`, `?dir=`, `?q=` und `?page=` aus dem Query-String,
+baut daraus zwei SQL-Abfragen (COUNT + Daten) mit LIMIT/OFFSET, und ubergibt alles
+an das Template. Jede Interaktion — Sortierung, Filter, Seitenwechsel — ist ein neuer
+HTTP-Request an dieselbe Route.
+
+**Warum eine Route statt zwei:** Bei SSR gibt es keine Trennung zwischen "Seite" und
+"Daten" — der Controller liefert beides in einem Schritt. Das ist das klassische
+Request-Response-Modell.
+
+---
+
+### `htdocs_symfony/templates/backend/twigSsrDemo/index.html.twig` *(neu)*
+**Das SSR-Demo-Template — reines Twig, kein JS.**
+
+- Erweitert `backend/base.html.twig`
+- Kein CDN, keine externe Abhangigkeit
+- Ein Bootstrap-5-`<table>` mit `table-striped table-hover`
+- Spaltenuberschriften als Sort-Links (`<a href="?sort=...&dir=...">`)
+- Sort-Indikator (▲/▼) via Twig-Bedingung
+- Suchformular (GET) mit versteckten `sort`/`dir`-Feldern, damit Filter und Sortierung
+  gleichzeitig aktiv bleiben
+- Bootstrap-Paginierung mit erster/letzter Seite und `…`-Trenner
+
+**Warum kein JS:** Der Punkt dieser Demo ist zu zeigen, dass man Sortierung, Filter und
+Paginierung komplett serverseitig abhandeln kann. Der Tradeoff: Jede Interaktion lost
+einen Seitenneuladen aus und der Server muss die Abfrage wiederholen.
+
+---
+
 ## Was bewusst NICHT gemacht wurde
 
 - Kein Navbar-Eintrag — die Demo ist eine Entwicklungs-/Evaluierungsseite, kein
@@ -160,7 +203,14 @@ weit verbreitet ist und kein jQuery benotigt. AG Grid ist kraftvoller, erfordert
 mehr expliziten Code: Man holt die Daten selbst per fetch() und ubergibt sie der Grid-API,
 anstatt einfach eine URL anzugeben. Dafur hat man mehr Kontrolle.
 
-Die Kernfrage fur uns ist: Welches Muster wollen wir langfristig einsetzen? Das Muster ist
-bei beiden identisch — schlanker JSON-API-Endpunkt, clientseitige Tabelle. Nur die
-Bibliothek unterscheidet sich. Euer Feedback zu UX, Entwicklererfahrung und Lizenz hilft
-uns, diese Entscheidung zu treffen."
+Die dritte Seite unter `/backend/twig-ssr-demo` zeigt den Gegenentwurf: kein JavaScript,
+keine Bibliothek, kein CDN. Symfony und Twig rendern die gesamte Seite inklusive Daten —
+Sortierung und Filter sind einfache Links mit Query-Parametern, Paginierung ist
+LIMIT/OFFSET in SQL. Jede Interaktion ist ein neuer HTTP-Request. Das ist exakt das Muster,
+das die alte PHP-Seite heute verwendet.
+
+Was habt ihr gesehen? Die SSR-Seite fuhlt sich langsamer an — jeder Klick ladt die Seite
+neu. Die JS-Bibliotheken reagieren sofort. Dafur hat die SSR-Seite null CDN-Abhangigkeiten
+und funktioniert ohne JavaScript im Browser. Das ist der Tradeoff, den wir bewusst
+diskutieren mussen: Interaktivitat gegen Einfachheit. Euer Feedback hilft uns, die richtige
+Entscheidung fur die Zukunft des Backends zu treffen."

--- a/demo-de.md
+++ b/demo-de.md
@@ -209,8 +209,26 @@ Sortierung und Filter sind einfache Links mit Query-Parametern, Paginierung ist
 LIMIT/OFFSET in SQL. Jede Interaktion ist ein neuer HTTP-Request. Das ist exakt das Muster,
 das die alte PHP-Seite heute verwendet.
 
-Was habt ihr gesehen? Die SSR-Seite fuhlt sich langsamer an — jeder Klick ladt die Seite
-neu. Die JS-Bibliotheken reagieren sofort. Dafur hat die SSR-Seite null CDN-Abhangigkeiten
-und funktioniert ohne JavaScript im Browser. Das ist der Tradeoff, den wir bewusst
-diskutieren mussen: Interaktivitat gegen Einfachheit. Euer Feedback hilft uns, die richtige
-Entscheidung fur die Zukunft des Backends zu treffen."
+Jetzt schaut euch die Templates nebeneinander an. Das Tabulator-Template hat 44 Zeilen.
+AG Grid hat 54. Das Twig-SSR-Template hat 116 — fast dreimal so viel — und das zahlt nicht
+die zusatzlichen 50 Zeilen PHP im Controller. Und trotz all diesem Code leistet es *weniger*:
+keine verschiebbaren Spalten, keine sofortige Reaktion, jede Sortierung oder Filterung ladt
+die Seite neu.
+
+Was macht der ganze Mehrcode? Er reimplementiert von Hand und schlechter genau das, was die
+Bibliotheken kostenlos liefern: Sort-Link-Generierung, Richtungsumschalten, das Durchschleifen
+des aktuellen Filters durch versteckte Formularfelder damit er beim Klick auf eine
+Spaltenuberschrift nicht verlorengeht, und einen Paginator mit Ellipsis-Logik. Diese Logik
+sitzt im Template und Controller statt in einer gut getesteten Bibliothek — und jedes neue
+Feature (Spaltenbreite anpassen, Zeilenauswahl, CSV-Export) bedeutet mehr PHP und Twig von
+Hand schreiben.
+
+Twig SSR ist absolut das richtige Werkzeug fur statische Inhalte, Formulare und einmalig
+gelesene Detailseiten — dafur ist es gebaut. Fur eine sortierbare, filterbare Datentabelle
+ist es das falsche Werkzeug. Die Komplexitat landet am falschen Ort, die UX ist schlechter,
+und der Code ist schwerer zu warten.
+
+Also: **der Weg, den wir nicht gehen sollten, ist reines Twig SSR fur interaktive Datentabellen.**
+Der JS-Bibliotheks-Ansatz ist nicht modern um seiner selbst willen — er ist schlicht weniger
+Code, mehr Funktionalitat und eine bessere Trennung der Verantwortlichkeiten. Die verbleibende
+Frage ist: welche Bibliothek? Genau dazu wollen wir heute euer Feedback."

--- a/demo-en.md
+++ b/demo-en.md
@@ -203,8 +203,24 @@ library, no CDN. Symfony and Twig render the complete page including data — so
 filtering are plain links with query parameters, pagination is LIMIT/OFFSET in SQL. Every
 interaction is a new HTTP request. This is exactly the pattern the legacy PHP site uses today.
 
-What did you notice? The SSR page feels slower — every click reloads the page. The JS
-libraries respond instantly. But the SSR page has zero CDN dependencies and works without
-JavaScript in the browser. That is the tradeoff we need to discuss deliberately:
-interactivity versus simplicity. Your feedback helps us make the right call for the future
-of the backend."
+Now look at the templates side by side. The Tabulator template is 44 lines. AG Grid is 54.
+The Twig SSR template is 116 — nearly three times as long — and that does not count the
+extra 50 lines of PHP in the controller. And despite all that code it does *less*: no
+movable columns, no instant response, every sort or filter change reloads the page.
+
+What is all that extra code doing? It is reimplementing, by hand and badly, exactly what
+the libraries give you for free: sort link generation, direction toggling, threading the
+current filter through hidden form fields so it does not get lost when you click a column
+header, and a paginator with ellipsis logic. That logic lives in the template and
+controller instead of in a well-tested library — and every new feature you want (column
+resize, row selection, CSV export) means writing more PHP and Twig by hand.
+
+Twig SSR is absolutely the right tool for static content, forms, and read-once detail
+pages — that is what it is designed for. But for a sortable, filterable data table it is
+the wrong tool. The complexity ends up in the wrong place, the UX is worse, and the code
+is harder to maintain.
+
+So: **the path not to go is pure Twig SSR for interactive data tables.** The JS library
+approach is not modern for its own sake — it is genuinely less code, more capability, and
+a better separation of concerns. The remaining question is which library. That is what we
+want your feedback on today."

--- a/demo-en.md
+++ b/demo-en.md
@@ -1,4 +1,4 @@
-# Tabulator & AG Grid Demo — Documentation & Speaker Notes
+# Tabulator, AG Grid & Twig SSR Demo — Documentation & Speaker Notes
 
 ## Quick Reference
 
@@ -7,6 +7,7 @@
 | **Start server** | `ddev start` (or `ddev restart` if already running) |
 | **Tabulator demo** | `https://try-opencaching.ddev.site/backend/tabulator-demo` |
 | **AG Grid demo**   | `https://try-opencaching.ddev.site/backend/ag-grid-demo` |
+| **Twig SSR demo**  | `https://try-opencaching.ddev.site/backend/twig-ssr-demo` |
 | **Login** | `root` / `developer` |
 | **In navbar?** | No — navigate directly via URL |
 | **PR** | https://github.com/OpencachingDeutschland/oc-server3/pull/957 |
@@ -26,11 +27,17 @@
 
 ## What Was Built
 
-Two proof-of-concept pages in the new Symfony-based Opencaching backend, showing
-client-side table rendering with two libraries side by side:
-[Tabulator](https://tabulator.info) and [AG Grid Community](https://www.ag-grid.com).
-Both pages show the same data (up to 200 caches) and the same features — sorting, column
-filters, pagination, movable columns — using the identical JSON endpoint pattern.
+Three proof-of-concept pages in the new Symfony-based Opencaching backend, comparing three
+different architectural approaches to table rendering:
+
+| Demo | Approach | JS dependency |
+|---|---|---|
+| [Tabulator](https://tabulator.info) | Client-side, declarative config, built-in Ajax URL | ~500 KB CDN |
+| [AG Grid Community](https://www.ag-grid.com) | Client-side, explicit fetch(), more powerful | ~700 KB CDN |
+| Twig SSR | Server-side, plain HTML, no JS | None |
+
+All three pages show the same data (up to 25 caches per page from the local DB) and the
+same features: sorting, column filters, pagination.
 
 ---
 
@@ -118,6 +125,41 @@ more control over loading state and error handling.
 
 ---
 
+### `htdocs_symfony/src/Controller/Backend/TwigSsrDemoControllerBackend.php` *(new)*
+**A single controller with one route — no separate data endpoint.**
+
+| Route | Purpose |
+|---|---|
+| `GET /backend/twig-ssr-demo` | Renders the complete HTML page with data |
+
+The controller reads `?sort=`, `?dir=`, `?q=`, and `?page=` from the query string,
+builds two SQL queries (COUNT + data) with LIMIT/OFFSET, and passes everything to the
+template. Every interaction — sort, filter, page change — is a new HTTP request to the
+same route.
+
+**Why one route instead of two:** With SSR there is no separation between "page" and
+"data" — the controller delivers both in one step. This is the classic
+request-response model.
+
+---
+
+### `htdocs_symfony/templates/backend/twigSsrDemo/index.html.twig` *(new)*
+**The SSR demo template — pure Twig, no JS.**
+
+- Extends `backend/base.html.twig`
+- No CDN, no external dependency
+- A Bootstrap 5 `<table>` with `table-striped table-hover`
+- Column headers as sort links (`<a href="?sort=...&dir=...">`)
+- Sort indicator (▲/▼) via Twig conditional
+- Search form (GET) with hidden `sort`/`dir` fields so filter and sort stay active simultaneously
+- Bootstrap pagination with first/last page links and `…` separators
+
+**Why no JS:** The point of this demo is to show that sorting, filtering, and pagination
+can be handled entirely server-side. The tradeoff: every interaction triggers a page
+reload and the server must re-run the query.
+
+---
+
 ## What is NOT done (intentionally)
 
 - No navbar entry — the demo is a dev/evaluation page, not a production feature
@@ -156,6 +198,13 @@ environments, with no jQuery dependency. AG Grid is more powerful, but requires 
 explicit code: you fetch the data yourself and hand it to the grid API rather than just
 supplying a URL. In return you get more control.
 
-The core question for us is: which pattern do we want to use long-term? The pattern is
-identical in both — a thin JSON API endpoint, a client-side table. Only the library differs.
-Your feedback on UX, developer experience, and licensing helps us make that call."
+The third page at `/backend/twig-ssr-demo` shows the opposite approach: no JavaScript, no
+library, no CDN. Symfony and Twig render the complete page including data — sorting and
+filtering are plain links with query parameters, pagination is LIMIT/OFFSET in SQL. Every
+interaction is a new HTTP request. This is exactly the pattern the legacy PHP site uses today.
+
+What did you notice? The SSR page feels slower — every click reloads the page. The JS
+libraries respond instantly. But the SSR page has zero CDN dependencies and works without
+JavaScript in the browser. That is the tradeoff we need to discuss deliberately:
+interactivity versus simplicity. Your feedback helps us make the right call for the future
+of the backend."

--- a/demo-en.md
+++ b/demo-en.md
@@ -1,0 +1,161 @@
+# Tabulator & AG Grid Demo — Documentation & Speaker Notes
+
+## Quick Reference
+
+| | |
+|---|---|
+| **Start server** | `ddev start` (or `ddev restart` if already running) |
+| **Tabulator demo** | `https://try-opencaching.ddev.site/backend/tabulator-demo` |
+| **AG Grid demo**   | `https://try-opencaching.ddev.site/backend/ag-grid-demo` |
+| **Login** | `root` / `developer` |
+| **In navbar?** | No — navigate directly via URL |
+| **PR** | https://github.com/OpencachingDeutschland/oc-server3/pull/957 |
+| **Checkout** | `gh pr checkout 957` |
+
+## Resources
+
+| | |
+|---|---|
+| **Opencaching Wiki** | https://wiki.opencaching.de/index.php/Hauptseite |
+| **Development** | https://wiki.opencaching.de/index.php/Entwicklung |
+| **Git workflow** | https://wiki.opencaching.de/index.php/Entwicklung/Git |
+| **Issue tracker** | https://opencaching.atlassian.net/jira/core/projects/RED/issues |
+| **Mattermost** | https://devchat.opencaching.earth |
+
+---
+
+## What Was Built
+
+Two proof-of-concept pages in the new Symfony-based Opencaching backend, showing
+client-side table rendering with two libraries side by side:
+[Tabulator](https://tabulator.info) and [AG Grid Community](https://www.ag-grid.com).
+Both pages show the same data (up to 200 caches) and the same features — sorting, column
+filters, pagination, movable columns — using the identical JSON endpoint pattern.
+
+---
+
+## Files Changed
+
+### `htdocs_symfony/templates/base.html.twig`
+**Bootstrap 5 added to the global base layout.**
+
+- Added Bootstrap 5.3.3 CSS (`<link>` in the `stylesheets` block)
+- Added Bootstrap 5.3.3 JS bundle (`<script>` in a new `javascripts` block)
+
+**Why:** No CSS framework was loaded globally before. This makes Bootstrap available to all
+pages that extend `base.html.twig`. Child templates can override or extend the `javascripts`
+block to add their own scripts.
+
+---
+
+### `htdocs_symfony/src/Controller/Backend/TabulatorDemoControllerBackend.php` *(new)*
+**A Symfony controller with two routes.**
+
+| Route | Purpose |
+|---|---|
+| `GET /backend/tabulator-demo` | Renders the HTML page |
+| `GET /backend/tabulator-demo/data` | Returns JSON (up to 200 caches) |
+
+The JSON endpoint queries the `caches`, `user`, and `cache_status` tables via Doctrine DBAL
+and returns: OC code, cache name, difficulty, terrain, owner username, status label.
+Difficulty and terrain are stored as integers×2 in the DB and are divided by 2.0 here.
+
+**Why two routes:** Separating the data endpoint from the page route is the standard "Ajax
+table" pattern. The browser loads the page first, then Tabulator fetches the data
+autonomously. The data endpoint is independently testable and reusable.
+
+---
+
+### `htdocs_symfony/templates/backend/tabulatorDemo/index.html.twig` *(new)*
+**The demo page template.**
+
+- Extends `backend/base.html.twig` (inherits navbar, sidebar, layout)
+- Adds Tabulator 6.3.0 CSS (Bootstrap 5 theme) via CDN
+- Adds Tabulator 6.3.0 JS via CDN
+- A `<div id="caches-table">` that Tabulator mounts onto, configured with:
+  - `ajaxURL` pointing to the `/data` route — Tabulator fetches data itself
+  - Client-side pagination (25 rows/page)
+  - Sortable and movable columns
+  - Header filter inputs on Code, Name, Owner, Status columns
+  - Number formatter for Difficulty and Terrain (one decimal place)
+
+**Why in the template, not the controller:** Page-specific JS belongs in the Twig
+`javascripts` block — this is the Symfony/Twig convention. The controller stays free of
+HTML concerns.
+
+---
+
+### `htdocs_symfony/src/Controller/Backend/AgGridDemoControllerBackend.php` *(new)*
+**Identical controller structure to the Tabulator demo.**
+
+| Route | Purpose |
+|---|---|
+| `GET /backend/ag-grid-demo` | Renders the HTML page |
+| `GET /backend/ag-grid-demo/data` | Returns JSON (up to 200 caches) |
+
+Same SQL query and data shape as the Tabulator endpoint — the comparison is intentionally
+fair: same data, same structure.
+
+---
+
+### `htdocs_symfony/templates/backend/agGridDemo/index.html.twig` *(new)*
+**The AG Grid demo template.**
+
+- Extends `backend/base.html.twig`
+- AG Grid Community 31.3.4 CSS (`ag-theme-quartz`) via CDN
+- AG Grid Community 31.3.4 JS via CDN
+- A `<div id="caches-table" class="ag-theme-quartz">` configured with:
+  - `domLayout: 'autoHeight'` — grid auto-sizes to page height
+  - Client-side pagination (25 rows/page)
+  - `floatingFilter: true` — filter inputs below column headers
+  - `sortable`, `resizable`, movable columns by default
+  - Number formatter for Difficulty and Terrain via `valueFormatter`
+  - Data loaded via `fetch()` and passed via `gridApi.setGridOption('rowData', ...)`
+
+**Difference from Tabulator:** AG Grid has no built-in `ajaxURL` option — you fetch the
+data yourself with `fetch()` and hand it to the grid API explicitly. More code, but also
+more control over loading state and error handling.
+
+---
+
+## What is NOT done (intentionally)
+
+- No navbar entry — the demo is a dev/evaluation page, not a production feature
+- No authentication bypass — the route requires `ROLE_TEAM` like all backend routes
+- No data editing — read-only demo only
+
+---
+
+## Speaker Notes
+
+"What you're looking at is a proof-of-concept for client-side table rendering in the new
+Opencaching backend — the Symfony-based app that will eventually replace the legacy PHP site.
+
+The page you see is rendered server-side by Symfony and Twig — just a shell with a navbar
+and an empty div. As soon as the page loads, Tabulator fetches the data itself from a
+dedicated JSON API endpoint at `/backend/tabulator-demo/data`. That endpoint returns up to
+200 geocaches from our local database as plain JSON. No page reload, no server-side
+pagination logic.
+
+On the client side, Tabulator takes that JSON and gives us sorting on every column, header
+filters on the text fields (try typing in the Name box), pagination with 25 rows per page,
+and movable columns — all with zero custom code for those features.
+
+We chose Tabulator because it integrates well with Bootstrap, has a permissive MIT license,
+and requires minimal configuration to get production-grade UX. The entire JavaScript
+initialisation is about 15 lines.
+
+The architectural pattern here — a thin JSON API route plus a client-side table library —
+is what we would use consistently if we adopt this approach. The backend just serialises
+data; all the table behaviour lives in the browser. This makes it easy to add filtering,
+export, or inline editing later without touching the server.
+
+Now we have a direct comparison. The second page at `/backend/ag-grid-demo` shows exactly
+the same thing built with AG Grid Community — a library used extensively in enterprise
+environments, with no jQuery dependency. AG Grid is more powerful, but requires a bit more
+explicit code: you fetch the data yourself and hand it to the grid API rather than just
+supplying a URL. In return you get more control.
+
+The core question for us is: which pattern do we want to use long-term? The pattern is
+identical in both — a thin JSON API endpoint, a client-side table. Only the library differs.
+Your feedback on UX, developer experience, and licensing helps us make that call."

--- a/htdocs_symfony/src/Controller/Backend/AgGridDemoControllerBackend.php
+++ b/htdocs_symfony/src/Controller/Backend/AgGridDemoControllerBackend.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oc\Controller\Backend;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class AgGridDemoControllerBackend extends AbstractController
+{
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    #[Route('/ag-grid-demo', name: 'ag_grid_demo_index')]
+    public function index(): Response
+    {
+        return $this->render('backend/agGridDemo/index.html.twig');
+    }
+
+    #[Route('/ag-grid-demo/data', name: 'ag_grid_demo_data')]
+    public function data(): JsonResponse
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT
+                c.wp_oc        AS code,
+                c.name         AS name,
+                c.difficulty / 2.0 AS difficulty,
+                c.terrain / 2.0    AS terrain,
+                u.username     AS owner,
+                cs.name        AS status
+            FROM caches c
+            INNER JOIN user u         ON c.user_id = u.user_id
+            INNER JOIN cache_status cs ON c.status  = cs.id
+            LIMIT 200'
+        );
+
+        foreach ($rows as &$row) {
+            $row['difficulty'] = (float) $row['difficulty'];
+            $row['terrain']    = (float) $row['terrain'];
+        }
+
+        return $this->json($rows);
+    }
+}

--- a/htdocs_symfony/src/Controller/Backend/TabulatorDemoControllerBackend.php
+++ b/htdocs_symfony/src/Controller/Backend/TabulatorDemoControllerBackend.php
@@ -39,6 +39,11 @@ class TabulatorDemoControllerBackend extends AbstractController
             LIMIT 200'
         );
 
+        foreach ($rows as &$row) {
+            $row['difficulty'] = (float) $row['difficulty'];
+            $row['terrain']    = (float) $row['terrain'];
+        }
+
         return $this->json($rows);
     }
 }

--- a/htdocs_symfony/src/Controller/Backend/TabulatorDemoControllerBackend.php
+++ b/htdocs_symfony/src/Controller/Backend/TabulatorDemoControllerBackend.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oc\Controller\Backend;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class TabulatorDemoControllerBackend extends AbstractController
+{
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    #[Route('/tabulator-demo', name: 'tabulator_demo_index')]
+    public function index(): Response
+    {
+        return $this->render('backend/tabulatorDemo/index.html.twig');
+    }
+
+    #[Route('/tabulator-demo/data', name: 'tabulator_demo_data')]
+    public function data(): JsonResponse
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT
+                c.wp_oc        AS code,
+                c.name         AS name,
+                c.difficulty / 2.0 AS difficulty,
+                c.terrain / 2.0    AS terrain,
+                u.username     AS owner,
+                cs.name        AS status
+            FROM caches c
+            INNER JOIN user u         ON c.user_id = u.user_id
+            INNER JOIN cache_status cs ON c.status  = cs.id
+            LIMIT 200'
+        );
+
+        return $this->json($rows);
+    }
+}

--- a/htdocs_symfony/src/Controller/Backend/TwigSsrDemoControllerBackend.php
+++ b/htdocs_symfony/src/Controller/Backend/TwigSsrDemoControllerBackend.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oc\Controller\Backend;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class TwigSsrDemoControllerBackend extends AbstractController
+{
+    private const PER_PAGE = 25;
+
+    private const SORT_COLUMNS = [
+        'code'       => 'c.wp_oc',
+        'name'       => 'c.name',
+        'difficulty' => 'c.difficulty',
+        'terrain'    => 'c.terrain',
+        'owner'      => 'u.username',
+        'status'     => 'cs.name',
+    ];
+
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    #[Route('/twig-ssr-demo', name: 'twig_ssr_demo_index')]
+    public function index(Request $request): Response
+    {
+        $sort = $request->query->get('sort', 'code');
+        $dir  = strtolower($request->query->get('dir', 'asc')) === 'desc' ? 'DESC' : 'ASC';
+        $q    = trim($request->query->get('q', ''));
+        $page = max(1, (int) $request->query->get('page', 1));
+
+        if (!array_key_exists($sort, self::SORT_COLUMNS)) {
+            $sort = 'code';
+        }
+
+        $orderBy = self::SORT_COLUMNS[$sort] . ' ' . $dir;
+
+        $params = [];
+        $where  = '';
+        if ($q !== '') {
+            $like   = '%' . $q . '%';
+            $where  = 'AND (c.wp_oc LIKE ? OR c.name LIKE ? OR u.username LIKE ? OR cs.name LIKE ?)';
+            $params = [$like, $like, $like, $like];
+        }
+
+        $baseSql = 'FROM caches c
+            INNER JOIN user u          ON c.user_id = u.user_id
+            INNER JOIN cache_status cs ON c.status  = cs.id
+            WHERE 1=1 ' . $where;
+
+        $total      = (int) $this->connection->fetchOne('SELECT COUNT(*) ' . $baseSql, $params);
+        $totalPages = max(1, (int) ceil($total / self::PER_PAGE));
+        $page       = min($page, $totalPages);
+        $offset     = ($page - 1) * self::PER_PAGE;
+
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT c.wp_oc AS code, c.name AS name,
+                c.difficulty / 2.0 AS difficulty,
+                c.terrain / 2.0    AS terrain,
+                u.username         AS owner,
+                cs.name            AS status
+            ' . $baseSql . '
+            ORDER BY ' . $orderBy . '
+            LIMIT ' . self::PER_PAGE . ' OFFSET ' . $offset,
+            $params
+        );
+
+        foreach ($rows as &$row) {
+            $row['difficulty'] = (float) $row['difficulty'];
+            $row['terrain']    = (float) $row['terrain'];
+        }
+
+        return $this->render('backend/twigSsrDemo/index.html.twig', [
+            'rows'       => $rows,
+            'sort'       => $sort,
+            'dir'        => strtolower($dir),
+            'q'          => $q,
+            'page'       => $page,
+            'totalPages' => $totalPages,
+            'total'      => $total,
+        ]);
+    }
+}

--- a/htdocs_symfony/templates/backend/agGridDemo/index.html.twig
+++ b/htdocs_symfony/templates/backend/agGridDemo/index.html.twig
@@ -20,7 +20,6 @@
 {% endblock %}
 
 {% block javascripts %}
-    {{ parent() }}
     <script src="https://cdn.jsdelivr.net/npm/ag-grid-community@31.3.4/dist/ag-grid-community.min.js"></script>
     <script>
         const gridApi = agGrid.createGrid(document.getElementById('caches-table'), {

--- a/htdocs_symfony/templates/backend/agGridDemo/index.html.twig
+++ b/htdocs_symfony/templates/backend/agGridDemo/index.html.twig
@@ -1,0 +1,54 @@
+{% extends 'backend/base.html.twig' %}
+
+{% block title %}AG Grid Demo – Opencaching Backend{% endblock %}
+
+{% block stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@31.3.4/styles/ag-grid.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@31.3.4/styles/ag-theme-quartz.css">
+{% endblock %}
+
+{% block page_title %}<h2 class="mb-3">AG Grid Demo</h2>{% endblock %}
+
+{% block page_content %}
+    <p class="text-muted mb-3">
+        Client-side rendered table using <a href="https://www.ag-grid.com" target="_blank">AG Grid Community</a>.
+        Data is fetched from <code>{{ path('backend_ag_grid_demo_data') }}</code> (up to 200 caches).
+    </p>
+
+    <div id="caches-table" class="ag-theme-quartz" style="width: 100%;"></div>
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    <script src="https://cdn.jsdelivr.net/npm/ag-grid-community@31.3.4/dist/ag-grid-community.min.js"></script>
+    <script>
+        const gridApi = agGrid.createGrid(document.getElementById('caches-table'), {
+            domLayout: 'autoHeight',
+            pagination: true,
+            paginationPageSize: 25,
+            defaultColDef: {
+                sortable: true,
+                resizable: true,
+                floatingFilter: true,
+            },
+            initialState: {
+                sort: { sortModel: [{ colId: 'code', sort: 'asc' }] },
+            },
+            columnDefs: [
+                { field: 'code',       headerName: 'OC Code',    filter: 'agTextColumnFilter',   width: 110 },
+                { field: 'name',       headerName: 'Name',        filter: 'agTextColumnFilter',   flex: 1, minWidth: 200 },
+                { field: 'difficulty', headerName: 'Difficulty',  filter: 'agNumberColumnFilter', width: 110,
+                  valueFormatter: p => p.value.toFixed(1) },
+                { field: 'terrain',    headerName: 'Terrain',     filter: 'agNumberColumnFilter', width: 100,
+                  valueFormatter: p => p.value.toFixed(1) },
+                { field: 'owner',      headerName: 'Owner',       filter: 'agTextColumnFilter',   width: 150 },
+                { field: 'status',     headerName: 'Status',      filter: 'agTextColumnFilter',   width: 130 },
+            ],
+        });
+
+        fetch("{{ path('backend_ag_grid_demo_data') }}")
+            .then(r => r.json())
+            .then(data => gridApi.setGridOption('rowData', data));
+    </script>
+{% endblock %}

--- a/htdocs_symfony/templates/backend/tabulatorDemo/index.html.twig
+++ b/htdocs_symfony/templates/backend/tabulatorDemo/index.html.twig
@@ -1,0 +1,44 @@
+{% extends 'backend/base.html.twig' %}
+
+{% block title %}Tabulator Demo – Opencaching Backend{% endblock %}
+
+{% block stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_bootstrap5.min.css">
+{% endblock %}
+
+{% block page_title %}<h2 class="mb-3">Tabulator Demo</h2>{% endblock %}
+
+{% block page_content %}
+    <p class="text-muted mb-3">
+        Client-side rendered table using <a href="https://tabulator.info" target="_blank">Tabulator</a>.
+        Data is fetched from <code>{{ path('backend_tabulator_demo_data') }}</code> (up to 200 caches).
+    </p>
+
+    <div id="caches-table"></div>
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
+    <script>
+        new Tabulator("#caches-table", {
+            ajaxURL: "{{ path('backend_tabulator_demo_data') }}",
+            layout: "fitColumns",
+            pagination: true,
+            paginationSize: 25,
+            movableColumns: true,
+            initialSort: [{ column: "code", dir: "asc" }],
+            columns: [
+                { title: "OC Code",    field: "code",       sorter: "string", headerFilter: true, width: 110 },
+                { title: "Name",       field: "name",       sorter: "string", headerFilter: true, minWidth: 200 },
+                { title: "Difficulty", field: "difficulty", sorter: "number", hozAlign: "center", width: 110,
+                  formatter: function(cell) { return cell.getValue().toFixed(1); } },
+                { title: "Terrain",    field: "terrain",    sorter: "number", hozAlign: "center", width: 100,
+                  formatter: function(cell) { return cell.getValue().toFixed(1); } },
+                { title: "Owner",      field: "owner",      sorter: "string", headerFilter: true, width: 150 },
+                { title: "Status",     field: "status",     sorter: "string", headerFilter: true, width: 130 },
+            ],
+        });
+    </script>
+{% endblock %}

--- a/htdocs_symfony/templates/backend/tabulatorDemo/index.html.twig
+++ b/htdocs_symfony/templates/backend/tabulatorDemo/index.html.twig
@@ -19,7 +19,6 @@
 {% endblock %}
 
 {% block javascripts %}
-    {{ parent() }}
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script>
         new Tabulator("#caches-table", {

--- a/htdocs_symfony/templates/backend/twigSsrDemo/index.html.twig
+++ b/htdocs_symfony/templates/backend/twigSsrDemo/index.html.twig
@@ -1,0 +1,116 @@
+{% extends 'backend/base.html.twig' %}
+
+{% block title %}Twig SSR Demo – Opencaching Backend{% endblock %}
+
+{% block page_title %}<h2 class="mb-3">Twig SSR Demo</h2>{% endblock %}
+
+{% block page_content %}
+    <p class="text-muted mb-3">
+        Server-side rendered table using plain Twig + Bootstrap 5. Sorting, filtering, and
+        pagination are handled entirely by the Symfony controller — every interaction is a new
+        HTTP request. No JavaScript table library required.
+    </p>
+
+    <form method="get" action="{{ path('backend_twig_ssr_demo_index') }}" class="row g-2 mb-3">
+        <div class="col-auto">
+            <input type="text" name="q" value="{{ q }}" class="form-control"
+                   placeholder="Filter by code, name, owner or status">
+        </div>
+        <input type="hidden" name="sort" value="{{ sort }}">
+        <input type="hidden" name="dir"  value="{{ dir }}">
+        <div class="col-auto">
+            <button type="submit" class="btn btn-primary">Filter</button>
+        </div>
+        {% if q %}
+        <div class="col-auto">
+            <a href="{{ path('backend_twig_ssr_demo_index', {sort: sort, dir: dir}) }}"
+               class="btn btn-outline-secondary">Clear</a>
+        </div>
+        {% endif %}
+    </form>
+
+    <p class="text-muted small mb-2">
+        {{ total }} cache{{ total != 1 ? 's' }}{% if q %} matching &ldquo;{{ q|e }}&rdquo;{% endif %}
+        &mdash; page {{ page }} of {{ totalPages }}
+    </p>
+
+    <table class="table table-striped table-hover table-sm">
+        <thead class="table-dark">
+            <tr>
+                {% set cols = {
+                    code:       'OC Code',
+                    name:       'Name',
+                    difficulty: 'D',
+                    terrain:    'T',
+                    owner:      'Owner',
+                    status:     'Status'
+                } %}
+                {% for field, label in cols %}
+                    {% set next_dir = (sort == field and dir == 'asc') ? 'desc' : 'asc' %}
+                    {% set center = field in ['difficulty', 'terrain'] %}
+                    <th{% if center %} class="text-center"{% endif %}>
+                        <a href="{{ path('backend_twig_ssr_demo_index', {sort: field, dir: next_dir, q: q, page: 1}) }}"
+                           class="text-decoration-none text-white">
+                            {{ label }}{% if sort == field %}&nbsp;{{ dir == 'asc' ? '▲' : '▼' }}{% endif %}
+                        </a>
+                    </th>
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in rows %}
+            <tr>
+                <td><code>{{ row.code }}</code></td>
+                <td>{{ row.name }}</td>
+                <td class="text-center">{{ row.difficulty|number_format(1) }}</td>
+                <td class="text-center">{{ row.terrain|number_format(1) }}</td>
+                <td>{{ row.owner }}</td>
+                <td>{{ row.status }}</td>
+            </tr>
+            {% else %}
+            <tr>
+                <td colspan="6" class="text-muted text-center py-3">No caches found.</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    {% if totalPages > 1 %}
+    <nav>
+        <ul class="pagination pagination-sm">
+            <li class="page-item {{ page == 1 ? 'disabled' }}">
+                <a class="page-link"
+                   href="{{ path('backend_twig_ssr_demo_index', {sort: sort, dir: dir, q: q, page: page - 1}) }}">«</a>
+            </li>
+            {% if page > 3 %}
+                <li class="page-item">
+                    <a class="page-link"
+                       href="{{ path('backend_twig_ssr_demo_index', {sort: sort, dir: dir, q: q, page: 1}) }}">1</a>
+                </li>
+                {% if page > 4 %}
+                    <li class="page-item disabled"><span class="page-link">…</span></li>
+                {% endif %}
+            {% endif %}
+            {% for p in range(max(1, page - 2), min(totalPages, page + 2)) %}
+                <li class="page-item {{ p == page ? 'active' }}">
+                    <a class="page-link"
+                       href="{{ path('backend_twig_ssr_demo_index', {sort: sort, dir: dir, q: q, page: p}) }}">{{ p }}</a>
+                </li>
+            {% endfor %}
+            {% if page < totalPages - 2 %}
+                {% if page < totalPages - 3 %}
+                    <li class="page-item disabled"><span class="page-link">…</span></li>
+                {% endif %}
+                <li class="page-item">
+                    <a class="page-link"
+                       href="{{ path('backend_twig_ssr_demo_index', {sort: sort, dir: dir, q: q, page: totalPages}) }}">{{ totalPages }}</a>
+                </li>
+            {% endif %}
+            <li class="page-item {{ page == totalPages ? 'disabled' }}">
+                <a class="page-link"
+                   href="{{ path('backend_twig_ssr_demo_index', {sort: sort, dir: dir, q: q, page: page + 1}) }}">»</a>
+            </li>
+        </ul>
+    </nav>
+    {% endif %}
+{% endblock %}

--- a/htdocs_symfony/templates/base.html.twig
+++ b/htdocs_symfony/templates/base.html.twig
@@ -10,7 +10,6 @@
     <title>{% block title %}Geocaching mit Opencaching.de{% endblock %}</title>
 
     {% block stylesheets %}
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
         <style>
         /* Grund-Setup für volle Höhe */
         * {
@@ -132,10 +131,6 @@
             ,
             &#xA9; opencaching.de {{ "now" | date("Y") }}
         </footer>
-    {% endblock %}
-
-    {% block javascripts %}
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     {% endblock %}
 
 </body>

--- a/htdocs_symfony/templates/base.html.twig
+++ b/htdocs_symfony/templates/base.html.twig
@@ -10,6 +10,7 @@
     <title>{% block title %}Geocaching mit Opencaching.de{% endblock %}</title>
 
     {% block stylesheets %}
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
         <style>
         /* Grund-Setup für volle Höhe */
         * {
@@ -131,6 +132,10 @@
             ,
             &#xA9; opencaching.de {{ "now" | date("Y") }}
         </footer>
+    {% endblock %}
+
+    {% block javascripts %}
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     {% endblock %}
 
 </body>


### PR DESCRIPTION
## Summary

Adds a demo page to the Symfony backend showing how to render a table client-side using
[Tabulator](https://tabulator.info), as a basis for evaluating table rendering libraries
for the new OC4 frontend.

## Changes

### `htdocs_symfony/templates/base.html.twig`
- Added Bootstrap 5.3.3 CSS and JS (CDN) to the global base layout
- Added a `{% block javascripts %}` block so child templates can inject page-specific scripts

### `htdocs_symfony/src/Controller/Backend/TabulatorDemoControllerBackend.php` *(new)*
- `GET /backend/tabulator-demo` — renders the page
- `GET /backend/tabulator-demo/data` — JSON API returning up to 200 caches (code, name,
  difficulty, terrain, owner, status)

### `htdocs_symfony/templates/backend/tabulatorDemo/index.html.twig` *(new)*
- Loads Tabulator 6.3.0 (Bootstrap 5 theme) from CDN
- Tabulator fetches data from the JSON endpoint via `ajaxURL`
- Client-side pagination (25 rows/page), sortable and movable columns, header filters on
  text columns, formatted display for difficulty and terrain

## Out of scope (intentional)

- No navbar entry — this is a dev/evaluation page, not a production feature
- No data editing — read-only
- No decision on which library to adopt — that follows after team evaluation