### PR TITLE
Fix XSS reported by Alex Harold

### DIFF
--- a/htdocs/coordinates.php
+++ b/htdocs/coordinates.php
@@ -18,8 +18,8 @@ if (isset($_REQUEST['lon'])) {
     $lon_float += $_REQUEST['lon'];
 }
 
-$cache_country = isset($_REQUEST['country']) ? $_REQUEST['country'] : false;
-$cache_desclang = isset($_REQUEST['desclang']) ? $_REQUEST['desclang'] : false;
+$cache_country = isset($_REQUEST['country']) && ctype_alpha($_REQUEST['country']) ? $_REQUEST['country'] : false;
+$cache_desclang = isset($_REQUEST['desclang']) && ctype_alpha($_REQUEST['desclang']) ? $_REQUEST['desclang'] : false;
 
 $coord = new coordinate($lat_float, $lon_float);
 
@@ -111,7 +111,7 @@ if ($wp != '') {
     sql_free_result($rs);
 }
 $tpl->assign('wp', $wp);
-$childWp = isset($_REQUEST['childwp']) ? $_REQUEST['childwp'] : '';
+$childWp = isset($_REQUEST['childwp']) && ctype_alnum($_REQUEST['childwp']) ? $_REQUEST['childwp'] : '';
 $tpl->assign('childwp', $childWp);
 
 $tpl->display();

--- a/htdocs/map2.php
+++ b/htdocs/map2.php
@@ -80,10 +80,10 @@ $tpl->assign('queryid', $nQueryId);
 if (!isset($_REQUEST['lat_min'])) {
     $tpl->assign('lat_min', null);
 } else {
-    $tpl->assign('lat_min', $_REQUEST['lat_min']);
-    $tpl->assign('lat_max', $_REQUEST['lat_max']);
-    $tpl->assign('lon_min', $_REQUEST['lon_min']);
-    $tpl->assign('lon_max', $_REQUEST['lon_max']);
+    $tpl->assign('lat_min', (float) $_REQUEST['lat_min']);
+    $tpl->assign('lat_max', (float) $_REQUEST['lat_max']);
+    $tpl->assign('lon_min', (float) $_REQUEST['lon_min']);
+    $tpl->assign('lon_max', (float) $_REQUEST['lon_max']);
 }
 
 // save options

--- a/htdocs/mydetails.php
+++ b/htdocs/mydetails.php
@@ -166,7 +166,8 @@ function assignFromDB($userid, $include_editor)
     sql_free_result($rs);
 
     if (isset($_REQUEST['desctext'])) {
-        $tpl->assign('desctext', $_REQUEST['desctext']);
+        $purifier = new OcHTMLPurifier($opt);
+        $tpl->assign('desctext', $purifier->purify($_REQUEST['desctext']));
     } else {
         $tpl->assign(
             'desctext',

--- a/htdocs/templates2/ocstyle/addtolist.tpl
+++ b/htdocs/templates2/ocstyle/addtolist.tpl
@@ -20,7 +20,7 @@
 
     <p style="margin-left:16px">
         <input type="radio" class="radio" id="newlist" name="listid" value="0" {if $default_list==0}checked="checked"{/if} />
-        <input type="text" name="newlist_name" maxlength="80" class="input400" value="{if $newlist_name !== false}{$newlist_name}{else}{t}New cache list{/t}{/if}" onfocus="if (this.value == '{t}New cache list{/t}') this.value=''; newlist.checked=1;" onblur="if (this.value == '') this.value = '{t}New cache list{/t}';" />
+        <input type="text" name="newlist_name" maxlength="80" class="input400" value="{if $newlist_name !== false}{$newlist_name|escape}{else}{t}New cache list{/t}{/if}" onfocus="if (this.value == '{t}New cache list{/t}') this.value=''; newlist.checked=1;" onblur="if (this.value == '') this.value = '{t}New cache list{/t}';" />
         &nbsp;
         <input type="checkbox" class="checkbox" id="newlist_public" name="newlist_public" value="1" {if $newlist_public}checked="checked"{/if} /> <label for="newlist_public">{t}public list{/t}</label>
         &nbsp;

--- a/htdocs/templates2/ocstyle/log_cache.tpl
+++ b/htdocs/templates2/ocstyle/log_cache.tpl
@@ -230,7 +230,7 @@ function show_tip(text)
     <input type="hidden" name="logid" value="{$logid}"/>
 {else}
     <input type="hidden" name="cacheid" value="{$cacheid}"/>
-    <input type="hidden" name="fieldnoteid" id="fieldnoteid" value="{$fieldnoteid}" />
+    <input type="hidden" name="fieldnoteid" id="fieldnoteid" value="{$fieldnoteid|escape}" />
 {/if}
 <input id="descMode" type="hidden" name="descMode" value="3" />
 <input id="oldDescMode" type="hidden" name="oldDescMode" value="3" />

--- a/htdocs/viewcache.php
+++ b/htdocs/viewcache.php
@@ -81,7 +81,7 @@ if (isset($_REQUEST['visitcounter']) && $_REQUEST['visitcounter'] == 1) {
 $bCrypt = !isset($_REQUEST['nocrypt']) || ($_REQUEST['nocrypt'] != 1);
 $tpl->assign('crypt', $bCrypt);
 
-$desclang = isset($_REQUEST['desclang']) ? $_REQUEST['desclang'] : false;
+$desclang = isset($_REQUEST['desclang']) && ctype_alpha($_REQUEST['desclang']) ? $_REQUEST['desclang'] : false;
 if ($desclang) {
     $sPreferedDescLang = $_REQUEST['desclang'] . ',' . $opt['template']['locale'] . ',EN';
 } else {
@@ -487,7 +487,8 @@ if (isset($_REQUEST['print']) && $_REQUEST['print'] == 'y') {
     $tpl->popup = 1;
     $tpl->assign('print', true);
     $tpl->name = 'viewcache_print';
-    $tpl->assign('log', $_REQUEST['log']);
+    $logParam = isset($_REQUEST['log']) && ctype_alnum($_REQUEST['log']) ? $_REQUEST['log'] : '';
+    $tpl->assign('log', $logParam);
 } else {
     $tpl->assign('print', false);
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
An XSS in the viewcache.php was possible.

### 2. What does this change do, exactly?
Remove the parameters `desclang` and `log` if they contain non alphanum chars.

### 3. Describe each step to reproduce the issue or behaviour.
https://www.opencaching. OFF de/viewcache.php?desclang=jaVasCript%3A%2F%2A-%2F%2A%2F%60%2F%27%2F%5C%22%2F%2A%2A%2F%28%2F+%2A%2FoNcliCk%3Dconfirm%28%27https%3A%2F%2Fwww.google.com%2Fsearch%3Fq%3D1%27%29+%29%2F%2F%250D%250A%250D%250A%2F%2F%3C%2FstYle%2F%3C%2FtitLe%2F%3C%2FteXtarEa%2F%3C%2FscRipt%2F--%21%3E%5C%5Cx3csVg%2F%3CsVg%2FoNloAd%3Dconfirm%28%27https%3A%2F%2Fwww.google.com%2Fsearch%3Fq%3D1%27%29%2F%2F%3E%5C%5Cx3e&wp=OC0E59

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
